### PR TITLE
fix: skip registry publish workflow when secret is missing

### DIFF
--- a/.github/workflows/publish_registry.yml
+++ b/.github/workflows/publish_registry.yml
@@ -10,14 +10,16 @@ on:
 
 jobs:
   publish-node:
-    if: ${{ secrets.REGISTRY_ACCESS_TOKEN != '' }}
     name: Publish Custom Node to registry
     runs-on: ubuntu-latest
+    env:
+      REGISTRY_ACCESS_TOKEN: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
 
       - name: Publish Custom Node
+        if: ${{ env.REGISTRY_ACCESS_TOKEN != '' }}
         uses: Comfy-Org/publish-node-action@main
         with:
-          personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
+          personal_access_token: ${{ env.REGISTRY_ACCESS_TOKEN }}

--- a/tests/test_registry_metadata.py
+++ b/tests/test_registry_metadata.py
@@ -33,6 +33,7 @@ def test_publish_workflow_exists_and_skips_without_registry_secret():
     assert "workflow_dispatch:" in workflow
     assert "branches:" in workflow
     assert "- main" in workflow
-    assert "secrets.REGISTRY_ACCESS_TOKEN != ''" in workflow
+    assert "REGISTRY_ACCESS_TOKEN: ${{ secrets.REGISTRY_ACCESS_TOKEN }}" in workflow
+    assert "if: ${{ env.REGISTRY_ACCESS_TOKEN != '' }}" in workflow
     assert "Comfy-Org/publish-node-action@main" in workflow
-    assert "personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}" in workflow
+    assert "personal_access_token: ${{ env.REGISTRY_ACCESS_TOKEN }}" in workflow


### PR DESCRIPTION
## Summary
- fix the registry publish workflow so missing secrets do not invalidate the workflow
- update tests to validate the secret guard pattern

## Verification
- docker compose run --rm test
- 5 tests passed locally in Docker
