### PR TITLE
fix: use lowercase Comfy registry publisher id

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ That is the official path to become searchable in the ComfyUI Registry and Comfy
 
 To finish public searchability, these two items still need to exist on the Comfy Registry side.
 
-1. A publisher account for `Deno`
+1. A publisher account for `deno`
 2. A repository secret named `REGISTRY_ACCESS_TOKEN`
 
 Once those are ready, the included publish workflow can push the node metadata to the registry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ Documentation = "https://github.com/Deno2026/comfyui-deno-custom-nodes#readme"
 "Bug Tracker" = "https://github.com/Deno2026/comfyui-deno-custom-nodes/issues"
 
 [tool.comfy]
-PublisherId = "Deno"
+PublisherId = "deno"
 DisplayName = "ComfyUI Deno Custom Nodes"
 Icon = "https://raw.githubusercontent.com/Deno2026/comfyui-deno-custom-nodes/main/icon.svg"
 requires-comfyui = ">=0.3.0"

--- a/tests/test_registry_metadata.py
+++ b/tests/test_registry_metadata.py
@@ -20,7 +20,7 @@ def test_pyproject_declares_registry_metadata_for_comfy_manager_discovery():
     assert pyproject["project"]["urls"]["Repository"] == "https://github.com/Deno2026/comfyui-deno-custom-nodes"
     assert pyproject["project"]["urls"]["Bug Tracker"] == "https://github.com/Deno2026/comfyui-deno-custom-nodes/issues"
 
-    assert pyproject["tool"]["comfy"]["PublisherId"] == "Deno"
+    assert pyproject["tool"]["comfy"]["PublisherId"] == "deno"
     assert pyproject["tool"]["comfy"]["DisplayName"] == "ComfyUI Deno Custom Nodes"
     assert pyproject["tool"]["comfy"]["requires-comfyui"] == ">=0.3.0"
     assert pyproject["tool"]["comfy"]["Icon"].endswith("icon.svg")


### PR DESCRIPTION
## Summary
- align PublisherId with the profile handle shown as @deno in Comfy Registry
- keep README and tests consistent with the actual publisher id

## Verification
- docker compose run --rm test
- 5 tests passed locally in Docker
