### PR TITLE
feat: update registry description for v0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # ComfyUI Deno Custom Nodes
 
-ComfyUI custom nodes by Deno.
+ComfyUI Deno Custom Nodes.
 
-The first node in this repository is a simple test node called Deno Image Resize.
-It resizes a ComfyUI IMAGE batch to a target width and height with one of four interpolation modes.
+The repository starts with a simple Deno Image Resize node and is intended to expand over time with more general-purpose custom nodes.
 
 ## Included node
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "deno-custom-nodes"
-description = "ComfyUI custom nodes by Deno, starting with a fast image resize node."
-version = "0.1.0"
+description = "ComfyUI Deno Custom Nodes"
+version = "0.1.1"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = []

--- a/tests/test_registry_metadata.py
+++ b/tests/test_registry_metadata.py
@@ -11,8 +11,8 @@ def test_pyproject_declares_registry_metadata_for_comfy_manager_discovery():
     pyproject = tomllib.loads(PYPROJECT_PATH.read_text())
 
     assert pyproject["project"]["name"] == "deno-custom-nodes"
-    assert pyproject["project"]["version"] == "0.1.0"
-    assert pyproject["project"]["description"] == "ComfyUI custom nodes by Deno, starting with a fast image resize node."
+    assert pyproject["project"]["version"] == "0.1.1"
+    assert pyproject["project"]["description"] == "ComfyUI Deno Custom Nodes"
     assert pyproject["project"]["requires-python"] == ">=3.10"
     assert pyproject["project"]["license"] == {"file": "LICENSE"}
     assert pyproject["project"]["classifiers"] == ["Operating System :: OS Independent"]


### PR DESCRIPTION
## Summary
- simplify the registry description to a more general package description
- bump the published version to 0.1.1 so the registry can accept the update
- adjust README and metadata tests to match the new broader positioning

## Verification
- docker compose run --rm test
- 5 tests passed locally in Docker
