### PR TITLE
fix: align Comfy registry profile metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ That is the official path to become searchable in the ComfyUI Registry and Comfy
 
 To finish public searchability, these two items still need to exist on the Comfy Registry side.
 
-1. A publisher account for `deno`
+1. A publisher account for `deno2026`
 2. A repository secret named `REGISTRY_ACCESS_TOKEN`
 
 Once those are ready, the included publish workflow can push the node metadata to the registry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ Documentation = "https://github.com/Deno2026/comfyui-deno-custom-nodes#readme"
 "Bug Tracker" = "https://github.com/Deno2026/comfyui-deno-custom-nodes/issues"
 
 [tool.comfy]
-PublisherId = "deno"
-DisplayName = "ComfyUI Deno Custom Nodes"
+PublisherId = "deno2026"
+DisplayName = "Deno Custom Nodes"
 Icon = "https://raw.githubusercontent.com/Deno2026/comfyui-deno-custom-nodes/main/icon.svg"
 requires-comfyui = ">=0.3.0"

--- a/tests/test_registry_metadata.py
+++ b/tests/test_registry_metadata.py
@@ -20,8 +20,8 @@ def test_pyproject_declares_registry_metadata_for_comfy_manager_discovery():
     assert pyproject["project"]["urls"]["Repository"] == "https://github.com/Deno2026/comfyui-deno-custom-nodes"
     assert pyproject["project"]["urls"]["Bug Tracker"] == "https://github.com/Deno2026/comfyui-deno-custom-nodes/issues"
 
-    assert pyproject["tool"]["comfy"]["PublisherId"] == "deno"
-    assert pyproject["tool"]["comfy"]["DisplayName"] == "ComfyUI Deno Custom Nodes"
+    assert pyproject["tool"]["comfy"]["PublisherId"] == "deno2026"
+    assert pyproject["tool"]["comfy"]["DisplayName"] == "Deno Custom Nodes"
     assert pyproject["tool"]["comfy"]["requires-comfyui"] == ">=0.3.0"
     assert pyproject["tool"]["comfy"]["Icon"].endswith("icon.svg")
 


### PR DESCRIPTION
## Summary
- align PublisherId with the registry handle shown as @deno2026
- align DisplayName with the registry profile name Deno Custom Nodes
- keep README and registry metadata tests consistent

## Verification
- docker compose run --rm test
- 5 tests passed locally in Docker
