### PR TITLE
[codex] Add autopilot harness

### DIFF
--- a/.agents/skills/deno-comfyui-node/SKILL.md
+++ b/.agents/skills/deno-comfyui-node/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: deno-comfyui-node
+description: Repository-local operating workflow for DENO ComfyUI custom node creation, modification, debugging, migration, frontend work, saved-workflow compatibility, runtime verification, release preparation, and Codex harness tasks. Use when the user naturally asks to change, fix, review, verify, release, or continue work in this repo.
+---
+
+# DENO ComfyUI Node Skill
+
+Use this skill to turn ordinary user conversation into a concise internal task contract, then run the correct implementation and verification loop without asking the user to fill out a template.
+
+## First Move
+
+1. Read root `AGENTS.md`.
+2. Run or inspect `tools/codex_task.py status`.
+3. If the user materially changed the request, update the active task with `tools/codex_task.py update --prompt "<latest intent>"`.
+4. Read only the reference files needed for the inferred capability tags.
+
+## Internal Contract
+
+Keep the formal contract in `.codex/state/ACTIVE_TASK.json` and `.codex/state/ACTIVE_TASK.md`. Include:
+
+- goal
+- user-visible behavior
+- inferred non-goals
+- assumptions
+- affected product surface
+- canonical state owners
+- risk level
+- capability tags
+- official runtime/upstream baseline
+- saved-workflow impact
+- acceptance tests
+- allowed implementation scope
+- verification plan
+- release status
+
+Do not dump this structure to the user unless requested. Summarize only the practical plan and current blocker.
+
+## Risk And Escalation
+
+- GREEN: copy, small styling, local calculation, existing helper use with no schema or lifecycle change.
+- YELLOW: DOM UI, async requests, existing lifecycle/storage/migration helper use, saved-workflow behavior without shape changes.
+- RED: schema or widget order change, dynamic slot topology, raw `node.inputs`/`node.widgets`/`target_slot` surgery, private ComfyUI API use, foundation public API change, data migration/deletion, or cross-node state authority change.
+
+For RED work, create `.codex/state/ARCHITECTURE_DECISION.md` before product implementation. Resolve the design from official ComfyUI sources when possible. Ask one concise question only when a real product decision remains.
+
+If the same acceptance test fails after two separate code-change attempts, stop product edits, write `.codex/state/ESCALATION.md`, and ask for design/GPT Pro review only if architecture remains unresolved.
+
+## Verification
+
+Run `tools/codex_gate.py` after implementation. It selects checks from changed paths, risk, capability tags, and recorded evidence.
+
+Never treat a single executed scenario as contract PASS. Record both:
+
+- `evidence_status`
+- `contract_status`
+
+Use `UNVERIFIED` for missing runtime surfaces.
+
+## References
+
+- `references/task-contract.md`: contract fields and update rules.
+- `references/risk-and-gates.md`: capability tags and gate expectations.
+- `references/runtime-evidence.md`: runtime proof labels and surface policy.
+
+## Scripts
+
+- `scripts/run-gate.ps1`: Windows wrapper for the deterministic gate.

--- a/.agents/skills/deno-comfyui-node/references/risk-and-gates.md
+++ b/.agents/skills/deno-comfyui-node/references/risk-and-gates.md
@@ -1,0 +1,30 @@
+# Risk And Gate Reference
+
+## GREEN
+
+Use for copy, small styling, local calculations, or existing helpers with no schema/lifecycle change.
+
+Required gates usually include parse checks, focused tests, and self-review.
+
+## YELLOW
+
+Use for DOM UI, async requests, existing lifecycle/storage/migration helpers, or saved-workflow behavior without shape changes.
+
+Required gates may include JS parse checks, relevant harnesses, fixture save/load tests, stale response tests, teardown tests, source/served identity, and runtime evidence.
+
+## RED
+
+Use for workflow schema/widget order changes, dynamic topology, direct host array mutation, private ComfyUI APIs, foundation API changes, migration/deletion, or cross-node state authority changes.
+
+Before product edits, create `.codex/state/ARCHITECTURE_DECISION.md` with:
+
+- official contract
+- options
+- selected invariant
+- rejected approaches
+- compatibility plan
+- acceptance tests
+
+## Two-Strike Rule
+
+The same acceptance test failing after two separate code-change attempts blocks further product edits. A rerun without code changes does not increment the strike count.

--- a/.agents/skills/deno-comfyui-node/references/runtime-evidence.md
+++ b/.agents/skills/deno-comfyui-node/references/runtime-evidence.md
@@ -1,0 +1,18 @@
+# Runtime Evidence Reference
+
+Use explicit labels:
+
+- `VERIFIED`: directly checked in the relevant runtime or artifact.
+- `INFERRED`: reasoned from source/tests but not directly checked.
+- `UNVERIFIED`: not checked.
+
+Evidence categories:
+
+- build proof: parse and unit tests
+- deployment proof: source/runtime hash, served JS marker, object info
+- source-contract proof: installed ComfyUI/frontend source identity
+- contract proof: workflow/prompt payload shape
+- behavior proof: real canvas interaction
+- compatibility proof: old/current workflows and declared runtimes
+
+Do not claim PASS for missing Portable, Desktop, or EZi surfaces unless the task explicitly scopes them out.

--- a/.agents/skills/deno-comfyui-node/references/task-contract.md
+++ b/.agents/skills/deno-comfyui-node/references/task-contract.md
@@ -1,0 +1,24 @@
+# Task Contract Reference
+
+The contract is internal state, not a user form.
+
+## Required Fields
+
+- `goal`: one sentence.
+- `user_visible_behavior`: what the user should observe.
+- `inferred_non_goals`: likely boundaries from the conversation and repo state.
+- `assumptions`: documented assumptions when asking is unnecessary.
+- `affected_product_surface`: node, docs, harness, release, or runtime surface.
+- `canonical_state_owners`: workflow, node properties, localStorage, backend-derived, runtime-only, official geometry.
+- `risk_level`: GREEN, YELLOW, or RED.
+- `capability_tags`: examples include `saved_workflow`, `frontend_js`, `dom`, `async`, `storage`, `dynamic_slots`, `runtime_sensitive`, `release`, `harness`.
+- `official_runtime_baseline`: installed/runtime or source-contract baseline used for the task.
+- `saved_workflow_impact`: none, read-only, preserves shape, migrates shape, or breaking.
+- `acceptance_tests`: stable IDs and human descriptions.
+- `allowed_implementation_scope`: file/path families allowed for the current task.
+- `verification_plan`: deterministic gates and runtime evidence.
+- `release_status`: local only, draft PR, release candidate, or released.
+
+## Update Rules
+
+Update the active task when the user changes goal, behavior, risk, non-goals, runtime target, or release status. Do not create a new task for "continue" prompts unless the prior task is closed.

--- a/.agents/skills/deno-comfyui-node/scripts/run-gate.ps1
+++ b/.agents/skills/deno-comfyui-node/scripts/run-gate.ps1
@@ -1,0 +1,7 @@
+param(
+  [string]$Mode = "local"
+)
+
+$ErrorActionPreference = "Stop"
+$repo = Resolve-Path (Join-Path $PSScriptRoot "..\..\..\..")
+python (Join-Path $repo "tools\codex_gate.py") --mode $Mode

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,59 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .codex/hooks/session_start.py"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .codex/hooks/user_prompt_submit.py"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .codex/hooks/pre_compact.py"
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .codex/hooks/post_compact.py"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .codex/hooks/stop.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/common.py
+++ b/.codex/hooks/common.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools import codex_task  # noqa: E402
+
+
+def read_payload() -> dict[str, Any]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+    try:
+        data = json.loads(raw)
+        return data if isinstance(data, dict) else {"payload": data}
+    except json.JSONDecodeError:
+        return {"text": raw}
+
+
+def prompt_from_payload(payload: dict[str, Any]) -> str:
+    for key in ("prompt", "message", "text", "input"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    if isinstance(payload.get("messages"), list) and payload["messages"]:
+        last = payload["messages"][-1]
+        if isinstance(last, dict):
+            content = last.get("content")
+            if isinstance(content, str):
+                return content.strip()
+    return ""
+
+
+def emit(**fields: Any) -> None:
+    print(json.dumps(fields, ensure_ascii=False))

--- a/.codex/hooks/post_compact.py
+++ b/.codex/hooks/post_compact.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from common import codex_task, emit, read_payload
+
+
+def main() -> int:
+    read_payload()
+    checkpoint = codex_task.CHECKPOINT_MD.read_text(encoding="utf-8") if codex_task.CHECKPOINT_MD.exists() else ""
+    context = checkpoint or codex_task.session_context()
+    emit(hook="PostCompact", developer_context=context)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/hooks/pre_compact.py
+++ b/.codex/hooks/pre_compact.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from common import codex_task, emit, read_payload
+
+
+def main() -> int:
+    payload = read_payload()
+    note = payload.get("reason", "pre-compact snapshot") if isinstance(payload, dict) else "pre-compact snapshot"
+    checkpoint = codex_task.checkpoint(str(note))
+    emit(hook="PreCompact", checkpoint=checkpoint)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/hooks/session_start.py
+++ b/.codex/hooks/session_start.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from common import codex_task, emit, read_payload
+
+
+def main() -> int:
+    payload = read_payload()
+    context = codex_task.session_context()
+    emit(hook="SessionStart", event=payload.get("event", "startup"), developer_context=context)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/hooks/stop.py
+++ b/.codex/hooks/stop.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+
+from common import ROOT, codex_task, emit, read_payload
+from tools import codex_gate
+
+
+STOP_STATE = codex_task.STATE_DIR / "STOP_HOOK.json"
+
+
+def read_stop_state() -> dict:
+    if STOP_STATE.exists():
+        return json.loads(STOP_STATE.read_text(encoding="utf-8"))
+    return {"stop_hook_active": False}
+
+
+def write_stop_state(data: dict) -> None:
+    codex_task.ensure_state_dir()
+    STOP_STATE.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    read_payload()
+    state = read_stop_state()
+    result = codex_gate.evaluate("stop", run_commands=True)
+    passed = result["evidence_status"] == "PASS" and result["contract_status"] == "PASS"
+    if passed:
+        write_stop_state({"stop_hook_active": False})
+        emit(hook="Stop", decision="allow", gate=result)
+        return 0
+
+    if not state.get("stop_hook_active"):
+        write_stop_state({"stop_hook_active": True})
+        emit(hook="Stop", decision="continue", missing=result.get("missing", []), failed=result.get("failed", []))
+        return 2
+
+    write_stop_state({"stop_hook_active": False})
+    codex_task.escalate("Stop hook gate failed after one continuation.", acceptance_id="stop-hook-gate")
+    emit(hook="Stop", decision="allow", status="BLOCKED", gate=result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/hooks/user_prompt_submit.py
+++ b/.codex/hooks/user_prompt_submit.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from common import codex_task, emit, prompt_from_payload, read_payload
+
+
+def main() -> int:
+    payload = read_payload()
+    prompt = prompt_from_payload(payload)
+    if prompt:
+        task = codex_task.update_task(prompt)
+        context = codex_task.render_task_md(task)
+    else:
+        context = codex_task.session_context()
+    emit(
+        hook="UserPromptSubmit",
+        developer_context=(
+            "Interpret conversational intent, update the internal task contract, "
+            "avoid formal user templates, and avoid unrequested features.\n\n" + context
+        ),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,39 @@
-## Summary
+## User-Visible Goal
 
-- What changed?
-- Why was it needed?
+<!-- Generated from .codex/state/ACTIVE_TASK.md. Keep this concise. -->
 
-## Checklist
+## Inferred Non-Goals
 
-- [ ] I ran `docker compose run --rm test`
-- [ ] I verified the node contract still matches ComfyUI expectations
-- [ ] I updated `CHANGELOG.md` for user-facing changes
-- [ ] I kept changes isolated to this feature branch
+<!-- What this PR intentionally does not change. -->
+
+## Risk And Capability Tags
+
+<!-- GREEN / YELLOW / RED, plus tags such as saved_workflow, frontend, async, storage, harness. -->
+
+## Official Runtime Baseline
+
+<!-- Official ComfyUI/source/runtime baseline used for the contract. -->
+
+## Saved-Workflow Impact
+
+<!-- none / preserves shape / migrates shape / breaking. Include visible restore evidence when relevant. -->
+
+## Tests
+
+<!-- Commands and results. -->
+
+## Runtime Evidence
+
+<!-- Source/runtime hash, served JS, object_info, canvas evidence, or N/A. -->
+
+## Unverified Or Out Of Scope
+
+<!-- Use UNVERIFIED explicitly. Do not hide missing surfaces. -->
+
+## Rollback
+
+<!-- Focused revert path or safe disable path. -->
+
+## Gate Result
+
+<!-- Paste the short result from .codex/state/GATE_RESULT.md. -->

--- a/.github/workflows/codex_harness_gate.yml
+++ b/.github/workflows/codex_harness_gate.yml
@@ -1,0 +1,47 @@
+name: codex harness gate
+
+on:
+  pull_request:
+    paths:
+      - .agents/**
+      - .codex/**
+      - tools/codex_*.py
+      - docs/codex/**
+      - tests/codex_harness/**
+      - .github/pull_request_template.md
+      - .github/workflows/*codex*gate*.yml
+      - .gitignore
+
+jobs:
+  codex-harness:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Compile harness
+        run: python -m py_compile tools/codex_task.py tools/codex_gate.py .codex/hooks/*.py
+
+      - name: Run harness tests
+        run: python -m pytest tests/codex_harness -q
+
+      - name: Run deterministic harness gate
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          git diff --name-only "$BASE_SHA"...HEAD > /tmp/codex_changed_files.txt
+          CODEX_HARNESS_CHANGED_FILES="$(cat /tmp/codex_changed_files.txt)" python tools/codex_gate.py --mode ci

--- a/.gitignore
+++ b/.gitignore
@@ -211,8 +211,9 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 
-# DENO local-only agent/operations docs.
-# Public GitHub should stay product/user-facing; keep these files local.
+# DENO local-only generated state and historical operations docs.
+# Public GitHub should stay product/user-facing; keep root AGENTS local.
+.codex/state/
 AGENTS.md
 SESSION_HANDOFF.md
 docs/CLAUDE_NODE_FRONTEND_GUIDE.md

--- a/deno_ltx_model_downloader.py
+++ b/deno_ltx_model_downloader.py
@@ -89,6 +89,13 @@ MODEL_ROOT_SUBDIRS = {
     "audio_encoders",
 }
 
+FOLDER_TYPE_ALIASES = {
+    "unet": ("unet", "diffusion_models"),
+    "diffusion_models": ("diffusion_models", "unet"),
+    "text_encoders": ("text_encoders", "clip"),
+    "clip": ("clip", "text_encoders"),
+}
+
 
 def _norm(path: Path | str) -> str:
     return str(Path(path).expanduser().resolve())
@@ -291,7 +298,27 @@ def _registered_model_dirs(folder_name: str) -> List[Path]:
     return candidates
 
 
-def _target_path_candidates(models_root: str, target_subdir: str, filename: str) -> List[Path]:
+def _folder_type_candidates(folder_name: str) -> Tuple[str, ...]:
+    normalized = str(folder_name or "").strip().replace("\\", "/").split("/", 1)[0]
+    if not normalized:
+        return ()
+    return FOLDER_TYPE_ALIASES.get(normalized, (normalized,))
+
+
+def _root_for_path(path: Path, roots: List[Dict] | None) -> Optional[Dict]:
+    for root in roots or []:
+        if _is_relative_to_or_same(path, Path(root["path"])):
+            return root
+    return None
+
+
+def _target_path_candidates(
+    models_root: str,
+    target_subdir: str,
+    filename: str,
+    *,
+    local_only: bool = False,
+) -> List[Path]:
     relative_path, _relative_label = _safe_relative_path(target_subdir, filename)
     root = Path(models_root)
     candidates: List[Path] = []
@@ -311,8 +338,11 @@ def _target_path_candidates(models_root: str, target_subdir: str, filename: str)
 
     folder_type = relative_parts[0]
     nested_parts = relative_parts[1:-1]
-    for model_dir in _registered_model_dirs(folder_type):
-        add(model_dir.joinpath(*nested_parts, filename))
+    for folder_name in _folder_type_candidates(folder_type):
+        for model_dir in _registered_model_dirs(folder_name):
+            if local_only and not _is_relative_to_or_same(model_dir, root):
+                continue
+            add(model_dir.joinpath(*nested_parts, filename))
 
     return candidates
 
@@ -348,43 +378,72 @@ def _resolve_target_file(
     filename: str,
     expected_size: int,
     *,
+    roots: List[Dict] | None = None,
     allow_deep_scan: bool = False,
 ) -> Dict:
     relative_path, configured_label = _safe_relative_path(target_subdir, filename)
     root = Path(models_root)
-    candidates = _target_path_candidates(models_root, target_subdir, filename)
-    target = candidates[0] if candidates else root / relative_path
+    local_candidates = _target_path_candidates(models_root, target_subdir, filename, local_only=True)
+    global_candidates = _target_path_candidates(models_root, target_subdir, filename, local_only=False)
+    target = local_candidates[0] if local_candidates else root / relative_path
     downloaded = 0
     status = "missing"
+    local_downloaded = 0
+    local_status = "missing"
     found_by = "configured"
+    found_path: Optional[Path] = None
+    local_found_path: Optional[Path] = None
 
-    for candidate in candidates:
+    for candidate in local_candidates:
         if _is_complete(candidate, expected_size):
-            target = candidate
+            local_downloaded = candidate.stat().st_size
+            local_status = "exists"
+            local_found_path = candidate
+            break
+
+    for candidate in global_candidates:
+        if _is_complete(candidate, expected_size):
             downloaded = candidate.stat().st_size
             status = "exists"
-            found_by = "registered" if candidate != candidates[0] else "configured"
+            found_path = candidate
+            found_by = "registered" if candidate != target else "configured"
             break
 
     if status == "missing" and allow_deep_scan:
-        scanned = _scan_for_filename((candidate.parent for candidate in candidates), filename, expected_size)
+        scanned = _scan_for_filename((candidate.parent for candidate in global_candidates), filename, expected_size)
         if scanned is not None:
-            target = scanned
             downloaded = scanned.stat().st_size
             status = "exists"
+            found_path = scanned
             found_by = "subfolder"
 
     if status == "missing":
-        for candidate in candidates:
+        for candidate in global_candidates:
             part = candidate.with_suffix(candidate.suffix + ".part")
             try:
                 if part.exists():
-                    target = candidate
                     downloaded = part.stat().st_size
                     status = "partial"
+                    found_path = part
+                    found_by = "partial"
                     break
             except OSError:
                 continue
+
+    if local_status == "missing":
+        for candidate in local_candidates:
+            part = candidate.with_suffix(candidate.suffix + ".part")
+            try:
+                if part.exists():
+                    local_downloaded = part.stat().st_size
+                    local_status = "partial"
+                    local_found_path = part
+                    break
+            except OSError:
+                continue
+
+    found_root = _root_for_path(found_path, roots) if found_path is not None else None
+    local_found_root = _root_for_path(local_found_path, roots) if local_found_path is not None else None
 
     return {
         "target": target,
@@ -393,7 +452,15 @@ def _resolve_target_file(
         "relative_path": _relative_to_root_label(target, root, configured_label),
         "configured_relative_path": configured_label,
         "downloaded": downloaded,
+        "local_downloaded": local_downloaded,
         "status": status,
+        "local_status": local_status,
+        "exists_in_selected_root": local_status == "exists",
+        "found_path": str(found_path) if found_path is not None and status in {"exists", "partial"} else "",
+        "found_root_id": found_root["id"] if found_root else "",
+        "found_root_path": found_root["path"] if found_root else "",
+        "local_found_path": str(local_found_path) if local_found_path is not None else "",
+        "local_found_root_id": local_found_root["id"] if local_found_root else "",
         "found_by": found_by,
     }
 
@@ -408,9 +475,15 @@ def _is_complete(path: Path, expected_size: int) -> bool:
     return size >= int(expected_size * 0.98)
 
 
-def _public_file(models_root: str, item: Dict) -> Dict:
+def _public_file(models_root: str, item: Dict, roots: List[Dict] | None = None) -> Dict:
     expected_size = int(item["size"])
-    resolved = _resolve_target_file(models_root, str(item["target_subdir"]), str(item["filename"]), expected_size)
+    resolved = _resolve_target_file(
+        models_root,
+        str(item["target_subdir"]),
+        str(item["filename"]),
+        expected_size,
+        roots=roots,
+    )
 
     return {
         "id": item["id"],
@@ -425,13 +498,21 @@ def _public_file(models_root: str, item: Dict) -> Dict:
         "target_dir": resolved["target_dir"],
         "size": expected_size,
         "downloaded": resolved["downloaded"],
+        "local_downloaded": resolved["local_downloaded"],
         "status": resolved["status"],
+        "local_status": resolved["local_status"],
+        "exists_in_selected_root": resolved["exists_in_selected_root"],
+        "found_path": resolved["found_path"],
+        "found_root_id": resolved["found_root_id"],
+        "found_root_path": resolved["found_root_path"],
+        "local_found_path": resolved["local_found_path"],
+        "local_found_root_id": resolved["local_found_root_id"],
         "found_by": resolved["found_by"],
     }
 
 
-def _public_files(models_root: str) -> List[Dict]:
-    return [_public_file(models_root, item) for item in MODEL_FILES]
+def _public_files(models_root: str, roots: List[Dict] | None = None) -> List[Dict]:
+    return [_public_file(models_root, item, roots) for item in MODEL_FILES]
 
 
 def _guess_filename(url: str) -> str:
@@ -573,7 +654,7 @@ def _model_subdirs(models_root: str) -> List[str]:
     return sorted(set(common + found), key=lambda item: (item.lower() not in common, item.casefold()))
 
 
-def _public_custom_file(models_root: str, row: Dict, index: int) -> Dict:
+def _public_custom_file(models_root: str, row: Dict, index: int, roots: List[Dict] | None = None) -> Dict:
     row = _normalize_package({"files": [row]})["files"][0]
     url = str(row.get("url") or "").strip()
     filename = str(row.get("filename") or "").strip() or _guess_filename(url)
@@ -582,21 +663,37 @@ def _public_custom_file(models_root: str, row: Dict, index: int) -> Dict:
     size = _expected_size(row)
 
     try:
-        resolved = _resolve_target_file(models_root, target_subdir, filename, size)
+        resolved = _resolve_target_file(models_root, target_subdir, filename, size, roots=roots)
         relative_label = resolved["relative_path"]
         error = ""
         target_path = resolved["target_path"]
         target_dir = resolved["target_dir"]
         status = resolved["status"]
+        local_status = resolved["local_status"]
         downloaded = resolved["downloaded"]
+        local_downloaded = resolved["local_downloaded"]
         found_by = resolved["found_by"]
+        exists_in_selected_root = resolved["exists_in_selected_root"]
+        found_path = resolved["found_path"]
+        found_root_id = resolved["found_root_id"]
+        found_root_path = resolved["found_root_path"]
+        local_found_path = resolved["local_found_path"]
+        local_found_root_id = resolved["local_found_root_id"]
     except ValueError as exc:
         relative_label = ""
         target_path = ""
         target_dir = ""
         status = "invalid"
+        local_status = "invalid"
         downloaded = 0
+        local_downloaded = 0
         found_by = ""
+        exists_in_selected_root = False
+        found_path = ""
+        found_root_id = ""
+        found_root_path = ""
+        local_found_path = ""
+        local_found_root_id = ""
         error = str(exc)
 
     return {
@@ -610,43 +707,78 @@ def _public_custom_file(models_root: str, row: Dict, index: int) -> Dict:
         "target_dir": target_dir,
         "size": size,
         "downloaded": downloaded,
+        "local_downloaded": local_downloaded,
         "status": status,
+        "local_status": local_status,
+        "exists_in_selected_root": exists_in_selected_root,
+        "found_path": found_path,
+        "found_root_id": found_root_id,
+        "found_root_path": found_root_path,
+        "local_found_path": local_found_path,
+        "local_found_root_id": local_found_root_id,
         "found_by": found_by,
         "error": error,
     }
 
 
-def _public_package_files(models_root: str, package: Dict) -> List[Dict]:
+def _public_package_files(models_root: str, package: Dict, roots: List[Dict] | None = None) -> List[Dict]:
     normalized = _normalize_package(package)
-    return [_public_custom_file(models_root, row, index) for index, row in enumerate(normalized.get("files", []))]
+    return [
+        _public_custom_file(models_root, row, index, roots)
+        for index, row in enumerate(normalized.get("files", []))
+    ]
+
+
+def _is_default_root(root: Dict) -> bool:
+    return "default" in set(root.get("sources") or [root.get("source")])
+
+
+def _auto_selected_root(roots: List[Dict]) -> Dict:
+    if not roots:
+        raise RuntimeError("No ComfyUI model roots were found.")
+    return sorted(
+        roots,
+        key=lambda root: (
+            -int(root.get("existing_count") or 0),
+            0 if _is_default_root(root) else 1,
+            str(root.get("canonical_path") or root.get("path") or "").casefold(),
+        ),
+    )[0]
 
 
 def _build_payload(root_id: str | None, state_value=None, package_value=None, model_root: str | None = None) -> Dict:
-    selected, roots, selection_mode, selection_reason = _select_root(root_id)
+    roots = _collect_model_roots()
+    if not roots:
+        raise RuntimeError("No ComfyUI model roots were found.")
     state = _parse_presets_state(state_value)
     package = _normalize_package(package_value) if package_value is not None else _active_package_from_state(state)
-    roots = [
-        {
-            **root,
-            "existing_count": sum(
-                1
-                for file in _public_package_files(root["path"], package)
-                if file["status"] == "exists"
-            ),
-        }
-        for root in roots
-    ]
-    if selection_mode == "auto" and roots:
-        selected_count = next(
-            (root["existing_count"] for root in roots if root["id"] == selected["id"]),
-            0,
+    files_by_root_id = {}
+    roots_with_counts = []
+    for root in roots:
+        root_files = _public_package_files(root["path"], package, roots)
+        files_by_root_id[root["id"]] = root_files
+        local_existing_count = sum(1 for file in root_files if file["local_status"] == "exists")
+        roots_with_counts.append(
+            {
+                **root,
+                "local_existing_count": local_existing_count,
+                "existing_count": local_existing_count,
+            }
         )
-        best = max(roots, key=lambda root: root["existing_count"])
-        if best["existing_count"] > selected_count:
-            selected = best
-            selection_reason = "auto_highest_ready_count"
+    roots = roots_with_counts
+    explicit_selected = next((root for root in roots if root["id"] == root_id), None) if root_id else None
+    if explicit_selected:
+        selected = explicit_selected
+        selection_mode = "explicit"
+        selection_reason = "valid_explicit_root"
+    else:
+        selected = _auto_selected_root(roots)
+        selection_mode = "auto"
+        selection_reason = "invalid_explicit_root_fallback" if root_id else "auto_best_ready_files"
 
-    files = _public_package_files(selected["path"], package)
+    files = files_by_root_id[selected["id"]]
+    available_anywhere_count = sum(1 for file in files if file["status"] == "exists")
+    selected_root_existing_count = sum(1 for file in files if file["local_status"] == "exists")
     return {
         "mode": "manual_setup_helper",
         "frontend_protocol": 3,
@@ -664,7 +796,9 @@ def _build_payload(root_id: str | None, state_value=None, package_value=None, mo
         "model_subdirs": _model_subdirs(selected["path"]),
         "files": files,
         "total_size": sum(int(item["size"]) for item in files),
-        "existing_count": sum(1 for file in files if file["status"] == "exists"),
+        "existing_count": available_anywhere_count,
+        "selected_root_existing_count": selected_root_existing_count,
+        "available_anywhere_count": available_anywhere_count,
     }
 
 

--- a/docs/architecture/FRONTEND_FOUNDATION_PLAN.md
+++ b/docs/architecture/FRONTEND_FOUNDATION_PLAN.md
@@ -1,0 +1,101 @@
+# DENO Frontend Foundation Plan
+
+Status: Phase 1 Gate A PASS. No production node is migrated by this document.
+
+## Goal
+
+Move repeated ComfyUI frontend failure patterns into small reviewed modules only when a pilot node proves the need. Phase 2 must not create a broad unused framework.
+
+## Phase 2A Minimum Vertical Slice
+
+Phase 2A is limited to the first pilot's required path. The current recommended pilot remains `DenoLTXPromptGuide`, and Gate A now treats its saved-shape failure as the deterministic failing acceptance test that Phase 2A must fix.
+
+Minimum candidate modules for that pilot:
+
+| Module | Phase 2A status | Reason |
+|---|---|---|
+| `workflow_migration` | Candidate | Prompt Guide already has a known legacy 7-value to 5-value migration and needs visible restore/re-save proof. |
+| `widget_state` | Candidate | Prompt Guide needs name-based widget read/write and generated `serialize:false` widget isolation. |
+| `lifecycle` | Conditional | Add only if the pilot needs a shared idempotent setup/teardown wrapper instead of local wrappers. |
+| `node_size` | Conditional | Add only if Prompt Guide grow/shrink behavior requires a shared manual-size helper. |
+| `state_authority` | Docs/static assertion only | Keep as manifest/checklist/static assertion in Phase 2A. Do not create a runtime abstraction yet. |
+| `compat` | Confirmed differences only | Add a thin shim only for host differences confirmed by installed frontend evidence. No speculative wrapper. |
+
+Explicitly delayed until a pilot requires them:
+
+- `dynamic_slots`
+- `overlay_manager`
+- `storage`
+- `async_latest`
+- `canvas_events`
+- `geometry_audit`
+
+## Deferred Module Catalog
+
+This catalog names likely future modules without authorizing skeleton implementation.
+
+| Module | Future responsibility | First allowed trigger |
+|---|---|---|
+| `compat/` | Isolate confirmed host differences and private/internal API access. | Installed and latest frontend evidence show a real divergence or unavoidable private API. |
+| `lifecycle` | Idempotent node mount and cleanup. | Pilot has more than one setup/reconfigure/remove path to unify. |
+| `state_authority` | Static declarations, owner linting, and review manifests first. | Runtime abstraction only after two migrated nodes need the same enforcement. |
+| `widget_state` | Preserve widget identity and normalize hidden/layout state. | Phase 2A pilot. |
+| `workflow_migration` | Pure saved-value migrations. | Phase 2A pilot. |
+| `dynamic_slots` | Managed dynamic socket reconciliation. | A real dynamic-slot pilot, not Prompt Guide. |
+| `node_size` | Manual-size baseline plus content-required height. | Prompt Guide only if needed; otherwise wait for a size-heavy pilot. |
+| `canvas_events` | Wheel, pointer, scrollbar, and blank-area behavior. | A panel/scrollbar pilot. |
+| `overlay_manager` | Body-mounted modal/popover lifecycle. | Ideogram/Local LLM/Downloader overlay pilot. |
+| `storage` | Versioned namespaced localStorage with workflow precedence. | Easy Model Download Helper or Ideogram pilot. |
+| `async_latest` | Request sequencing and disposal. | Route-backed async pilot. |
+| `geometry_audit` | Measure off-node sockets, DOM panels, and stale hit regions. | Dynamic-slot or DOM-panel pilot. |
+
+## Phase Gates
+
+- Gate A: PASS. Phase 1 docs, source-contract evidence, and cards reviewed. The Prompt Guide fixture exists, is source-identical, and reproduces the known saved-shape failure deterministically.
+- Gate B / Phase 2A: minimum vertical slice for one pilot with pure tests and production migration only after the failing acceptance test is fixed.
+- Gate C: one production pilot migration with fresh/saved/copy-paste/queue/runtime parity and rollback plan.
+
+## Phase 2A Entry Conditions
+
+Phase 2A must not start until:
+
+- `DenoLTXPromptGuide` has a current saved workflow fixture, not only a legacy fixture.
+- The current fixture is source-identical and reproduces the known failure deterministically.
+- Installed frontend 1.45.15 source contracts are accepted for the exact APIs used by the pilot.
+- Any private/internal API needed by the pilot is either excluded or isolated in a confirmed compat adapter.
+- The source/runtime served JS mismatch is resolved or the pilot uses a disposable runtime for behavior proof.
+
+The current Prompt Guide fixture does not need to pass canonical 5-value save before Phase 2A entry. That failure is the Phase 2A target.
+
+## Phase 2A Exit Criteria
+
+Phase 2A acceptance requires:
+
+- first save writes the canonical 5 values
+- reload restores the exact visible values
+- second save writes the canonical 5 values
+- current clipboard path passes: graph.add -> configure
+- vintage/template clipboard path passes: configure -> graph.add
+- Queue Prompt inputs are exact
+- no new console errors attributable to Prompt Guide create/save/reload/copy/paste/queue actions
+
+Startup/runtime console errors collected before pilot actions must remain recorded separately as `startupBaselineErrors`; action-phase errors must be recorded separately as `actionPhaseErrors`.
+
+## Migration Priority
+
+1. `DenoLTXPromptGuide`: first candidate; fixture exists and deterministically reproduces the known canonical 5-value save failure.
+2. `DenoLTXModelDownloader`: later, after storage/async/root-intent contracts are ready.
+3. Small overlay/dialog nodes.
+4. `DenoLocalLLMRefiner`: after storage, async, widget migration, and state-changing verification patterns are proven.
+5. `DenoIdeogramDirector`: after overlay/storage/lifecycle contracts mature.
+6. Director/LTX AI Studio family: read-only inventory only until product contract and provenance gates settle.
+
+## Current Baseline Caveat
+
+The active 8188 runtime served DENO JS that did not match this worktree during Phase 1. Gate A used a source-identical disposable runtime for Prompt Guide fixture proof and still found a blocker: visible restore and Queue Prompt passed, but saved `widgets_values` remained a 7-slot generated-widget shape instead of the canonical 5-value shape.
+
+## Gate A Root Cause
+
+Installed/official `LGraphNode` workflow serialization checks `widget.serialize`, not `widget.options.serialize`, and writes `widgets_values` by live `node.widgets` array index. Prompt Guide inserts generated widgets at live indices 0 and 4, so current saves write a 7-slot shape. The node's `node.widgets_values` mirror does not control `graph.serialize()`.
+
+This is the Phase 2A implementation target, not a Gate A evidence collection failure.

--- a/docs/architecture/FRONTEND_PLAYBOOK.md
+++ b/docs/architecture/FRONTEND_PLAYBOOK.md
@@ -1,0 +1,70 @@
+# DENO Frontend Playbook
+
+Status: Phase 1 Gate A PASS architecture draft.
+
+## Read Path
+
+For frontend work, read these in order:
+
+1. `docs/architecture/FRONTEND_PLAYBOOK.md`
+2. `docs/architecture/cards/<node>.yaml`
+3. `docs/architecture/STATE_AUTHORITY_RULES.md`
+4. `docs/architecture/VERIFICATION_GATES.md`
+
+If a node has a separate product contract under `docs/nodes/`, read that before implementation as well.
+
+## UI Kinds
+
+- `native_widget`: normal ComfyUI widgets plus small custom draw helpers.
+- `bounded_panel`: one compact canvas or DOM panel inside the node.
+- `companion_workspace`: larger DOM board/sidebar/modal workspace.
+- `read_only_inventory`: architecture inventory for work that must not be edited in the current phase.
+
+## State Rules
+
+Workflow widgets own execution inputs. Versioned JSON widgets own complex documents. Official node geometry is owned by ComfyUI serialization `pos`, `size`, and `flags`. DENO `node.properties` owns only namespaced UI preferences and migration markers. localStorage owns reusable preferences/libraries only. Backend responses own derived readiness/status only.
+
+Backend effective result and explicit user intent must be displayed as separate concepts. For example, a backend may report an effective root, but the workflow still owns the user's explicit root intent.
+
+## Lifecycle Matrix
+
+Every non-trivial frontend card must cover:
+
+- fresh create
+- workflow load: graph.add -> configure
+- current clipboard: graph.add -> configure
+- vintage/template clipboard: configure -> graph.add
+- legacy migration
+- clone/duplicate
+- connection/widget change
+- save/reload/re-save
+- queue prompt
+- remove/recreate
+
+## Dynamic UI
+
+Dynamic slot rules apply only to DENO-owned real dynamic slots behind a reviewed adapter. Backend-declared/static inputs are not removed just because they are hidden. Visual, layout, interaction, and serialization must align, but hiding/removal must follow the host contract.
+
+## Size
+
+Use:
+
+```text
+rendered_height = max(required_content_height, user_manual_min_height)
+```
+
+Official position, size, and collapsed state come from ComfyUI `pos`, `size`, and `flags`. DENO may store only additional namespaced preferences.
+
+## Async
+
+Use latest-wins gates. Ignore stale responses and responses after node removal. Never promote a backend-derived response into workflow intent without a user action.
+
+## Storage
+
+Namespace and version every browser storage key. Corrupt JSON must recover. Workflow state wins over localStorage for active selections.
+
+## Verification
+
+Use fresh, current saved, legacy saved, current clipboard, vintage/template clipboard, Queue Prompt, resize, wheel/middle-click, console/network, source/served hash, and declared runtime matrix. Mark missing surfaces as `UNVERIFIED`; do not fold them into a pass.
+
+Console evidence must separate startup/runtime baseline noise from pilot action failures. Preserve pre-action errors as `startupBaselineErrors`, then record Prompt Guide create/save/reload/copy/paste/queue errors as `actionPhaseErrors`. The hard gate is no new pilot-attributable `actionPhaseErrors`.

--- a/docs/architecture/REVIEW_PACKET_SPEC.md
+++ b/docs/architecture/REVIEW_PACKET_SPEC.md
@@ -1,0 +1,130 @@
+# DENO Frontend Review Packet Specification
+
+Status: Phase 1 Gate A PASS draft.
+
+## Goal
+
+Produce a compact ZIP that lets an independent reviewer challenge the state contract, saved workflow path, runtime identity, source-contract evidence, and risk matrix without reading a whole chat transcript.
+
+## Command Shape
+
+```text
+python tools/build_node_review_packet.py --node <NODE_ID> --runtime <URL> --include-upstream
+```
+
+The command is a future target. This Phase 1 document defines the packet, not the tool.
+
+## Required Structure
+
+```text
+00_MANIFEST.md
+01_SCOPE.md
+02_GIT_STATE/
+03_SOURCE/
+04_ARCHITECTURE_CARD.yaml
+05_UPSTREAM_RUNTIME_BASELINE.md
+06_FIXTURES/
+07_TEST_RESULTS/
+08_BROWSER_EVIDENCE/
+09_CONSOLE_NETWORK/
+10_RISK_MATRIX.md
+11_OPEN_QUESTIONS.md
+12_SOURCE_CONTRACT/
+13_NEW_FILE_EVIDENCE/
+```
+
+## Manifest Fields
+
+- Repo path or repo-relative identity.
+- Branch and HEAD.
+- Dirty files.
+- Runtime URL and queue state when behavior proof is claimed.
+- Backend version and frontend package version.
+- Source/runtime/served hashes.
+- Source-contract excerpt manifest and official raw-source hash match result.
+- Fixture pass/fail status, including failed saved-shape and console/network evidence.
+- `startupBaselineErrors` and `actionPhaseErrors` recorded separately.
+- Included files and exclusions.
+- Packet SHA256.
+
+Public/tracked packet specifications must not require local absolute paths, current PID values, personal paths, or session records.
+
+## Evidence Labels
+
+Every claim must be one of:
+
+- `VERIFIED`
+- `INFERRED`
+- `UNVERIFIED`
+
+Do not merge evidence levels. A screenshot is behavior evidence, not serialization evidence. A unit test is build/contract evidence, not real-canvas behavior evidence.
+
+## Git Evidence For New Files
+
+If architecture docs are untracked, normal `git diff` may be empty. Review packets must include one of:
+
+- non-empty `git diff --no-index /dev/null <new-file>` evidence for each new file
+- a `NEW_FILES_MANIFEST` plus the full file originals
+
+Keep failures and `UNVERIFIED` rows in the packet. Do not include only successful evidence.
+
+## Public vs Local Location Policy
+
+Tracked/public repo may contain:
+
+- technical architecture rules
+- node architecture cards
+- verification gates
+- review packet specification
+
+Local/internal only:
+
+- `SESSION_HANDOFF`
+- runtime absolute paths and current PID values
+- incident casebook/history
+- personal operations notes
+
+Public docs must not include personal information, local absolute paths, current PIDs, or session transcripts.
+
+## Prohibited Packet Patterns
+
+- Include only successful tests while dropping failures.
+- Use whole JSON string search instead of inspecting `output[nodeId].inputs`.
+- Use a fresh-node screenshot as saved workflow proof.
+- Claim third-party extension compatibility when that extension was not loaded and exercised.
+- Treat manually injected state as actual pointer/network lifecycle proof.
+- Include unrelated repo history just because it is available.
+
+## Reviewer Response Format
+
+```text
+PASS | PASS WITH NOTES | BLOCK
+
+Blockers:
+High:
+Notes:
+Verified:
+Unverified:
+Recommended next action:
+```
+
+## Minimum Risk Matrix
+
+Each packet should challenge at least these cells:
+
+- Fresh node.
+- Current saved node.
+- Legacy saved node.
+- Current clipboard: graph.add -> configure.
+- Vintage/template clipboard: configure -> graph.add.
+- Queue Prompt.
+- Runtime source/served identity.
+- Installed frontend source-contract identity.
+- Missing optional resources.
+- Active missing resources.
+- Resize grow/shrink.
+- Wheel and middle-click.
+- Console/network errors.
+- Declared runtime matrix.
+
+For console/network evidence, preserve startup/runtime baseline failures instead of deleting them. The hard gate is no new error attributable to the scoped pilot actions.

--- a/docs/architecture/STATE_AUTHORITY_RULES.md
+++ b/docs/architecture/STATE_AUTHORITY_RULES.md
@@ -1,0 +1,89 @@
+# DENO Frontend State Authority Rules
+
+Status: Phase 1 Gate A PASS draft. This is an architecture rule document only; no production node is migrated by this file.
+
+## Purpose
+
+Every user-visible or execution-affecting value must have one canonical owner. A fallback, cache, backend-derived result, or effective computed value may assist the UI, but it must not silently become the user's saved intent.
+
+## State Classes
+
+| State class | Canonical owner | Persistence | Notes |
+|---|---|---|---|
+| Execution input | Workflow widget or workflow document field | Workflow JSON | Values sent to Queue Prompt. Preserve by widget/input name and schema, not by visual row position alone. |
+| Complex editor document | Versioned JSON widget | Workflow JSON | Use for boards, timelines, preset documents, and multi-field editors. |
+| Official node geometry | ComfyUI node serialization `pos`, `size`, `flags` | Workflow JSON | This owns position, width, height, collapsed state, and other host-recognized geometry. |
+| DENO UI preference | DENO-namespaced `node.properties` key | Workflow JSON | Only preferences that are not official geometry and not execution inputs, such as selected tab, scroll memory, panel mode, or migration marker. |
+| Shared library preference | Namespaced localStorage | Browser profile | Preset library or recent-list cache only. Workflow active selection wins. |
+| Explicit user intent | Workflow widget, versioned document widget, or deliberate user action | Workflow JSON | The user's chosen preset/root/model/prompt/mode. This must stay separate from effective computed results. |
+| Backend-derived effective result | Backend response | Runtime only unless explicitly accepted by the user | Status, readiness, effective root, detected model list, selected backend fallback. Display it separately from explicit intent. |
+| Request generation | Frontend runtime | Runtime only | Sequence token or AbortController. Not serialized. |
+| Temporary DOM/canvas state | Frontend runtime | Runtime only | Drag state, hover, open overlay, wheel capture. Must teardown. |
+
+## Precedence
+
+1. Saved workflow values are read before any default, backend result, or storage merge.
+2. Existing widget values are preserved by widget/input name, not by current row position alone.
+3. Official ComfyUI geometry is restored from `pos`, `size`, and `flags`; DENO code must not claim generic width/height ownership through `node.properties`.
+4. DENO `node.properties` may restore DENO-namespaced UI preferences only after execution values and official geometry are restored.
+5. localStorage may merge reusable libraries, but must not select the active preset/model/root for a saved workflow.
+6. Backend responses may display effective state, but cannot replace explicit user intent unless the user clicked a control that changes intent.
+7. Async responses are accepted only if they belong to the latest request for that node scope.
+
+## Clone, Copy, And Peer Sync
+
+Peer sync and clone paths must use allowlists. Copy executable values such as prompt text, mode, count, timing, and accepted preset documents. Do not copy manual layout locks, transient request ids, runtime catalog maps, open overlays, stale route responses, or per-node teardown handles.
+
+Copy/paste must follow the observed host order for the exact path being exercised. Do not describe the vintage/template path as the universal official copy/paste path.
+
+Required path names:
+
+- workflow load: graph.add -> configure
+- current clipboard: graph.add -> configure
+- vintage/template clipboard: configure -> graph.add
+
+A node must survive configure-before-add and add-before-configure paths when the pilot claims those paths, then reconcile after graph add without losing saved values.
+
+## Dynamic Topology
+
+Dynamic topology rules apply only to DENO-owned real dynamic slots that a reviewed adapter explicitly owns. They must not be generalized to every backend-declared/static input.
+
+DENO-owned dynamic rows require matching layers:
+
+- Visual row
+- Layout size
+- Interactive hit/socket geometry
+- Serialization and prompt payload
+
+Backend-declared/static inputs are not removed merely because a row is hidden or visually collapsed. Visual, layout, interaction, and serialization must align, but the host contract decides whether a control is hidden in place, converted, removed, or represented as a compatibility row.
+
+Direct `node.inputs`, `node.widgets`, `node.widgets_values`, and `target_slot` mutation is allowed only inside a reviewed foundation adapter with fixtures. Product nodes should call the adapter and provide node-specific fixture cases instead of owning raw topology surgery.
+
+## Async Requests
+
+Each node with backend routes needs latest-wins behavior:
+
+- Assign a request token before calling `fetch`.
+- Ignore stale responses.
+- Ignore responses after node removal.
+- Do not write backend-derived defaults into user-owned workflow widgets.
+- Show errors separately from saved intent.
+
+## Migration Owner
+
+The node architecture card owns the workflow schema version and migration matrix. A migration is incomplete until it proves:
+
+- Legacy raw values normalize to the current schema.
+- Visible restored values match the raw values.
+- Re-save produces the canonical current shape.
+- Queue Prompt sends the expected `output[nodeId].inputs`.
+
+## Serialization Authority
+
+For installed/official `LGraphNode` workflow serialization, the host checks `widget.serialize`, not `widget.options.serialize`, and writes `widgets_values` by live `node.widgets` array index. A product node's `node.widgets_values` mirror is not sufficient authority for `graph.serialize()`.
+
+For Prompt Guide specifically, generated presentation widgets at live indices 0 and 4 make current saves write a 7-slot shape. The Phase 2A adapter must make canonical serialization explicit instead of assuming generated widget metadata will be ignored.
+
+## Stop Conditions
+
+Stop implementation and report if a value has two canonical owners, if localStorage overrides workflow state, if official geometry and DENO layout memory disagree, if a hidden compatibility field can become an active execution value, or if a backend-derived effective value is being stored as explicit intent.

--- a/docs/architecture/VERIFICATION_GATES.md
+++ b/docs/architecture/VERIFICATION_GATES.md
@@ -1,0 +1,135 @@
+# DENO Frontend Verification Gates
+
+Status: Phase 1 Gate A PASS draft.
+
+## Evidence Levels
+
+| Level | What it proves | Examples |
+|---|---|---|
+| Build proof | Files parse and unit-level contracts hold | `node --check`, pytest, pure harness |
+| Deployment proof | The runtime is serving the expected files | source/runtime hashes, served JS marker, `/object_info`, process identity |
+| Source-contract proof | Installed ComfyUI/frontend source is identified for the API being used | dist-info, RECORD, source map with `sourcesContent`, tag/source hash comparison |
+| Contract proof | Frontend/backend/workflow payloads agree | input names, widget order, `graphToPrompt().output[nodeId].inputs` |
+| Behavior proof | A user path works in a real canvas | click, resize, wheel, modal, save/reload, console logs |
+| Compatibility proof | Old workflows and declared runtimes still work | legacy fixtures, current saved fixture, Portable/Desktop/EZi surfaces |
+
+`UNVERIFIED` is never a PASS. A result can be `PASS WITH NOTES` only when hard gates pass and clearly scoped soft gates remain unverified.
+
+## Source-Contract Gate
+
+Before a foundation module uses a ComfyUI frontend API, record:
+
+- installed package version and installed asset/map path
+- installed sourceContent hash when available
+- official tag/commit/hash comparison for the installed version
+- latest upstream tag/commit/hash comparison
+- public/private/internal classification
+- Phase 2 usable contract
+- whether a compat adapter is required
+
+If exact installed source cannot be secured for a private/internal API, keep that API `UNVERIFIED` and exclude the dependent module from Phase 2A.
+
+## Capability Gates
+
+### Dynamic Inputs
+
+- 0 to 1 to max to 1 to 0.
+- Mode A to mode B and back.
+- Real link on active row.
+- Real link on legacy or high row when supported.
+- Current clipboard lifecycle: graph.add -> configure.
+- Vintage/template clipboard lifecycle: configure -> graph.add.
+- Save, reload, native draw/arrange.
+- Queue Prompt exact key allowlist.
+- No off-node socket, duplicate socket, stale live widget binding, or hidden hit region.
+
+### Saved Workflow Migration
+
+- Legacy fixture raw values.
+- Current saved fixture raw values.
+- Visible restored values row by row.
+- Re-save round trip.
+- Current clipboard: graph.add -> configure.
+- Vintage/template clipboard: configure -> graph.add.
+- Queue Prompt exact inputs.
+- Missing optional resource while disabled/off/hidden.
+- Enabled missing resource fails with a clear field name.
+
+### Prompt Guide Phase 2A Acceptance
+
+Gate A accepted the evidence collection. The current Prompt Guide fixture's canonical saved-shape failure is the deterministic failing acceptance test for Phase 2A.
+
+Phase 2A must prove:
+
+- first save writes the canonical 5 values
+- reload restores the exact visible values
+- second save writes the canonical 5 values
+- current clipboard path passes: graph.add -> configure
+- vintage/template clipboard path passes: configure -> graph.add
+- Queue Prompt inputs are exact
+- no new Prompt Guide action-phase console errors
+
+Record `startupBaselineErrors` separately from `actionPhaseErrors`. Startup/userdata 404s or pre-initialization warnings observed before pilot actions are baseline evidence, not action failures.
+
+### DOM Panel
+
+- Mount once.
+- Remove and recreate.
+- Resize grow and shrink.
+- CJK text and long text.
+- Small viewport.
+- Wheel inside scroll region.
+- Wheel and middle-click on blank area.
+- Listener, observer, timer teardown.
+
+### localStorage
+
+- Empty storage.
+- Valid current storage.
+- Legacy storage migration.
+- Corrupt JSON recovery.
+- Workflow active selection overrides storage.
+- Cross-workflow contamination absent.
+
+### Async Requests
+
+- Latest request wins.
+- Out-of-order response ignored.
+- Abort or dispose.
+- Node removed before response.
+- Loading, error, success state.
+- Backend-derived state not promoted to explicit user intent.
+
+### Overlay
+
+- Single instance per node/tool.
+- Escape close.
+- Outside-click close when intended.
+- Viewport clamp.
+- Focus restore or safe focus loss.
+- Cleanup on node removal.
+
+### Manual Sizing
+
+- Initial auto-fit.
+- User grows.
+- User shrinks to content minimum.
+- Content expands beyond manual baseline.
+- Content contracts back to manual baseline.
+- Save and reload.
+- Vue Nodes path only when claimed.
+
+## Runtime Policy
+
+| Surface | Default |
+|---|---|
+| Installed official ComfyUI runtime | HARD for local behavior claims |
+| Portable / Easy-Install user baseline | HARD for public UI fixes |
+| Official Desktop | HARD when claimed or surface-sensitive |
+| Easy-Install Desktop / EZi WebView | HARD when claimed or surface-sensitive |
+| Vue Nodes | HARD only if touched or claimed |
+| Third-party extension behavior | OUT OF SCOPE unless explicitly claimed |
+
+## Active Queue Rule
+
+If `/queue` is running or pending, do not restart or sync the active runtime. Read-only API checks are allowed. Runtime behavior proof must be marked `UNVERIFIED` or moved to a disposable runtime.

--- a/docs/architecture/cards/deno-ltx-director-inventory.yaml
+++ b/docs/architecture/cards/deno-ltx-director-inventory.yaml
@@ -1,0 +1,177 @@
+schema_version: 2
+node_id: DenoLTXAIStudio
+aliases:
+  - Deno LTX Director
+  - Deno LTX AI Studio
+display_name: "(Deno) LTX AI Studio"
+status: read_only_inventory_phase1_r2
+owner: DENO
+ui_kind: read_only_inventory
+
+verified_against:
+  frontend_package: comfyui_frontend_package 1.45.15
+  comfyui_version: "0.25.1"
+  source_contract_baseline_ref: tmp/frontend-foundation-phase1/03_UPSTREAM_RUNTIME_BASELINE.md
+  source_contract_excerpts_ref: tmp/frontend-foundation-phase1/12_SOURCE_CONTRACT.md
+  last_reviewed_date: "2026-06-24"
+  behavior_runtime: UNVERIFIED
+  reason: Director/AI Studio WIP is intentionally outside this Phase 1 worktree scope
+
+product_contract:
+  purpose: DENO-owned LTX director/studio product inspired by WDC LTX Director ideas, not backed by WDC at runtime.
+  user_visible_behavior:
+    - DENO-owned node, routes, frontend, and studio_data remain the product authority.
+    - Human authority, review gates, timeline planning, transition intelligence, cleanup/NAG UX, and result review remain product goals.
+  non_goals:
+    - No WDC source import in this phase.
+    - No WDC LTXDirector hidden backend.
+    - No Director WIP source modification from this frontend foundation pass.
+
+entrypoints:
+  current_public_worktree:
+    source_inventory: absent
+    evidence:
+      - tests/test_ltx_tiled_nodes_static.py asserts DenoLTXAIStudio and LTXDirector are absent from tiled beta source
+  read_only_wip_inventory:
+    observed_repo_relative_files:
+      - deno_ltx_ai_studio.py
+      - web/js/deno_ltx_ai_studio.js
+      - tests/test_ltx_ai_studio_node.py
+      - tests/test_ltx_ai_studio_overlay.py
+      - tests/js/ltx_ai_studio_overlay_harness.mjs
+    modification_status: not_modified_by_phase1_r2
+
+state_authority:
+  expected_workflow:
+    - studio_data
+    - timeline/project document fields after product schema is approved
+  expected_backend_derived:
+    - readiness/status
+    - generated draft/review suggestions
+  expected_runtime_only:
+    - editor selection
+    - scrubber drag state
+    - preview playback state
+    - route request state
+  official_geometry:
+    - pos
+    - size
+    - flags
+  prohibited_authorities:
+    - WDC LTXDirector widgets
+    - WDC frontend state
+    - localStorage as active project authority
+
+precedence:
+  - DENO workflow studio_data must own project state after schema approval
+  - Local LLM drafts and review results are proposals until accepted by user action
+  - WDC timeline data may be a migration/reference input only, not runtime authority
+  - localStorage may cache preferences, not active project/timeline state
+
+lifecycle_matrix:
+  fresh_create:
+    expected: out_of_scope
+    status: UNVERIFIED
+  workflow_load_graph_add_then_configure:
+    path_name: "workflow load: graph.add -> configure"
+    expected: out_of_scope until product schema exists
+    status: UNVERIFIED
+  current_clipboard_graph_add_then_configure:
+    path_name: "current clipboard: graph.add -> configure"
+    expected: out_of_scope
+    status: UNVERIFIED
+  vintage_template_clipboard_configure_then_graph_add:
+    path_name: "vintage/template clipboard: configure -> graph.add"
+    expected: out_of_scope
+    status: UNVERIFIED
+  legacy_migration:
+    expected: WDC workflow migration may be planned only after provenance and schema gates
+    status: UNVERIFIED
+  clone_duplicate:
+    expected: out_of_scope
+    status: UNVERIFIED
+  connection_widget_change:
+    expected: out_of_scope
+    status: UNVERIFIED
+  save_reload_resave:
+    expected: out_of_scope until studio_data schema exists
+    status: UNVERIFIED
+  queue_prompt:
+    expected: out_of_scope
+    status: UNVERIFIED
+  remove_recreate:
+    expected: out_of_scope
+    status: UNVERIFIED
+
+schema_and_migrations:
+  workflow_schema_version: not_started_in_this_phase
+  planned_document_widget: studio_data
+  migration_sources:
+    - WDC timeline_data reference only after provenance review
+    - Temporal Director AI assets only after explicit migration map
+  required_before_pilot:
+    - product schema
+    - provenance gate
+    - WDC boundary review
+    - DENO-owned fixture
+
+official_hooks: []
+
+extension_api_usage: []
+
+host_interceptions: []
+
+private_internal_apis:
+  - api: timeline editor DOM/overlay behavior
+    classification: future_companion_workspace_internal
+    phase2_usable_contract: excluded from Phase 2A
+    compat_adapter_needed: yes_later
+  - api: WDC PromptRelay/Kijai provenance
+    classification: provenance_gate
+    phase2_usable_contract: no import without approval
+    compat_adapter_needed: external_dependency_or_clean_room_plan
+
+fixtures:
+  current_saved:
+    status: UNVERIFIED
+  legacy:
+    status: UNVERIFIED
+  required:
+    - DENO-owned studio_data fixture
+    - WDC reference fixture only if provenance gate permits analysis
+    - Local LLM draft/review acceptance fixture
+
+hard_gates:
+  - do not modify Director WIP in Frontend Foundation Phase 1/R2
+  - do not start Phase 2A with Director/AI Studio
+  - do not import GPL/WDC source or PromptRelay code without provenance approval
+  - do not use WDC as runtime backend
+  - do not publish, version bump, or public README rewrite as incidental foundation work
+
+soft_gates:
+  - future timeline editor layout audit
+  - future studio_data save/reload/re-save audit
+  - future review-gate transaction audit
+
+rollback:
+  strategy: no migration in this phase; leave WIP untouched and use this card only as inventory
+  files:
+    - none_in_current_worktree
+
+third_party_policy:
+  WDC:
+    allowed: reference_benchmark_migration_source_after_gate
+    prohibited: runtime_backend_hidden_control_plane_source_import_without_approval
+  KJNodes_LTXVideo_VHS:
+    allowed: normal ecosystem dependencies when the DENO-owned workflow needs them
+  Local_LLM:
+    allowed: DENO-owned local routes and review/draft proposals
+
+phase2a_recommendation:
+  recommended: false
+  reason: product/provenance/schema gates are larger than frontend foundation vertical slice
+
+open_questions:
+  - What exact DENO studio_data schema becomes canonical?
+  - Which WDC concepts are clean-room reimplemented versus treated only as comparison fixtures?
+  - Which timeline/review/result loop fixtures are required before any public workflow migration?

--- a/docs/architecture/cards/easy-model-download-helper.yaml
+++ b/docs/architecture/cards/easy-model-download-helper.yaml
@@ -1,0 +1,209 @@
+schema_version: 2
+node_id: DenoLTXModelDownloader
+display_name: "(Deno) Easy Model Download Helper"
+status: phase1_r2_later_candidate
+owner: DENO
+ui_kind: dom_panel
+
+verified_against:
+  frontend_package: comfyui_frontend_package 1.45.15
+  comfyui_version: "0.25.1"
+  source_contract_baseline_ref: tmp/frontend-foundation-phase1/03_UPSTREAM_RUNTIME_BASELINE.md
+  source_contract_excerpts_ref: tmp/frontend-foundation-phase1/12_SOURCE_CONTRACT.md
+  last_reviewed_date: "2026-06-24"
+  behavior_runtime: UNVERIFIED
+  reason: this card is a later candidate; current Phase 1 fixture work only exercised Prompt Guide
+
+product_contract:
+  purpose: Help users open official model links and place files into ComfyUI-recognized model folders.
+  user_visible_behavior:
+    - Shows target roots and readiness without automatic downloads.
+    - Root button is explicit copy-target intent.
+    - Readiness checks all registered model roots for matching model types.
+  non_goals:
+    - No downloader exposure without release approval.
+    - No arbitrary filesystem probing outside ComfyUI model roots.
+
+entrypoints:
+  frontend:
+    - web/js/deno_ltx_model_downloader.js
+  backend:
+    - deno_ltx_model_downloader.py
+  tests:
+    - tests/test_image_resize_node.py
+
+state_authority:
+  workflow:
+    - model_root
+    - presets_json
+  workflow_intent_notes:
+    model_root:
+      classification: mixed_legacy_workflow_field_effective_path_mirror_future_migration_source
+      evidence:
+        - frontend writes selected root path to model_root widget when user selects a root
+        - renderRoots writes backend effective models_root into the hidden model_root widget
+        - frontend sends model_root to backend as legacy_model_root evidence
+      not_canonical_for:
+        - current explicit root id
+        - current root mode
+        - backend effective root result
+      caveat: runtime explicit intent is rootMode + explicitRootId, backend effective result is effectiveRootId + models_root, and no explicit root id/mode is currently persisted
+    presets_json:
+      classification: explicit workflow preset document
+  runtime_explicit_intent:
+    - rootMode
+    - explicitRootId
+  backend_derived:
+    - effectiveRootId
+    - selected_root_id
+    - models_root
+    - readiness
+    - detected model roots
+    - selection_reason
+  local_storage:
+    - key: deno_ltx_model_downloader_presets_v3
+      classification: reusable preset library only
+      not_authority_for:
+        - active preset
+        - active root
+  runtime_only:
+    - refreshSequence
+    - DOM editing state
+  official_geometry:
+    - pos
+    - size
+    - flags
+
+precedence:
+  - workflow presets_json active_preset_id wins over localStorage
+  - localStorage may merge preset libraries but resets stored active_preset_id to default on read/write
+  - runtime explicit root intent is rootMode plus explicitRootId
+  - model_root is a legacy workflow field/effective path mirror/future migration source, not canonical explicit root intent
+  - backend selected_root_id/models_root is an effective result and must be displayed separately from explicit intent
+  - stale async responses are ignored by refreshSequence
+
+lifecycle_matrix:
+  fresh_create:
+    expected: hidden workflow widgets are created, DOM panel mounts once, default presets_json and default root are shown.
+    status: INFERRED from source
+  workflow_load_graph_add_then_configure:
+    path_name: "workflow load: graph.add -> configure"
+    expected: presets_json is read before localStorage merge; model_root is treated as legacy/mirror evidence until a future explicit root id/mode schema exists.
+    status: UNVERIFIED for visible restore
+  current_clipboard_graph_add_then_configure:
+    path_name: "current clipboard: graph.add -> configure"
+    expected: copied presets_json remains workflow-owned; copied model_root must not be promoted to canonical explicit intent without rootMode/explicitRootId schema.
+    status: UNVERIFIED
+  vintage_template_clipboard_configure_then_graph_add:
+    path_name: "vintage/template clipboard: configure -> graph.add"
+    expected: copied presets_json remains workflow-owned; copied model_root must not be promoted to canonical explicit intent without rootMode/explicitRootId schema.
+    status: UNVERIFIED
+  legacy_migration:
+    expected: old node ID/widget IDs map to current model_root and presets_json.
+    status: INFERRED from tests for replacement metadata
+  clone_duplicate:
+    expected: clone copies workflow widgets but not DOM edit state or refreshSequence.
+    status: UNVERIFIED
+  connection_widget_change:
+    expected: presets editor writes presets_json and storage library; root chip click writes model_root and triggers route check.
+    status: INFERRED from source
+  save_reload_resave:
+    expected: workflow re-saves model_root and presets_json; localStorage cannot choose active preset/root.
+    status: UNVERIFIED
+  queue_prompt:
+    expected: node has no execution output side effect; helper is output-node UI only and run returns empty tuple.
+    status: VERIFIED from backend source
+  remove_recreate:
+    expected: DOM panel listeners are removed with node/widget cleanup.
+    status: UNVERIFIED
+
+schema_and_migrations:
+  workflow_schema_version: 1
+  fields:
+    - model_root
+    - presets_json
+  root_schema_decision:
+    status: OPEN
+    current_persisted_explicit_root_id: none
+    current_persisted_root_mode: none
+    future_candidate: path-stable explicit root id or explicit mode field
+    model_root_future_role: legacy workflow field / effective path mirror / migration source
+  local_storage_schema:
+    current: deno_ltx_model_downloader_presets_v3
+    legacy:
+      - deno_ltx_model_downloader_presets_v1
+      - deno_ltx_model_downloader_presets_v2
+  required_before_pilot:
+    - saved workflow fixture with explicit root selection
+    - corrupt localStorage fixture
+    - backend route fixture where explicit root is invalid and effective root falls back
+
+official_hooks:
+  - app.registerExtension
+  - beforeRegisterNodeDef
+
+extension_api_usage:
+  - addDOMWidget
+  - api.fetchApi
+
+host_interceptions:
+  - api: nodeType.prototype.onNodeCreated/setup DOM widget
+    classification: deprecated_fragile_host_interception
+    phase2_usable_contract: later DOM-panel lifecycle adapter only
+    compat_adapter_needed: yes
+
+private_internal_apis:
+  - api: node.size direct assignment for panel fit
+    classification: internal geometry mutation
+    phase2_usable_contract: not in Phase 2A unless node_size pilot chooses this node
+    compat_adapter_needed: yes
+
+fixtures:
+  current_saved:
+    status: UNVERIFIED
+  required:
+    - workflow active preset differs from localStorage active preset
+    - selected model_root missing from current roots
+    - corrupt localStorage
+    - stale async response after root/preset switch
+
+hard_gates:
+  - workflow active preset beats localStorage
+  - localStorage cannot select active preset or active root
+  - backend-derived effectiveRootId/models_root is separate from runtime explicit rootMode/explicitRootId
+  - model_root is not treated as canonical explicit root intent until a persisted schema exists
+  - stale async response cannot overwrite current root intent
+  - selected root remains destination while readiness checks all registered roots
+
+soft_gates:
+  - DOM panel grow/shrink
+  - wheel and middle-click over blank panel regions
+  - Desktop and EZi surfaces for public behavior claims
+
+rollback:
+  strategy: keep current DOM panel implementation; do not migrate to foundation until storage and async fixtures pass
+  files:
+    - web/js/deno_ltx_model_downloader.js
+    - deno_ltx_model_downloader.py
+    - tests/test_image_resize_node.py
+
+third_party_policy:
+  external_sites:
+    - Hugging Face links are user-opened manually
+    - Civitai links are user-opened manually
+  downloads: no automatic downloader exposure without explicit release approval
+  filesystem: only ComfyUI-recognized model roots
+
+phase2a_recommendation:
+  recommended: false
+  earliest_phase: after_prompt_guide
+  needed_modules:
+    - storage
+    - async_latest
+    - overlay_manager
+    - node_size
+
+open_questions:
+  - Should a path-stable explicit root id or explicit root mode be added as a workflow field in a future breaking-safe schema?
+  - How should model_root migrate once explicit root id/mode exists: legacy evidence, display mirror, or compatibility-only backend input?
+  - What is the visible UI copy when explicit root intent is invalid but backend effective root falls back?

--- a/docs/architecture/cards/ideogram-director.yaml
+++ b/docs/architecture/cards/ideogram-director.yaml
@@ -1,0 +1,187 @@
+schema_version: 2
+node_id: DenoIdeogramDirector
+display_name: "(Deno) Ideogram Director"
+status: phase1_r2_later_candidate
+owner: DENO
+ui_kind: companion_workspace
+
+verified_against:
+  frontend_package: comfyui_frontend_package 1.45.15
+  comfyui_version: "0.25.1"
+  source_contract_baseline_ref: tmp/frontend-foundation-phase1/03_UPSTREAM_RUNTIME_BASELINE.md
+  source_contract_excerpts_ref: tmp/frontend-foundation-phase1/12_SOURCE_CONTRACT.md
+  last_reviewed_date: "2026-06-24"
+  behavior_runtime: UNVERIFIED
+  reason: this card is a later candidate; current Phase 1 fixture work only exercised Prompt Guide
+
+product_contract:
+  purpose: Visual Ideogram 4 caption studio for structured JSON prompt, dimensions, seed, and BBOX layout.
+  user_visible_behavior:
+    - Board state is visible, editable, and serialized through workflow widgets.
+    - Backdrop and import_json are the only intended wired inputs.
+    - Language view can translate editable board text while final output remains model-ready.
+  non_goals:
+    - Backdrop does not enter generation prompt.
+    - localStorage presets must not override current board values.
+
+entrypoints:
+  frontend:
+    - web/js/deno_ideogram_director.js
+  backend:
+    - deno_ideogram_director.py
+  tests:
+    - tests/test_translate_engine.py
+    - tests/test_ideogram_director_canvas_hotfix.py
+
+state_authority:
+  workflow:
+    - width
+    - height
+    - seed
+    - high_level_description
+    - background
+    - style fields
+    - import_mode
+    - caption_data
+    - seed_lock
+    - auto_save
+    - save_prefix
+    - aspect_ratio
+    - include_aspect_ratio
+    - translate_output
+    - view_language
+    - translation_engine
+    - libretranslate_url
+  local_storage:
+    - denoIdd.stylePresets
+    - denoIdd.layoutPresets
+  backend_derived:
+    - translation output
+    - validation/status messages
+  runtime_only:
+    - fullscreen body-mounted DOM
+    - gallery modal
+    - drag and bbox edit state
+  official_geometry:
+    - pos
+    - size
+    - flags
+
+precedence:
+  - workflow caption_data and widgets own active board state
+  - localStorage presets are libraries only and cannot overwrite the active board
+  - import_json is a workflow/import path, not a hidden source of live board truth after normalization
+  - fullscreen/gallery DOM state is runtime-only and must teardown
+  - translation results must be explicit output/preview, not silent replacement of source text unless user accepts
+
+lifecycle_matrix:
+  fresh_create:
+    expected: board initializes from workflow defaults with only intended sockets.
+    status: UNVERIFIED in Phase 1
+  workflow_load_graph_add_then_configure:
+    path_name: "workflow load: graph.add -> configure"
+    expected: caption_data raw JSON and visible board restore match before any localStorage merge.
+    status: UNVERIFIED for current worktree
+  current_clipboard_graph_add_then_configure:
+    path_name: "current clipboard: graph.add -> configure"
+    expected: copied board document and dimensions survive without fullscreen/gallery runtime state.
+    status: UNVERIFIED
+  vintage_template_clipboard_configure_then_graph_add:
+    path_name: "vintage/template clipboard: configure -> graph.add"
+    expected: copied board document and dimensions survive without fullscreen/gallery runtime state.
+    status: UNVERIFIED
+  legacy_migration:
+    expected: old import_json hidden-widget slot migrates without creating extra active sockets.
+    status: INFERRED from existing tests
+  clone_duplicate:
+    expected: clone copies workflow board document but not modal/drag/runtime handles.
+    status: UNVERIFIED
+  connection_widget_change:
+    expected: backdrop/import_json socket behavior stays explicit and board state remains workflow-owned.
+    status: UNVERIFIED
+  save_reload_resave:
+    expected: raw caption_data and visible board match after hard reload and second save.
+    status: UNVERIFIED
+  queue_prompt:
+    expected: prompt payload is generated from visible board/workflow values, excluding backdrop from text prompt.
+    status: INFERRED from product contract/source
+  remove_recreate:
+    expected: fullscreen, gallery, observers, and event listeners clean up.
+    status: UNVERIFIED
+
+schema_and_migrations:
+  workflow_schema_version: ideogram_director_caption_data_current
+  complex_document_widget: caption_data
+  known_legacy_shapes:
+    - import_json as hidden widget/input compatibility path
+  required_before_migration:
+    - current saved board fixture
+    - old import_json fixture
+    - localStorage preset conflict fixture
+    - translated view fixture
+
+official_hooks:
+  - app.registerExtension
+  - beforeRegisterNodeDef
+
+extension_api_usage:
+  - api.fetchApi for translation/helper routes
+
+host_interceptions:
+  - api: nodeType.prototype.onNodeCreated/setup
+    classification: deprecated_fragile_host_interception
+    phase2_usable_contract: later lifecycle adapter only
+    compat_adapter_needed: yes
+  - api: body-mounted DOM overlay lifecycle
+    classification: host_sensitive_dom_interception
+    phase2_usable_contract: later overlay_manager pilot only
+    compat_adapter_needed: yes
+
+private_internal_apis:
+  - api: socket hiding/fallback for import_json/backdrop
+    classification: internal LiteGraph socket behavior
+    phase2_usable_contract: wait for dynamic/geometry adapter
+    compat_adapter_needed: yes
+
+fixtures:
+  current_saved:
+    status: UNVERIFIED
+  required:
+    - current caption_data board fixture
+    - legacy import_json fixture
+    - localStorage style/layout library conflict
+    - translation mode fixture
+
+hard_gates:
+  - old import_json hidden-widget slot migration
+  - socketless fallback leaves only intended sockets
+  - fullscreen and gallery overlays clean up on close and node removal
+  - localStorage preset deletion has guardrails and does not alter current board
+  - saved caption_data raw JSON and visible board restore match
+
+soft_gates:
+  - Desktop and EZi surfaces for public behavior claims
+  - small viewport/fullscreen layout
+  - translation route network failures
+
+rollback:
+  strategy: defer foundation migration; keep current companion workspace code until overlay/storage/lifecycle helpers mature
+  files:
+    - web/js/deno_ideogram_director.js
+    - deno_ideogram_director.py
+    - tests/test_translate_engine.py
+
+third_party_policy:
+  ideogram: prompt text only; no external account action by node
+  translation:
+    - local/explicit LibreTranslate URL only when configured
+  storage: presets library only, not active board authority
+
+phase2a_recommendation:
+  recommended: false
+  reason: complex DOM workspace should validate later helpers, not be the first helper author
+
+open_questions:
+  - Which board fixture is the canonical current saved workflow?
+  - Which legacy import_json shapes are still public compatibility commitments?
+  - Should translation acceptance become an explicit workflow field in a future schema?

--- a/docs/architecture/cards/local-llm-loader-reviewer.yaml
+++ b/docs/architecture/cards/local-llm-loader-reviewer.yaml
@@ -1,0 +1,193 @@
+schema_version: 2
+node_id: DenoLocalLLMRefiner
+display_name: "(Deno) Local LLM Loader"
+status: phase1_r2_later_candidate
+owner: DENO
+ui_kind: bounded_panel
+
+verified_against:
+  frontend_package: comfyui_frontend_package 1.45.15
+  comfyui_version: "0.25.1"
+  source_contract_baseline_ref: tmp/frontend-foundation-phase1/03_UPSTREAM_RUNTIME_BASELINE.md
+  source_contract_excerpts_ref: tmp/frontend-foundation-phase1/12_SOURCE_CONTRACT.md
+  last_reviewed_date: "2026-06-24"
+  behavior_runtime: UNVERIFIED
+  reason: this card is a later candidate; current Phase 1 fixture work only exercised Prompt Guide
+
+product_contract:
+  purpose: Call local Ollama or LM Studio models from ComfyUI for prompt rewriting/review, with optional IMAGE input and reviewer gate behavior.
+  user_visible_behavior:
+    - Provider-specific model rows remain visible only for the active provider.
+    - Missing saved models are preserved and labeled as missing.
+    - Stop, unload, refresh, seed mode, and preview controls do not shift saved widget values.
+  non_goals:
+    - No non-localhost server calls.
+    - No hidden removed provider path becoming active execution.
+
+entrypoints:
+  frontend:
+    - web/js/deno_local_llm_refiner.js
+  backend:
+    - deno_local_llm_refiner.py
+  tests:
+    - tests/test_local_llm_reviewer_graph_transform.py
+    - tests/test_image_resize_node.py
+
+state_authority:
+  workflow:
+    - provider
+    - ollama_model
+    - lm_studio_model
+    - custom_server_url
+    - custom_model
+    - system_prompt
+    - thinking
+    - seed
+    - seed_mode
+    - model_memory
+    - keep_minutes
+    - comfy_vram_policy
+    - prompt
+  node_properties:
+    - denoLocalLLMPreviewScroll
+    - denoLocalLLMModelChoicesByProvider
+  local_storage:
+    - system prompt preset library
+  backend_derived:
+    - detected provider model list
+    - provider loaded/unloaded state
+    - route progress/status
+  runtime_only:
+    - __denoLocalLLMState
+    - preview dialogs
+    - progress listeners
+  official_geometry:
+    - pos
+    - size
+    - flags
+
+precedence:
+  - saved provider/model rows win over provider refresh defaults
+  - absent saved provider model must display as missing, not installed
+  - localStorage prompt library cannot replace workflow prompt/system_prompt
+  - backend provider status cannot rewrite workflow intent
+  - state-changing Stop/Unload verification must restore or prove the next normal run path
+
+lifecycle_matrix:
+  fresh_create:
+    expected: provider default rows map to backend input order; generated controls do not serialize.
+    status: UNVERIFIED in Phase 1
+  workflow_load_graph_add_then_configure:
+    path_name: "workflow load: graph.add -> configure"
+    expected: old/current widgets_values normalize before visible provider rows are hidden or shown.
+    status: VERIFIED by focused tests, real canvas pending
+  current_clipboard_graph_add_then_configure:
+    path_name: "current clipboard: graph.add -> configure"
+    expected: copied provider/model/prompt values survive generated controls and route refresh.
+    status: UNVERIFIED
+  vintage_template_clipboard_configure_then_graph_add:
+    path_name: "vintage/template clipboard: configure -> graph.add"
+    expected: copied provider/model/prompt values survive generated controls and route refresh.
+    status: UNVERIFIED
+  legacy_migration:
+    expected: old 18-slot saved layout restores Thinking and provider rows visibly.
+    status: VERIFIED by tests/test_local_llm_reviewer_graph_transform.py
+  clone_duplicate:
+    expected: clone copies executable widget values, not progress listeners/dialog/runtime route state.
+    status: UNVERIFIED
+  connection_widget_change:
+    expected: provider switch hides inactive rows without losing saved model ids; IMAGE input does not shift widgets.
+    status: UNVERIFIED
+  save_reload_resave:
+    expected: visible provider rows match raw saved values and second save does not rewrite missing models to defaults.
+    status: UNVERIFIED for real canvas
+  queue_prompt:
+    expected: output[nodeId].inputs contains provider-specific fields and no shifted UI labels as model names.
+    status: INFERRED from tests/source
+  remove_recreate:
+    expected: dialogs, timers, event listeners, and progress subscriptions tear down.
+    status: UNVERIFIED
+
+schema_and_migrations:
+  workflow_schema_version: local_llm_current_widget_order
+  known_legacy_shapes:
+    - old generated button/value layout around provider rows
+    - missing saved Ollama model
+    - missing saved LM Studio model
+  required_before_migration:
+    - current saved fixture per provider
+    - state-changing route recovery fixture
+    - provider switch keep-loaded fixture
+
+official_hooks:
+  - app.registerExtension
+  - beforeRegisterNodeDef
+
+extension_api_usage:
+  - api.fetchApi
+
+host_interceptions:
+  - api: nodeType.prototype.configure wrapper
+    classification: deprecated_fragile_host_interception
+    phase2_usable_contract: use through workflow_migration only after smaller pilot proves helper
+    compat_adapter_needed: yes
+  - api: nodeType.prototype.onNodeCreated/setup
+    classification: deprecated_fragile_host_interception
+    phase2_usable_contract: later lifecycle adapter only
+    compat_adapter_needed: yes
+
+private_internal_apis:
+  - api: direct widget order normalization before LiteGraph restore
+    classification: internal
+    phase2_usable_contract: use through workflow_migration only after smaller pilot proves helper
+    compat_adapter_needed: yes
+  - api: custom canvas preview draw and scroll handlers
+    classification: internal interaction surface
+    phase2_usable_contract: not in Phase 2A
+    compat_adapter_needed: yes
+
+fixtures:
+  legacy:
+    - tests/test_local_llm_reviewer_graph_transform.py inline fixtures
+  current_saved:
+    status: UNVERIFIED
+  required:
+    - Ollama missing saved model
+    - LM Studio missing saved model
+    - Custom Local Server shifted model rejection
+    - Stop/Unload next-run recovery
+
+hard_gates:
+  - old saved layout restores Thinking and provider rows visibly
+  - missing saved Ollama and LM Studio models are preserved and blocked clearly
+  - Stop and Unload are checked for both providers or marked UNVERIFIED
+  - state-changing verification restores next normal run path
+  - wheel and custom scrollbar behavior in preview and More dialogs
+
+soft_gates:
+  - Desktop and EZi surfaces for public behavior claims
+  - model refresh race matrix
+
+rollback:
+  strategy: do not migrate until Prompt Guide and storage/async helpers are proven; keep current node-local guards
+  files:
+    - web/js/deno_local_llm_refiner.js
+    - deno_local_llm_refiner.py
+    - tests/test_local_llm_reviewer_graph_transform.py
+
+third_party_policy:
+  allowed_providers:
+    - Ollama on local host
+    - LM Studio on local host
+    - explicit Custom Local Server local endpoint
+  external_account_actions: none
+  non_localhost: blocked unless user explicitly changes product policy
+
+phase2a_recommendation:
+  recommended: false
+  reason: high value but too many provider, async, storage, and state-changing cells for first foundation proof
+
+open_questions:
+  - Which current saved provider fixtures should be canonical for release gates?
+  - Should missing saved model display copy be standardized across Loader and Reviewer variants?
+  - What is the exact state restoration rule after Stop/Unload verification?

--- a/docs/architecture/cards/ltx-prompt-guide.yaml
+++ b/docs/architecture/cards/ltx-prompt-guide.yaml
@@ -1,0 +1,234 @@
+schema_version: 2
+node_id: DenoLTXPromptGuide
+display_name: "(Deno) LTX Prompt Guide"
+status: phase1_gate_a_pass_phase2a_ready
+owner: DENO
+ui_kind: native_widget
+
+verified_against:
+  frontend_package: comfyui_frontend_package 1.45.15
+  comfyui_version: "0.25.1"
+  source_contract_baseline_ref: tmp/frontend-foundation-phase1/03_UPSTREAM_RUNTIME_BASELINE.md
+  source_contract_excerpts_ref: tmp/frontend-foundation-phase1/12_SOURCE_CONTRACT.md
+  last_reviewed_date: "2026-06-24"
+  behavior_runtime: VERIFIED_KNOWN_FAILING_ACCEPTANCE_TEST
+  behavior_evidence: tmp/frontend-foundation-phase1/prompt-guide-current-fixture/ltx-prompt-guide-current-verification.json
+  reason: source-identical disposable runtime proved visible restore and Queue Prompt values, and deterministically reproduced the known canonical 5-value saved-shape failure that Phase 2A must fix
+
+product_contract:
+  purpose: Combine CLIP text encoding and LTX frame-rate conditioning, with dialogue-duration guidance.
+  user_visible_behavior:
+    - Positive prompt remains visible and editable.
+    - Negative prompt visibility is controlled by a beginner-facing toggle.
+    - Saved workflows keep the 5-value canonical shape.
+  non_goals:
+    - No dynamic sockets.
+    - No localStorage.
+    - No DOM overlay.
+
+entrypoints:
+  frontend:
+    - web/js/deno_ltx_prompt_guide.js
+  backend:
+    - deno_ltx_prompt_guide.py
+  tests:
+    - tests/test_public_workflow_migration.py
+    - tests/test_image_resize_node.py
+
+state_authority:
+  workflow:
+    - positive_prompt
+    - language
+    - frame_rate
+    - show_negative_prompt
+    - negative_prompt
+  official_geometry:
+    - pos
+    - size
+    - flags
+  node_properties:
+    - key: __deno_ltx_prompt_guide_save_restore
+      classification: migration_runtime_marker
+      evidence: web/js/deno_ltx_prompt_guide.js sets it after shape-based normalization returns values; that can be known legacy 7-slot input or current 5-plus input
+      not_authority_for:
+        - prompt text
+        - negative prompt toggle
+        - node width
+        - node height
+  runtime_only:
+    - __denoLtxPromptGuideConfiguredWidgetValues
+
+precedence:
+  - saved widgets_values are normalized before LiteGraph restore
+  - generated serialize_false widgets are never canonical prompt text
+  - widget names reapply the 5 canonical values after configure/setup
+  - official node size comes from ComfyUI serialization, with any DENO sizing helper limited to content fit
+
+lifecycle_matrix:
+  fresh_create:
+    expected: setupNode inserts generated summary/toggle widgets with serialize false and syncs 5 real widget values.
+    status: VERIFIED partial in disposable runtime; visible values and Queue Prompt matched, saved widgets_values did not become canonical 5
+  workflow_load_graph_add_then_configure:
+    path_name: "workflow load: graph.add -> configure"
+    expected: configure wrapper normalizes legacy/current values before LiteGraph row restore, then onConfigure reapplies by name.
+    status: VERIFIED by source, existing tests, and disposable reload visible proof; saved output still failed canonical 5 shape
+  current_clipboard_graph_add_then_configure:
+    path_name: "current clipboard: graph.add -> configure"
+    expected: current clipboard must preserve visible values, Queue Prompt inputs, and canonical 5-value saved shape.
+    status: REQUIRED in Phase 2A
+  vintage_template_clipboard_configure_then_graph_add:
+    path_name: "vintage/template clipboard: configure -> graph.add"
+    expected: configure must tolerate generated widgets being present or absent and still reapply 5 canonical values.
+    status: VERIFIED for ordering and visible/prompt values; canonical 5-value saved shape remains a Phase 2A acceptance criterion
+  legacy_migration:
+    expected: legacy 7-value shape maps to 5 real values only for exact empty-display-slot shape.
+    status: VERIFIED by tests/test_public_workflow_migration.py legacy checks
+  clone_duplicate:
+    expected: clone copies executable widget values only; generated widgets are rebuilt.
+    status: UNVERIFIED
+  connection_widget_change:
+    expected: prompt/language/frame_rate/toggle/negative changes sync node.widgets_values to the compact shape.
+    status: INFERRED from source callback wrappers
+  save_reload_resave:
+    expected: first save and second save remain 5 canonical values with visible rows matching raw values.
+    status: FAILED in source-identical disposable runtime; visible rows matched but first/second save wrote 7 widget slots
+  queue_prompt:
+    expected: backend receives positive_prompt, language, frame_rate, show_negative_prompt, negative_prompt.
+    status: VERIFIED in source-identical disposable runtime for first save, second save, and vintage copied node
+  remove_recreate:
+    expected: generated widgets are removed/rebuilt idempotently; no external listeners require teardown.
+    status: INFERRED
+
+schema_and_migrations:
+  contract_revision: 1
+  persisted_version_field: none
+  migration_dispatch: shape_based
+  canonical_widget_count: 5
+  exact_current_shape:
+    - positive_prompt
+    - language
+    - frame_rate
+    - show_negative_prompt
+    - negative_prompt
+  legacy_shapes:
+    - name: v0_3_8_7_values
+      shape: ["display_slot", "positive_prompt", "language", "frame_rate", "display_slot", "show_negative_prompt", "negative_prompt"]
+      status: VERIFIED by existing fixture coverage
+  current_source_behavior:
+    - getNormalizedLtxPromptGuideSerializedValues accepts the exact legacy 7-slot empty-display shape
+    - getNormalizedLtxPromptGuideSerializedValues also accepts 5-or-more values by slicing to 5
+    - the disposable runtime proved current saves still write the 7-slot generated-widget shape, so current source behavior is not enough for the Phase 2A foundation fixture gate
+  gate_a_root_cause:
+    - installed and official LGraphNode workflow serialization checks widget.serialize, not widget.options.serialize
+    - graph.serialize writes widgets_values by live node.widgets array index
+    - Prompt Guide inserts generated widgets at live indices 0 and 4, so current saves write a 7-slot shape
+    - node.widgets_values mirror does not control graph.serialize
+  unknown_future_shape_policy: UNVERIFIED/open decision; do not make silent truncate of unknown arrays a foundation default without a reviewed compatibility rule
+  phase2a_entry_condition:
+    - current saved workflow fixture exists
+    - current fixture is source-identical
+    - current fixture reproduces the known canonical 5-value saved-shape failure deterministically
+
+official_hooks:
+  - app.registerExtension
+  - beforeRegisterNodeDef
+
+extension_api_usage: []
+
+host_interceptions:
+  - api: nodeType.prototype.configure wrapper
+    classification: deprecated_fragile_host_interception
+    phase2_usable_contract: isolate in workflow_migration helper only after current fixture passes
+    compat_adapter_needed: yes
+  - api: nodeType.prototype.onNodeCreated wrapper
+    classification: deprecated_fragile_host_interception
+    phase2_usable_contract: isolate in lifecycle helper only if needed
+    compat_adapter_needed: yes
+  - api: nodeType.prototype.onConfigure wrapper
+    classification: deprecated_fragile_host_interception
+    phase2_usable_contract: isolate in lifecycle/workflow_migration helper only if needed
+    compat_adapter_needed: yes
+
+private_internal_apis:
+  - api: node.widgets_values direct assignment
+    classification: internal
+    phase2_usable_contract: only through widget_state/workflow_migration helper after fixture proof
+    compat_adapter_needed: yes
+  - api: widget.computeSize and custom widget draw
+    classification: internal_litegraph_widget_contract
+    phase2_usable_contract: use only for native-widget pilot with canvas proof
+    compat_adapter_needed: maybe
+
+fixtures:
+  legacy:
+    - tests/fixtures/public_workflows/ltx23_8gb_vram.json
+  current_saved:
+    status: KNOWN_FAILING_ACCEPTANCE_TEST
+    fixture_dir: tmp/frontend-foundation-phase1/prompt-guide-current-fixture
+    verification: tmp/frontend-foundation-phase1/prompt-guide-current-fixture/ltx-prompt-guide-current-verification.json
+    known_failure: saved workflow JSON remains 7-slot generated-widget shape instead of canonical 5 values
+    already_passed:
+      - visible restore
+      - Queue Prompt exact inputs
+      - vintage/template clipboard ordering and visible/prompt values
+    still_required_in_phase2a:
+      - current clipboard path
+      - canonical 5-value first save
+      - canonical 5-value second save
+      - no new pilot-attributable actionPhaseErrors
+    console_evidence_policy:
+      startupBaselineErrors: preserve startup/userdata 404s and pre-initialization warnings
+      actionPhaseErrors: must contain no new Prompt Guide create/save/reload/copy/paste/queue errors
+
+hard_gates:
+  - legacy 7-value fixture visible restore
+  - fresh node row mapping
+  - first save canonical 5-value shape
+  - reload exact visible values
+  - second save canonical 5-value shape
+  - current clipboard path passes graph.add -> configure
+  - vintage/template clipboard path passes configure -> graph.add
+  - Queue Prompt exact inputs
+  - no new actionPhaseErrors attributable to Prompt Guide actions
+  - grow and shrink around prompt and negative prompt widgets if node_size is included
+
+soft_gates:
+  - current clipboard real-canvas proof
+  - vintage/template clipboard real-canvas proof
+  - Desktop and EZi surfaces for public behavior claims
+
+rollback:
+  strategy: remove foundation helper import and keep existing local configure wrapper
+  files:
+    - web/js/deno_ltx_prompt_guide.js
+    - deno_ltx_prompt_guide.py
+    - tests/test_public_workflow_migration.py
+
+third_party_policy:
+  dependencies: ComfyUI/LiteGraph only
+  use_everywhere: out_of_scope
+  external_services: none
+
+phase2a_recommendation:
+  recommended: true
+  readiness: READY
+  known_failing_acceptance_test:
+    - canonical saved 5-value shape
+  already_passed:
+    - visible restore
+    - Queue Prompt exact inputs
+    - vintage/template clipboard ordering and visible/prompt values
+  still_required:
+    - current clipboard path
+    - first save canonical 5 values
+    - second save canonical 5 values
+    - no new pilot-attributable actionPhaseErrors
+  minimum_modules:
+    - workflow_migration
+    - widget_state
+    - lifecycle_if_needed
+    - node_size_if_needed
+
+open_questions:
+  - How should Prompt Guide produce canonical 5 saved widgets_values when LiteGraph serialize indexes non-generated widgets by their full widget array position?
+  - Should current 5-plus truncation stay as compatibility behavior, or be narrowed before foundation reuse?

--- a/docs/codex/AUTHORITY_AUDIT.md
+++ b/docs/codex/AUTHORITY_AUDIT.md
@@ -1,0 +1,63 @@
+# Codex Authority Audit
+
+Generated for the autopilot harness bootstrap.
+
+## Base
+
+- Repository: `Deno2026/comfyui-deno-custom-nodes`
+- Bootstrap branch: `Codex/autopilot-harness-bootstrap-20260626`
+- Base commit: `b88b7447cf0388aad913fc929e4a20b47f1153ba`
+- Included Phase 1 foundation commit: `e4ab65fe2051ed9a89462ca9b247e0ac9a1e0eaa`
+- Included Phase 2A Prompt Guide foundation commit: `95548340a452ade31440053bb2df14a96b648eee`
+- Ancestry check: both Phase 1 and Phase 2A are ancestors of the base commit.
+
+## Worktree Audit
+
+The bootstrap was created as a dedicated worktree from the clean base commit. Existing Director, release, runtime, and local WIP worktrees were not modified.
+
+Observed relevant clean worktrees:
+
+- `E:/DENO-Worktrees/comfyui-deno-frontend-foundation` at Phase 1.
+- `E:/DENO-Worktrees/comfyui-deno-frontend-foundation-phase2a-prompt-guide` at Phase 2A.
+- `E:/DENO-Worktrees/comfyui-deno-frontend-foundation-phase2b-model-downloader` at the base commit.
+
+## Authority Classification
+
+| Path | Class | Autoload | Notes |
+|---|---|---:|---|
+| `AGENTS.md` | AUTOLOAD | Local only | Compact durable repo rules created in the worktree but kept out of public Git tracking by the existing public-boundary test. |
+| `.agents/skills/deno-comfyui-node/SKILL.md` | AUTOLOAD | On trigger | Conversational DENO ComfyUI operating skill. |
+| `.agents/skills/deno-comfyui-node/references/*.md` | ON_DEMAND | No | Loaded only for matching capability tags. |
+| `.codex/hooks.json` | AUTOLOAD | Hook trust | Repository hook wiring; requires one-time `/hooks` trust. |
+| `.codex/hooks/*.py` | AUTOLOAD | Hook trust | Startup, prompt, compaction, and stop hook implementations. |
+| `.codex/state/*` | GENERATED_STATE | No | Local volatile state; ignored by Git. |
+| `tools/codex_task.py` | AUTOLOAD | Tool | Concise task state and two-strike ledger tool. |
+| `tools/codex_gate.py` | AUTOLOAD | Tool | Deterministic gate and evidence/contract status tool. |
+| `docs/codex/AUTHORITY_AUDIT.md` | ON_DEMAND | No | This audit. |
+| `docs/codex/HARNESS.md` | ON_DEMAND | No | Owner-facing trust and operation notes. |
+| `docs/architecture/FRONTEND_FOUNDATION_PLAN.md` | PRODUCT_CONTRACT | No | Phase and module boundary contract. |
+| `docs/architecture/FRONTEND_PLAYBOOK.md` | PRODUCT_CONTRACT | No | Frontend work read path and lifecycle matrix. |
+| `docs/architecture/STATE_AUTHORITY_RULES.md` | PRODUCT_CONTRACT | No | State ownership rules. |
+| `docs/architecture/VERIFICATION_GATES.md` | PRODUCT_CONTRACT | No | Capability gate source. |
+| `docs/architecture/REVIEW_PACKET_SPEC.md` | PRODUCT_CONTRACT | No | Reviewer artifact specification. |
+| `docs/architecture/cards/*.yaml` | PRODUCT_CONTRACT | No | Node-specific architecture cards. |
+| `.github/pull_request_template.md` | ON_DEMAND | No | Draft PR reporting surface. |
+| `.github/workflows/ci.yml` | ON_DEMAND | CI | Existing test suite workflow. |
+| `.github/workflows/codex_harness_gate.yml` | ON_DEMAND | CI | Harness gate workflow added by this bootstrap. |
+| `tests/codex_harness/**` | ON_DEMAND | Test | Harness self-tests. |
+
+## Missing Or Local-Only Authorities At Base
+
+The clean base commit did not track root `AGENTS.md`, `SESSION_HANDOFF.md`, `docs/DENO_NODE_RETROSPECTIVE.md`, `docs/NODE_WORK_INDEX.md`, or `docs/nodes/**`. They remain local-only operating references in other worktrees and are not made public by this bootstrap.
+
+The bootstrap generated a compact local root `AGENTS.md` in this worktree for Codex autoload, but the PR intentionally does not track it because the repository's existing public-surface test forbids root `AGENTS.md` in `git ls-files`.
+
+## Archive Decision
+
+No tracked oversized incident log or chronological handoff existed in the clean base worktree, so no history was moved. The new harness stores volatile current state in ignored `.codex/state/` and can generate a concise local `SESSION_HANDOFF.md` when needed.
+
+## Instruction Budget Targets
+
+- Root `AGENTS.md`: <= 8 KiB.
+- Automatically loaded repo docs: <= 16 KiB combined.
+- Generated `SESSION_HANDOFF.md`: <= 150 lines.

--- a/docs/codex/HARNESS.md
+++ b/docs/codex/HARNESS.md
@@ -1,0 +1,47 @@
+# Codex Autopilot Harness
+
+This harness lets the owner speak naturally while Codex maintains an internal task contract, deterministic gates, and a concise local state file.
+
+The compact root `AGENTS.md` remains local-only in this repository. Public Git tracking carries the skill, hooks, tools, tests, and `docs/codex` guidance instead, because the existing release safety test forbids root agent instructions in the public Git surface.
+
+## Owner Flow
+
+Normal prompts can stay conversational:
+
+```text
+This node seems to lose values after saving. Please check it.
+Continue.
+Only match official ComfyUI behavior.
+```
+
+Codex updates `.codex/state/ACTIVE_TASK.json` and chooses the required checks internally.
+
+## One-Time Hook Trust
+
+Repository hooks live under `.codex/hooks.json` and `.codex/hooks/*.py`.
+
+After reviewing this PR, trust the project hooks once through Codex `/hooks`. The hooks only read prompts, maintain local `.codex/state/`, snapshot checkpoints, and run the deterministic gate. They do not call paid APIs, push, publish, or release.
+
+## Local State
+
+Generated files under `.codex/state/` are ignored:
+
+- `ACTIVE_TASK.json`
+- `ACTIVE_TASK.md`
+- `CHECKPOINT.md`
+- `FAILURE_LEDGER.json`
+- `ESCALATION.md`
+- `GATE_RESULT.json`
+- `GATE_RESULT.md`
+
+These files are the resume authority for compaction and new sessions.
+
+## Gate
+
+Run:
+
+```text
+python tools/codex_gate.py --mode local
+```
+
+The gate records both `evidence_status` and `contract_status`. `UNVERIFIED` is not a pass.

--- a/tests/codex_harness/test_task_state.py
+++ b/tests/codex_harness/test_task_state.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_modules(monkeypatch, tmp_path, changed_files: str | None = ""):
+    monkeypatch.setenv("CODEX_HARNESS_REPO_ROOT", str(ROOT))
+    monkeypatch.setenv("CODEX_HARNESS_STATE_DIR", str(tmp_path / "state"))
+    if changed_files is None:
+        monkeypatch.delenv("CODEX_HARNESS_CHANGED_FILES", raising=False)
+    else:
+        monkeypatch.setenv("CODEX_HARNESS_CHANGED_FILES", changed_files)
+    sys.path.insert(0, str(ROOT))
+    import tools.codex_task as codex_task
+    import tools.codex_gate as codex_gate
+
+    codex_task = importlib.reload(codex_task)
+    codex_gate = importlib.reload(codex_gate)
+    return codex_task, codex_gate
+
+
+def run_hook(script: str, tmp_path: Path, payload: dict, changed_files: str = "") -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["CODEX_HARNESS_REPO_ROOT"] = str(ROOT)
+    env["CODEX_HARNESS_STATE_DIR"] = str(tmp_path / "state")
+    env["CODEX_HARNESS_CHANGED_FILES"] = changed_files
+    return subprocess.run(
+        [sys.executable, str(ROOT / ".codex" / "hooks" / script)],
+        cwd=ROOT,
+        input=json.dumps(payload),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        check=False,
+    )
+
+
+def test_instruction_size_budget(monkeypatch, tmp_path):
+    _task, gate = load_modules(monkeypatch, tmp_path, "AGENTS.md")
+    status, detail = gate.instruction_budget_check()
+    assert status == "PASS", detail
+
+
+def test_natural_prompt_creates_and_updates_one_contract(monkeypatch, tmp_path):
+    task, _gate = load_modules(monkeypatch, tmp_path)
+    first = task.start_task("\uc774 \ub178\ub4dc \uc800\uc7a5\ud558\uba74 \uac12\uc774 \uc0ac\ub77c\uc9c0\ub294 \uac83 \uac19\uc544. \ud55c\ubc88 \ubd10\uc918.")
+    task_id = first["task_id"]
+    assert "saved_workflow" in first["contract"]["capability_tags"]
+    assert first["contract"]["risk_level"] == "YELLOW"
+
+    second = task.update_task("\uc544\uae4c \uc598\uae30\ud55c \ubc29\ud5a5\uc740 \ubcc4\ub85c\uc57c. \uacf5\uc2dd ComfyUI \uae30\uc900\ub9cc \ub9de\ucdb0\uc918.")
+    assert second["task_id"] == task_id
+    assert "Third-party compatibility is not a goal unless explicitly requested." in second["contract"]["inferred_non_goals"]
+
+    third = task.update_task("\uacc4\uc18d \ud574\uc918.")
+    assert third["task_id"] == task_id
+    assert len(third["journal"]) == 3
+
+
+def test_session_start_without_active_task_injects_natural_prompt_instruction(tmp_path):
+    result = run_hook("session_start.py", tmp_path, {"event": "startup"})
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert "Infer and persist the task contract" in data["developer_context"]
+
+
+def test_prompt_hook_and_compaction_restore_context(tmp_path):
+    prompt = "\uc774 \ub178\ub4dc \uc800\uc7a5\ud558\uba74 \uac12\uc774 \uc0ac\ub77c\uc9c0\ub294 \uac83 \uac19\uc544."
+    submitted = run_hook("user_prompt_submit.py", tmp_path, {"prompt": prompt})
+    assert submitted.returncode == 0, submitted.stderr
+    data = json.loads(submitted.stdout)
+    assert "saved-workflow-visible-state" in data["developer_context"]
+
+    pre = run_hook("pre_compact.py", tmp_path, {"reason": "test compact"})
+    assert pre.returncode == 0, pre.stderr
+    post = run_hook("post_compact.py", tmp_path, {})
+    assert post.returncode == 0, post.stderr
+    restored = json.loads(post.stdout)
+    assert "Codex Checkpoint" in restored["developer_context"]
+    assert "saved_workflow" in restored["developer_context"]
+
+
+def test_stop_hook_blocks_once_then_escalates_without_loop(tmp_path):
+    first_prompt = {"prompt": "Build Codex harness without touching product code."}
+    setup = run_hook("user_prompt_submit.py", tmp_path, first_prompt, changed_files="README.md")
+    assert setup.returncode == 0, setup.stderr
+
+    first = run_hook("stop.py", tmp_path, {}, changed_files="README.md")
+    assert first.returncode == 2
+    assert json.loads(first.stdout)["decision"] == "continue"
+
+    second = run_hook("stop.py", tmp_path, {}, changed_files="README.md")
+    assert second.returncode == 0
+    assert json.loads(second.stdout)["status"] == "BLOCKED"
+    assert (tmp_path / "state" / "ESCALATION.md").exists()
+
+
+def test_two_strike_rule_escalates_only_for_separate_code_attempts(monkeypatch, tmp_path):
+    task, _gate = load_modules(monkeypatch, tmp_path)
+    task.start_task("Codex harness task")
+    task.record_test("saved-workflow-visible-state", "FAIL", attempt="a1", code_change=True)
+    ledger = task.load_failure_ledger()
+    assert ledger["failures"]["saved-workflow-visible-state"]["attempt_count"] == 1
+
+    task.record_test("saved-workflow-visible-state", "FAIL", attempt="a1", code_change=False)
+    ledger = task.load_failure_ledger()
+    assert ledger["failures"]["saved-workflow-visible-state"]["attempt_count"] == 1
+
+    task.record_test("saved-workflow-visible-state", "FAIL", attempt="a2", code_change=True)
+    active = task.load_task()
+    assert active["status"] == "BLOCKED"
+    assert task.ESCALATION_MD.exists()
+
+
+def test_gate_selects_checks_from_tags_and_paths(monkeypatch, tmp_path):
+    _task, gate = load_modules(monkeypatch, tmp_path)
+    selected = gate.select_required_gates(
+        ["web/js/deno_example.js"],
+        ["saved_workflow", "async", "storage"],
+        "YELLOW",
+    )
+    assert "node_check" in selected
+    assert "workflow_migration_fixture" in selected
+    assert "async_latest" in selected
+    assert "storage_precedence" in selected
+
+
+def test_evidence_status_is_separate_from_contract_status(monkeypatch, tmp_path):
+    task, gate = load_modules(monkeypatch, tmp_path, "")
+    task.start_task("Saved workflow harness check")
+    task.record_test("workflow_migration_fixture", "EXECUTED", evidence_path="scenario ran")
+    result = gate.evaluate("local", run_commands=True)
+    assert result["checks"]["workflow_migration_fixture"]["status"] == "UNVERIFIED"
+    assert result["evidence_status"] == "UNVERIFIED"
+    assert result["contract_status"] == "UNVERIFIED"
+
+
+def test_red_task_requires_architecture_decision(monkeypatch, tmp_path):
+    task, gate = load_modules(monkeypatch, tmp_path, "")
+    task.start_task("Change workflow schema and widget order.")
+    result = gate.evaluate("local", run_commands=True)
+    assert result["checks"]["architecture_decision"]["status"] == "FAIL"
+    assert result["contract_status"] == "FAIL"
+
+
+def test_unrequested_product_file_change_is_detected(monkeypatch, tmp_path):
+    task, gate = load_modules(monkeypatch, tmp_path, "web/js/deno_extra_nodes.js")
+    task.start_task("Build Codex autopilot harness")
+    result = gate.evaluate("local", run_commands=False)
+    assert result["checks"]["product_scope"]["status"] == "FAIL"
+    assert "web/js/deno_extra_nodes.js" in result["checks"]["product_scope"]["detail"]
+
+
+def test_generated_handoff_stays_under_150_lines(monkeypatch, tmp_path):
+    task, _gate = load_modules(monkeypatch, tmp_path, "AGENTS.md")
+    task.start_task("Build Codex autopilot harness")
+    text = task.generate_handoff()
+    assert len(text.splitlines()) <= 150

--- a/tests/js/ltx_model_downloader_foundation_harness.mjs
+++ b/tests/js/ltx_model_downloader_foundation_harness.mjs
@@ -1,0 +1,599 @@
+import assert from "node:assert/strict";
+import {
+    mergeLibraryByStableId,
+    promoteLibraryItem,
+    readVersionedJsonStorage,
+    upsertLibraryItem,
+    writeJsonStorage,
+} from "../../web/js/deno_frontend_core/storage.js";
+import { createLifecycleScope, getNodeLifecycleScope } from "../../web/js/deno_frontend_core/lifecycle.js";
+import { createLatestRequest } from "../../web/js/deno_frontend_core/async_latest.js";
+
+class FakeStorage {
+    constructor(values = {}) {
+        this.values = new Map(Object.entries(values));
+    }
+    getItem(key) {
+        return this.values.has(key) ? this.values.get(key) : null;
+    }
+    setItem(key, value) {
+        this.values.set(key, String(value));
+    }
+}
+
+class FakeTarget {
+    constructor() {
+        this.listeners = new Map();
+    }
+    addEventListener(type, listener, options) {
+        const key = `${type}:${Boolean(options?.capture || options === true)}`;
+        const listeners = this.listeners.get(key) || new Set();
+        listeners.add(listener);
+        this.listeners.set(key, listeners);
+    }
+    removeEventListener(type, listener, options) {
+        const key = `${type}:${Boolean(options?.capture || options === true)}`;
+        this.listeners.get(key)?.delete(listener);
+    }
+    count(type, capture = false) {
+        return this.listeners.get(`${type}:${capture}`)?.size || 0;
+    }
+}
+
+class FakeMutationObserver {
+    static instances = [];
+    constructor(callback) {
+        this.callback = callback;
+        this.observeCount = 0;
+        this.disconnectCount = 0;
+        FakeMutationObserver.instances.push(this);
+    }
+    observe() {
+        this.observeCount += 1;
+    }
+    disconnect() {
+        this.disconnectCount += 1;
+    }
+}
+
+globalThis.MutationObserver = FakeMutationObserver;
+
+function normalizeLibrary(value = {}) {
+    return {
+        schema_version: 4,
+        presets: Array.isArray(value.presets)
+            ? value.presets.map((item) => ({ ...item, id: String(item.id), title: String(item.title || item.id) }))
+            : [],
+    };
+}
+
+function slugify(value) {
+    const slug = String(value || "custom_preset")
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9가-힣]+/gi, "_")
+        .replace(/^_+|_+$/g, "");
+    return slug || "custom_preset";
+}
+
+function uniquePresetId(baseId, presets = []) {
+    const safeBase = slugify(baseId || "custom_preset");
+    const used = new Set(presets.map((item) => String(item?.id || "")).filter(Boolean));
+    if (!used.has(safeBase)) {
+        return safeBase;
+    }
+    let index = 2;
+    while (used.has(`${safeBase}_${index}`)) {
+        index += 1;
+    }
+    return `${safeBase}_${index}`;
+}
+
+function writePresetLibraryItemFromStorage(storage, packageValue) {
+    const latestLibrary = readVersionedJsonStorage({
+        storage,
+        currentKey: "library_v4",
+        normalize: normalizeLibrary,
+        fallback: normalizeLibrary(),
+    });
+    const presets = upsertLibraryItem(latestLibrary.presets, packageValue);
+    const nextLibrary = {
+        schema_version: 4,
+        presets,
+    };
+    writeJsonStorage(storage, "library_v4", nextLibrary);
+    return nextLibrary;
+}
+
+function saveNewPresetFromLatestLibrary(storage, workflowPresets, title, payload) {
+    const latestLibrary = readVersionedJsonStorage({
+        storage,
+        currentKey: "library_v4",
+        normalize: normalizeLibrary,
+        fallback: normalizeLibrary(),
+    });
+    const latestViewPresets = mergeLibraryByStableId(workflowPresets, latestLibrary.presets);
+    const id = uniquePresetId(slugify(title), latestViewPresets);
+    const packageValue = {
+        ...payload,
+        id,
+        title,
+    };
+    writePresetLibraryItemFromStorage(storage, packageValue);
+    return packageValue;
+}
+
+function testStorageContracts() {
+    const workflowPresets = [{ id: "workflow_pack", title: "Workflow Pack" }];
+    const libraryPresets = [{ id: "library_pack", title: "Library Pack" }];
+    const workflowBytes = JSON.stringify({ active_preset_id: "workflow_pack", presets: workflowPresets });
+    const storage = new FakeStorage({
+        current_v4: "{bad json",
+        legacy_v3: JSON.stringify({
+            active_preset_id: "library_pack",
+            presets: libraryPresets,
+        }),
+    });
+
+    const library = readVersionedJsonStorage({
+        storage,
+        currentKey: "current_v4",
+        legacyKeys: ["legacy_v3"],
+        normalize: normalizeLibrary,
+        fallback: normalizeLibrary(),
+    });
+    const merged = mergeLibraryByStableId(workflowPresets, library.presets);
+    assert.deepEqual(library.presets.map((item) => item.id), ["library_pack"]);
+    assert.deepEqual(merged.map((item) => item.id), ["workflow_pack", "library_pack"]);
+    assert.equal(workflowBytes, JSON.stringify({ active_preset_id: "workflow_pack", presets: workflowPresets }));
+
+    const promoted = promoteLibraryItem(workflowPresets, library.presets[0]);
+    assert.deepEqual(promoted.map((item) => item.id), ["workflow_pack", "library_pack"]);
+    assert.equal(writeJsonStorage(storage, "current_v4", normalizeLibrary({ presets: promoted })), true);
+    assert.match(storage.getItem("current_v4"), /library_pack/);
+
+    const workflowOnlyPresets = [{ id: "workflow_only", title: "Workflow Only" }];
+    const savedLibrary = upsertLibraryItem(libraryPresets, workflowOnlyPresets[0]);
+    assert.deepEqual(savedLibrary.map((item) => item.id), ["library_pack", "workflow_only"]);
+    assert.deepEqual(workflowOnlyPresets.map((item) => item.id), ["workflow_only"]);
+
+    const updatedLibrary = upsertLibraryItem(savedLibrary, { id: "library_pack", title: "Library Pack Updated" });
+    assert.deepEqual(updatedLibrary.map((item) => item.id), ["library_pack", "workflow_only"]);
+    assert.equal(updatedLibrary[0].title, "Library Pack Updated");
+    assert.equal(updatedLibrary[1].title, "Workflow Only");
+}
+
+function testConcurrentLibraryViewsPreservePresets() {
+    const storage = new FakeStorage({
+        library_v4: JSON.stringify({
+            schema_version: 4,
+            presets: [{ id: "library_a", title: "Library A" }],
+        }),
+    });
+    const staleViewOneLibrary = readVersionedJsonStorage({
+        storage,
+        currentKey: "library_v4",
+        normalize: normalizeLibrary,
+        fallback: normalizeLibrary(),
+    });
+    const staleViewTwoLibrary = readVersionedJsonStorage({
+        storage,
+        currentKey: "library_v4",
+        normalize: normalizeLibrary,
+        fallback: normalizeLibrary(),
+    });
+
+    assert.deepEqual(staleViewOneLibrary.presets.map((item) => item.id), ["library_a"]);
+    assert.deepEqual(staleViewTwoLibrary.presets.map((item) => item.id), ["library_a"]);
+
+    writePresetLibraryItemFromStorage(storage, { id: "library_b", title: "Library B" });
+    writePresetLibraryItemFromStorage(storage, { id: "library_c", title: "Library C" });
+    const mergedLibrary = readVersionedJsonStorage({
+        storage,
+        currentKey: "library_v4",
+        normalize: normalizeLibrary,
+        fallback: normalizeLibrary(),
+    });
+    assert.deepEqual(mergedLibrary.presets.map((item) => item.id), ["library_a", "library_b", "library_c"]);
+
+    writePresetLibraryItemFromStorage(storage, { id: "library_b", title: "Library B Updated" });
+    const updatedLibrary = readVersionedJsonStorage({
+        storage,
+        currentKey: "library_v4",
+        normalize: normalizeLibrary,
+        fallback: normalizeLibrary(),
+    });
+    assert.deepEqual(updatedLibrary.presets.map((item) => item.id), ["library_a", "library_b", "library_c"]);
+    assert.deepEqual(updatedLibrary.presets.map((item) => item.title), ["Library A", "Library B Updated", "Library C"]);
+}
+
+function testStaleViewsAllocateDistinctNewPresetIds() {
+    const storage = new FakeStorage({
+        library_v4: JSON.stringify({
+            schema_version: 4,
+            presets: [{ id: "library_a", title: "Library A", source: "initial" }],
+        }),
+    });
+    const workflowPresets = [];
+    const staleViewOneLibrary = readVersionedJsonStorage({
+        storage,
+        currentKey: "library_v4",
+        normalize: normalizeLibrary,
+        fallback: normalizeLibrary(),
+    });
+    const staleViewTwoLibrary = readVersionedJsonStorage({
+        storage,
+        currentKey: "library_v4",
+        normalize: normalizeLibrary,
+        fallback: normalizeLibrary(),
+    });
+
+    assert.deepEqual(staleViewOneLibrary.presets.map((item) => item.id), ["library_a"]);
+    assert.deepEqual(staleViewTwoLibrary.presets.map((item) => item.id), ["library_a"]);
+
+    const first = saveNewPresetFromLatestLibrary(storage, workflowPresets, "New Preset", { source: "view_1" });
+    const second = saveNewPresetFromLatestLibrary(storage, workflowPresets, "New Preset", { source: "view_2" });
+    const mergedLibrary = readVersionedJsonStorage({
+        storage,
+        currentKey: "library_v4",
+        normalize: normalizeLibrary,
+        fallback: normalizeLibrary(),
+    });
+
+    assert.equal(first.id, "new_preset");
+    assert.equal(second.id, "new_preset_2");
+    assert.deepEqual(mergedLibrary.presets.map((item) => item.id), ["library_a", "new_preset", "new_preset_2"]);
+    assert.deepEqual(mergedLibrary.presets.map((item) => item.source), ["initial", "view_1", "view_2"]);
+
+    writePresetLibraryItemFromStorage(storage, { id: "new_preset", title: "New Preset Updated", source: "view_1_updated" });
+    const updatedLibrary = readVersionedJsonStorage({
+        storage,
+        currentKey: "library_v4",
+        normalize: normalizeLibrary,
+        fallback: normalizeLibrary(),
+    });
+    assert.deepEqual(updatedLibrary.presets.map((item) => item.id), ["library_a", "new_preset", "new_preset_2"]);
+    assert.deepEqual(updatedLibrary.presets.map((item) => item.source), ["initial", "view_1_updated", "view_2"]);
+}
+
+function testLifecycleContracts() {
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+    let timeoutCallback = null;
+    let animationCallback = null;
+    const clearedTimeouts = [];
+    const canceledAnimationFrames = [];
+    try {
+        globalThis.setTimeout = (callback) => {
+            timeoutCallback = callback;
+            return 101;
+        };
+        globalThis.clearTimeout = (id) => {
+            clearedTimeouts.push(id);
+        };
+        globalThis.requestAnimationFrame = (callback) => {
+            animationCallback = callback;
+            return 202;
+        };
+        globalThis.cancelAnimationFrame = (id) => {
+            canceledAnimationFrames.push(id);
+        };
+
+        const node = {
+            removed: 0,
+            onRemoved() {
+                this.removed += 1;
+            },
+        };
+        const target = new FakeTarget();
+        const scope = getNodeLifecycleScope(node, "model-downloader");
+        const sameScope = getNodeLifecycleScope(node, "model-downloader");
+        assert.equal(scope, sameScope);
+
+        const listener = () => {};
+        scope.addEventListener(target, "click", listener);
+        scope.addEventListener(target, "wheel", listener, { capture: true });
+        scope.observeMutation({}, () => {}, { childList: true });
+        let timeoutFired = 0;
+        let animationFrameFired = 0;
+        scope.setTimeout(() => {
+            timeoutFired += 1;
+        }, 10);
+        scope.requestAnimationFrame(() => {
+            animationFrameFired += 1;
+        });
+        assert.equal(target.count("click"), 1);
+        assert.equal(target.count("wheel", true), 1);
+        assert.equal(FakeMutationObserver.instances.at(-1).observeCount, 1);
+
+        node.onRemoved();
+        assert.equal(node.removed, 1);
+        assert.equal(scope.disposed, true);
+        assert.equal(target.count("click"), 0);
+        assert.equal(target.count("wheel", true), 0);
+        assert.equal(FakeMutationObserver.instances.at(-1).disconnectCount, 1);
+        assert.deepEqual(clearedTimeouts, [101]);
+        assert.deepEqual(canceledAnimationFrames, [202]);
+        timeoutCallback();
+        animationCallback(0);
+        assert.equal(timeoutFired, 0);
+        assert.equal(animationFrameFired, 0);
+        scope.dispose();
+        assert.equal(FakeMutationObserver.instances.at(-1).disconnectCount, 1);
+    } finally {
+        globalThis.setTimeout = originalSetTimeout;
+        globalThis.clearTimeout = originalClearTimeout;
+        globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+        globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
+}
+
+async function testDisposedLifecycleDoesNotResurrect() {
+    const node = {
+        panelCount: 0,
+        requestCount: 0,
+        onRemoved() {},
+    };
+    const target = new FakeTarget();
+    const initialScope = getNodeLifecycleScope(node, "ltx-model-downloader");
+    let installedLatePanel = false;
+
+    function scheduleSetupLikeConfigure() {
+        const scope = getNodeLifecycleScope(node, "ltx-model-downloader");
+        if (!scope.disposed) {
+            queueMicrotask(() => {
+                const lateScope = getNodeLifecycleScope(node, "ltx-model-downloader");
+                if (lateScope.disposed) {
+                    return;
+                }
+                installedLatePanel = true;
+                node.panelCount += 1;
+                lateScope.addEventListener(target, "click", () => {});
+                lateScope.observeMutation({}, () => {}, { childList: true });
+                lateScope.setTimeout(() => {
+                    node.requestCount += 1;
+                }, 0);
+            });
+        }
+    }
+
+    scheduleSetupLikeConfigure();
+    node.onRemoved();
+    const disposedScope = getNodeLifecycleScope(node, "ltx-model-downloader");
+    assert.equal(initialScope.disposed, true);
+    assert.equal(disposedScope.disposed, true);
+    assert.notEqual(disposedScope, initialScope);
+    assert.equal(disposedScope.pendingCleanupCount, 0);
+
+    let disposedTimeoutFired = false;
+    disposedScope.addEventListener(target, "click", () => {});
+    disposedScope.observeMutation({}, () => {}, { childList: true });
+    disposedScope.setTimeout(() => {
+        disposedTimeoutFired = true;
+    }, 0);
+    disposedScope.requestAnimationFrame(() => {
+        disposedTimeoutFired = true;
+    });
+    await Promise.resolve();
+
+    assert.equal(installedLatePanel, false);
+    assert.equal(node.panelCount, 0);
+    assert.equal(node.requestCount, 0);
+    assert.equal(target.count("click"), 0);
+    assert.equal(disposedTimeoutFired, false);
+}
+
+function testDisposedScopeCleanupImmediate() {
+    const node = {
+        onRemoved() {},
+    };
+    const liveScope = getNodeLifecycleScope(node, "disposed-cleanup");
+    node.onRemoved();
+    assert.equal(liveScope.disposed, true);
+
+    const disposedScope = getNodeLifecycleScope(node, "disposed-cleanup");
+    let cleanupCount = 0;
+    const unregister = disposedScope.onDispose(() => {
+        cleanupCount += 1;
+    });
+    assert.equal(cleanupCount, 1);
+    assert.equal(typeof unregister, "function");
+    unregister();
+    assert.equal(cleanupCount, 1);
+}
+
+function testLiveDisposedScopeCleanupRunsOnce() {
+    const scope = createLifecycleScope();
+    scope.dispose();
+    let cleanupCount = 0;
+    const unregister = scope.onDispose(() => {
+        cleanupCount += 1;
+    });
+    assert.equal(cleanupCount, 1);
+    assert.equal(typeof unregister, "function");
+    unregister();
+    assert.equal(cleanupCount, 1);
+}
+
+async function testCompletedCleanupCountsStayStable() {
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+    const timers = [];
+    const frames = [];
+    let nextTimeoutId = 0;
+    let nextFrameId = 1000;
+
+    try {
+        globalThis.setTimeout = (callback) => {
+            const id = ++nextTimeoutId;
+            timers.push({ id, callback });
+            return id;
+        };
+        globalThis.clearTimeout = (id) => {
+            const index = timers.findIndex((timer) => timer.id === id);
+            if (index >= 0) {
+                timers.splice(index, 1);
+            }
+        };
+        globalThis.requestAnimationFrame = (callback) => {
+            const id = ++nextFrameId;
+            frames.push({ id, callback });
+            return id;
+        };
+        globalThis.cancelAnimationFrame = (id) => {
+            const index = frames.findIndex((frame) => frame.id === id);
+            if (index >= 0) {
+                frames.splice(index, 1);
+            }
+        };
+
+        const scope = getNodeLifecycleScope({}, "cleanup-stability");
+        const baseline = scope.pendingCleanupCount;
+        for (let index = 0; index < 100; index += 1) {
+            let timeoutFired = 0;
+            let frameFired = 0;
+            scope.setTimeout(() => {
+                timeoutFired += 1;
+            }, 0);
+            timers.shift().callback();
+            assert.equal(timeoutFired, 1);
+            assert.equal(scope.pendingCleanupCount, baseline);
+
+            scope.requestAnimationFrame(() => {
+                frameFired += 1;
+            });
+            frames.shift().callback(index);
+            assert.equal(frameFired, 1);
+            assert.equal(scope.pendingCleanupCount, baseline);
+        }
+
+        const latest = createLatestRequest(scope);
+        const afterLatestSetup = scope.pendingCleanupCount;
+        assert.equal(afterLatestSetup, baseline + 1);
+        const applied = [];
+        for (let index = 0; index < 100; index += 1) {
+            await latest.run(async () => index, {
+                apply(value) {
+                    applied.push(value);
+                },
+            });
+            assert.equal(scope.pendingCleanupCount, afterLatestSetup);
+        }
+        assert.equal(applied.length, 100);
+        scope.dispose();
+        assert.equal(scope.pendingCleanupCount, 0);
+    } finally {
+        globalThis.setTimeout = originalSetTimeout;
+        globalThis.clearTimeout = originalClearTimeout;
+        globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+        globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
+}
+
+function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+async function testLatestRequestContracts() {
+    const scope = getNodeLifecycleScope({}, "async");
+    const latest = createLatestRequest(scope);
+    const first = deferred();
+    const second = deferred();
+    const applied = [];
+    const errors = [];
+
+    const firstRun = latest.run(async () => first.promise, {
+        apply(value) {
+            applied.push(value);
+        },
+        onError(error) {
+            errors.push(error);
+        },
+    });
+    const secondRun = latest.run(async () => second.promise, {
+        apply(value) {
+            applied.push(value);
+        },
+        onError(error) {
+            errors.push(error);
+        },
+    });
+    first.resolve("stale");
+    second.resolve("fresh");
+    await Promise.all([firstRun, secondRun]);
+    assert.deepEqual(applied, ["fresh"]);
+    assert.deepEqual(errors, []);
+
+    const held = deferred();
+    const disposedRun = latest.run(async () => held.promise, {
+        apply(value) {
+            applied.push(value);
+        },
+    });
+    scope.dispose();
+    held.resolve("disposed");
+    await disposedRun;
+    assert.deepEqual(applied, ["fresh"]);
+
+    const abortScope = getNodeLifecycleScope({}, "abort");
+    const abortLatest = createLatestRequest(abortScope);
+    await abortLatest.run(async () => {
+        const error = new Error("aborted");
+        error.name = "AbortError";
+        throw error;
+    }, {
+        onError(error) {
+            throw error;
+        },
+    });
+}
+
+async function testDisposedLatestRequestDoesNotStart() {
+    const scope = getNodeLifecycleScope({}, "async-disposed");
+    const latest = createLatestRequest(scope);
+    scope.dispose();
+
+    let taskCalled = false;
+    let applyCalled = false;
+    let errorCalled = false;
+
+    await latest.run(async () => {
+        taskCalled = true;
+        return "late";
+    }, {
+        apply() {
+            applyCalled = true;
+        },
+        onError() {
+            errorCalled = true;
+        },
+    });
+
+    assert.equal(taskCalled, false);
+    assert.equal(applyCalled, false);
+    assert.equal(errorCalled, false);
+    assert.equal(latest.begin(), null);
+}
+
+testStorageContracts();
+testConcurrentLibraryViewsPreservePresets();
+testStaleViewsAllocateDistinctNewPresetIds();
+testLifecycleContracts();
+await testDisposedLifecycleDoesNotResurrect();
+testDisposedScopeCleanupImmediate();
+testLiveDisposedScopeCleanupRunsOnce();
+await testCompletedCleanupCountsStayStable();
+await testLatestRequestContracts();
+await testDisposedLatestRequestDoesNotStart();
+
+console.log("ltx_model_downloader_foundation_harness PASS");

--- a/tests/js/ltx_prompt_guide_workflow_migration_harness.mjs
+++ b/tests/js/ltx_prompt_guide_workflow_migration_harness.mjs
@@ -1,0 +1,357 @@
+import {
+    applyOrderedWidgetValues,
+    canonicalOrderedSerializationValues,
+    findWidget,
+} from "../../web/js/deno_frontend_core/widget_state.js";
+import {
+    createExactWidgetValueShapeMigration,
+    expandCanonicalValuesForGeneratedSlots,
+    installWorkflowWidgetMigration,
+} from "../../web/js/deno_frontend_core/workflow_migration.js";
+
+const NODE_NAME = "DenoLTXPromptGuide";
+const GENERATED_PREFIX = "deno_ltx_prompt_guide_";
+const GENERATED_SLOTS = [0, 4];
+const WIDGET_SPECS = [
+    { name: "positive_prompt", defaultValue: "" },
+    { name: "language", defaultValue: "Auto", normalize: (value) => String(value || "Auto") },
+    { name: "frame_rate", defaultValue: 25, normalize: (value) => Number(value) || 25 },
+    { name: "show_negative_prompt", defaultValue: false, normalize: (value) => Boolean(value) },
+    { name: "negative_prompt", defaultValue: "" },
+];
+const missingCanonicalWidgetWarnings = new WeakSet();
+
+function check(condition, message) {
+    if (!condition) {
+        throw new Error(message);
+    }
+}
+
+function eq(actual, expected, message) {
+    const actualJson = JSON.stringify(actual);
+    const expectedJson = JSON.stringify(expected);
+    check(actualJson === expectedJson, `${message}\nactual:   ${actualJson}\nexpected: ${expectedJson}`);
+}
+
+function hostConfigure(info) {
+    this.__hostConfigureCalls = (this.__hostConfigureCalls || 0) + 1;
+    this.__hostConfigureReceived = [...(info.widgets_values || [])];
+    if (this.__throwOnConfigure) {
+        throw new Error("host configure throw sentinel");
+    }
+    let valueIndex = 0;
+    for (const widget of this.widgets || []) {
+        if (widget.serialize === false) {
+            continue;
+        }
+        if (valueIndex >= info.widgets_values.length) {
+            break;
+        }
+        widget.value = info.widgets_values[valueIndex++];
+    }
+}
+
+function hostSerialize(node) {
+    const serialized = {};
+    if (node.widgets && node.serialize_widgets) {
+        serialized.widgets_values = [];
+        for (const [index, widget] of node.widgets.entries()) {
+            if (widget.serialize === false) {
+                continue;
+            }
+            serialized.widgets_values[index] = widget.value ?? null;
+        }
+    }
+    node.onSerialize?.(serialized);
+    return serialized;
+}
+
+function makePromptGuideNode({ generated = true } = {}) {
+    const realWidgets = [
+        { name: "positive_prompt", value: "" },
+        { name: "language", value: "Auto" },
+        { name: "frame_rate", value: 25 },
+        { name: "show_negative_prompt", value: false },
+        { name: "negative_prompt", value: "" },
+    ];
+    const widgets = generated
+        ? [
+              { name: `${GENERATED_PREFIX}dialogue_summary`, value: "" },
+              realWidgets[0],
+              realWidgets[1],
+              realWidgets[2],
+              { name: `${GENERATED_PREFIX}negative_toggle`, value: "" },
+              realWidgets[3],
+              realWidgets[4],
+          ]
+        : realWidgets;
+    return {
+        type: NODE_NAME,
+        widgets,
+        serialize_widgets: true,
+        properties: {},
+    };
+}
+
+function installPromptGuideAdapter(nodeType) {
+    const normalize = createExactWidgetValueShapeMigration({
+        canonicalCount: WIDGET_SPECS.length,
+        legacyGeneratedSlots: GENERATED_SLOTS,
+    });
+
+    return installWorkflowWidgetMigration(nodeType, { name: NODE_NAME }, {
+        nodeName: NODE_NAME,
+        pendingValuesKey: "__denoLtxPromptGuideConfiguredWidgetValues",
+        normalizeSerializedValues: normalize,
+        getConfigureWidgetValues(node, canonicalValues) {
+            const hasGenerated = (node.widgets || []).some((widget) => String(widget?.name || "").startsWith(GENERATED_PREFIX));
+            return hasGenerated
+                ? expandCanonicalValuesForGeneratedSlots(canonicalValues, GENERATED_SLOTS)
+                : canonicalValues;
+        },
+        applyCanonicalValues(node, canonicalValues) {
+            applyOrderedWidgetValues(node, WIDGET_SPECS, canonicalValues);
+            node.properties.__deno_ltx_prompt_guide_save_restore = "ltx-prompt-guide-save-reload-v2";
+        },
+        getCanonicalSerializationValues(node) {
+            const missing = WIDGET_SPECS.map((spec) => spec.name).filter((name) => !findWidget(node, name));
+            if (missing.length) {
+                missingCanonicalWidgetWarnings.add(node);
+                return null;
+            }
+            return canonicalOrderedSerializationValues(node, WIDGET_SPECS);
+        },
+    });
+}
+
+function testShapeClassifier() {
+    const normalize = createExactWidgetValueShapeMigration({
+        canonicalCount: 5,
+        legacyGeneratedSlots: GENERATED_SLOTS,
+    });
+
+    eq(normalize(["POS", "Korean", 24, true, "NEG"]), ["POS", "Korean", 24, true, "NEG"], "exact current 5 passes unchanged");
+    eq(normalize(["", "POS", "Korean", 24, "", true, "NEG"]), ["POS", "Korean", 24, true, "NEG"], "legacy 7 maps to canonical 5");
+    eq(normalize([null, "POS", "English", 30, null, false, "NEG"]), ["POS", "English", 30, false, "NEG"], "null generated slots map as empty");
+    check(normalize(["", "POS", "Korean", 24, "not empty", true, "NEG"]) === null, "non-empty generated slot is unknown");
+    check(normalize(["POS", "Korean", 24, true, "NEG", "extra"]) === null, "6-slot shape is unknown");
+    check(normalize(["", "POS", "Korean", 24, "", true, "NEG", "extra"]) === null, "8-slot shape is unknown");
+    check(normalize("not-array") === null, "non-array shape is unknown");
+}
+
+function testHostContractWithGeneratedWidgets() {
+    let priorSerializeCalls = 0;
+    const nodeType = {
+        prototype: {
+            configure: hostConfigure,
+            onSerialize(info) {
+                priorSerializeCalls += 1;
+                info.priorCallbackWasCalled = true;
+            },
+        },
+    };
+    check(installPromptGuideAdapter(nodeType) === true, "adapter installed");
+
+    const node = makePromptGuideNode({ generated: true });
+    Object.setPrototypeOf(node, nodeType.prototype);
+    nodeType.prototype.configure.call(node, {
+        widgets_values: ["", "POSITIVE SAVE", "Korean", 24, "", true, "NEGATIVE SAVE"],
+    });
+
+    eq(
+        node.__hostConfigureReceived,
+        ["", "POSITIVE SAVE", "Korean", 24, "", true, "NEGATIVE SAVE"],
+        "host configure receives generated-slot shape",
+    );
+    check(node.__hostConfigureCalls === 1, "prior configure called once");
+    check(findWidget(node, "positive_prompt").value === "POSITIVE SAVE", "positive prompt restored");
+    check(findWidget(node, "negative_prompt").value === "NEGATIVE SAVE", "negative prompt restored");
+
+    const rawHostShape = [];
+    for (const [index, widget] of node.widgets.entries()) {
+        if (widget.serialize === false) {
+            continue;
+        }
+        rawHostShape[index] = widget.value ?? null;
+    }
+    eq(
+        rawHostShape,
+        ["", "POSITIVE SAVE", "Korean", 24, "", true, "NEGATIVE SAVE"],
+        "unadapted host serialization reproduces the 7-slot failure",
+    );
+
+    const serialized = hostSerialize(node);
+    check(priorSerializeCalls === 1, "prior onSerialize called once");
+    check(serialized.priorCallbackWasCalled === true, "prior onSerialize mutation preserved");
+    eq(
+        serialized.widgets_values,
+        ["POSITIVE SAVE", "Korean", 24, true, "NEGATIVE SAVE"],
+        "adapter compacts host serialization to canonical 5",
+    );
+    eq(node.widgets_values, serialized.widgets_values, "node mirror follows canonical values without being the authority");
+}
+
+function testConfigureTemporarilyExpandsAndRestoresCallerInfo() {
+    const nodeType = { prototype: { configure: hostConfigure } };
+    installPromptGuideAdapter(nodeType);
+
+    const currentNode = makePromptGuideNode({ generated: true });
+    Object.setPrototypeOf(currentNode, nodeType.prototype);
+    const currentValues = ["POS", "Korean", 24, true, "NEG"];
+    const currentInfo = { widgets_values: currentValues };
+    nodeType.prototype.configure.call(currentNode, currentInfo);
+    eq(
+        currentNode.__hostConfigureReceived,
+        ["", "POS", "Korean", 24, "", true, "NEG"],
+        "host receives expanded 7-slot shape for current canonical input",
+    );
+    check(currentInfo.widgets_values === currentValues, "current caller info keeps exact original 5-value array reference");
+    eq(currentInfo.widgets_values, ["POS", "Korean", 24, true, "NEG"], "current caller info values remain unchanged");
+
+    const legacyNode = makePromptGuideNode({ generated: true });
+    Object.setPrototypeOf(legacyNode, nodeType.prototype);
+    const legacyValues = ["", "LEGACY POS", "English", 30, "", false, "LEGACY NEG"];
+    const legacyInfo = { widgets_values: legacyValues };
+    nodeType.prototype.configure.call(legacyNode, legacyInfo);
+    eq(
+        legacyNode.__hostConfigureReceived,
+        ["", "LEGACY POS", "English", 30, "", false, "LEGACY NEG"],
+        "host receives generated 7-slot shape for legacy input",
+    );
+    check(legacyInfo.widgets_values === legacyValues, "legacy caller info keeps exact original 7-value array reference");
+    eq(legacyInfo.widgets_values, legacyValues, "legacy caller info values remain unchanged");
+
+    const throwingNode = makePromptGuideNode({ generated: true });
+    throwingNode.__throwOnConfigure = true;
+    Object.setPrototypeOf(throwingNode, nodeType.prototype);
+    const throwingValues = ["THROW POS", "Korean", 25, true, "THROW NEG"];
+    const throwingInfo = { widgets_values: throwingValues };
+    let threw = false;
+    try {
+        nodeType.prototype.configure.call(throwingNode, throwingInfo);
+    } catch (error) {
+        threw = error.message === "host configure throw sentinel";
+    }
+    check(threw, "throwing host configure propagates the original error");
+    check(throwingInfo.widgets_values === throwingValues, "throwing caller info keeps exact original array reference");
+    eq(throwingInfo.widgets_values, throwingValues, "throwing caller info values are restored");
+}
+
+function testHostContractWithCurrentShapeAndNoGeneratedWidgets() {
+    const nodeType = { prototype: { configure: hostConfigure } };
+    installPromptGuideAdapter(nodeType);
+    const node = makePromptGuideNode({ generated: false });
+    Object.setPrototypeOf(node, nodeType.prototype);
+    nodeType.prototype.configure.call(node, {
+        widgets_values: ["POS", "English", 30, false, "NEG"],
+    });
+
+    eq(node.__hostConfigureReceived, ["POS", "English", 30, false, "NEG"], "host receives current 5 unchanged");
+    eq(hostSerialize(node).widgets_values, ["POS", "English", 30, false, "NEG"], "no-generated save remains canonical 5");
+}
+
+function testUnknownShapePassesThroughConfigureAndDoesNotRewriteSerialization() {
+    const nodeType = { prototype: { configure: hostConfigure } };
+    installPromptGuideAdapter(nodeType);
+    const node = makePromptGuideNode({ generated: true });
+    Object.setPrototypeOf(node, nodeType.prototype);
+    const unknown = ["POS", "English", 30, false, "NEG", "extra"];
+    nodeType.prototype.configure.call(node, { widgets_values: unknown });
+
+    eq(node.__hostConfigureReceived, unknown, "unknown configure shape is passed through");
+    check(node.__denoLtxPromptGuideConfiguredWidgetValues === undefined, "unknown shape does not create pending migration");
+    eq(
+        hostSerialize(node).widgets_values,
+        ["POS", "English", 30, false, "NEG", "extra", ""],
+        "unknown-configured node preserves host serialization instead of inventing canonical values",
+    );
+
+    const recognized = ["KNOWN POS", "Korean", 31, true, "KNOWN NEG"];
+    nodeType.prototype.configure.call(node, { widgets_values: recognized });
+    eq(
+        hostSerialize(node).widgets_values,
+        recognized,
+        "later recognized configure clears unknown state and re-enables canonical serialization",
+    );
+}
+
+function testDoubleInstallIsNoopForSameInstallKey() {
+    let priorConfigureCalls = 0;
+    let priorSerializeCalls = 0;
+    let applyCalls = 0;
+    let canonicalSerializeCalls = 0;
+    const normalize = createExactWidgetValueShapeMigration({
+        canonicalCount: WIDGET_SPECS.length,
+        legacyGeneratedSlots: GENERATED_SLOTS,
+    });
+    const nodeType = {
+        prototype: {
+            configure() {
+                priorConfigureCalls += 1;
+            },
+            onSerialize(info) {
+                priorSerializeCalls += 1;
+                info.priorSerialize = true;
+            },
+        },
+    };
+    const spec = {
+        nodeName: NODE_NAME,
+        installKey: "prompt-guide-r2-double-install",
+        normalizeSerializedValues: normalize,
+        getConfigureWidgetValues(_node, canonicalValues) {
+            return canonicalValues;
+        },
+        applyCanonicalValues() {
+            applyCalls += 1;
+        },
+        getCanonicalSerializationValues() {
+            canonicalSerializeCalls += 1;
+            return ["SER", "Korean", 24, false, "NEG"];
+        },
+    };
+
+    check(installWorkflowWidgetMigration(nodeType, { name: NODE_NAME }, spec) === true, "first install succeeds");
+    check(installWorkflowWidgetMigration(nodeType, { name: NODE_NAME }, spec) === false, "second install for same key is a noop");
+
+    const node = makePromptGuideNode({ generated: false });
+    Object.setPrototypeOf(node, nodeType.prototype);
+    nodeType.prototype.configure.call(node, { widgets_values: ["POS", "English", 30, true, "NEG"] });
+    const serialized = {};
+    nodeType.prototype.onSerialize.call(node, serialized);
+
+    check(priorConfigureCalls === 1, "prior configure called exactly once after double install");
+    check(priorSerializeCalls === 1, "prior onSerialize called exactly once after double install");
+    check(applyCalls === 1, "applyCanonicalValues called exactly once after double install");
+    check(canonicalSerializeCalls === 1, "getCanonicalSerializationValues called exactly once after double install");
+    eq(serialized.widgets_values, ["SER", "Korean", 24, false, "NEG"], "double install does not duplicate serialization hook");
+    check(Object.keys(nodeType.prototype).every((key) => !key.includes("workflow_widget_migration")), "install marker is non-enumerable");
+}
+
+function testMissingRequiredWidgetLeavesHostSerializationUntouched() {
+    const nodeType = { prototype: { configure: hostConfigure } };
+    installPromptGuideAdapter(nodeType);
+    const node = makePromptGuideNode({ generated: true });
+    node.widgets = node.widgets.filter((widget) => widget.name !== "negative_prompt");
+    Object.setPrototypeOf(node, nodeType.prototype);
+    nodeType.prototype.configure.call(node, {
+        widgets_values: ["POS", "Korean", 24, true, "NEG"],
+    });
+
+    const serialized = hostSerialize(node);
+    check(missingCanonicalWidgetWarnings.has(node), "missing required widget was detected");
+    eq(
+        serialized.widgets_values,
+        ["", "POS", "Korean", 24, "", true],
+        "missing required widget leaves host serialization untouched instead of serializing defaults",
+    );
+}
+
+testShapeClassifier();
+testHostContractWithGeneratedWidgets();
+testConfigureTemporarilyExpandsAndRestoresCallerInfo();
+testHostContractWithCurrentShapeAndNoGeneratedWidgets();
+testUnknownShapePassesThroughConfigureAndDoesNotRewriteSerialization();
+testDoubleInstallIsNoopForSameInstallKey();
+testMissingRequiredWidgetLeavesHostSerializationUntouched();
+console.log("OK ltx_prompt_guide_workflow_migration_harness");

--- a/tests/test_image_resize_node.py
+++ b/tests/test_image_resize_node.py
@@ -1998,7 +1998,10 @@ def test_ltx_model_setup_helper_checks_registered_model_folder_names():
 
     assert result["status"] == "exists"
     assert result["found_by"] == "registered"
-    assert result["relative_path"].replace("\\", "/") == "TextEncoders/flux2-klein-9b-uncensored-q6_k.gguf"
+    assert result["relative_path"].replace("\\", "/") == "text_encoders/flux2-klein-9b-uncensored-q6_k.gguf"
+    assert result["found_path"].endswith("TextEncoders\\flux2-klein-9b-uncensored-q6_k.gguf") or result[
+        "found_path"
+    ].endswith("TextEncoders/flux2-klein-9b-uncensored-q6_k.gguf")
 
 
 def test_ltx_model_setup_helper_does_not_probe_unregistered_nearby_roots():
@@ -2064,7 +2067,7 @@ def test_ltx_model_setup_helper_includes_registered_yaml_model_root():
     assert payload["selection_mode"] == "auto"
 
 
-def test_ltx_model_setup_helper_autoselects_registered_root_with_ready_files():
+def test_ltx_model_setup_helper_separates_root_local_counts_from_global_availability():
     load_package()
     module = sys.modules["comfyui_deno_custom_nodes.deno_ltx_model_downloader"]
     folder_paths = sys.modules["folder_paths"]
@@ -2075,15 +2078,24 @@ def test_ltx_model_setup_helper_autoselects_registered_root_with_ready_files():
         "title": "Tiny Pack",
         "files": [
             {
+                "id": "alpha",
                 "url": "https://example.com/model-a.safetensors",
                 "target_subdir": "diffusion_models",
                 "filename": "model-a.safetensors",
                 "size": 1,
             },
             {
+                "id": "text",
                 "url": "https://example.com/model-b.safetensors",
                 "target_subdir": "text_encoders",
                 "filename": "model-b.safetensors",
+                "size": 1,
+            },
+            {
+                "id": "vae",
+                "url": "https://example.com/model-c.safetensors",
+                "target_subdir": "vae",
+                "filename": "model-c.safetensors",
                 "size": 1,
             },
         ],
@@ -2091,34 +2103,186 @@ def test_ltx_model_setup_helper_autoselects_registered_root_with_ready_files():
 
     with tempfile.TemporaryDirectory() as temp_dir:
         default_root = Path(temp_dir) / "ComfyUI" / "models"
-        registered_root = Path(temp_dir) / "ComfyUI Model" / "models"
+        root_a = Path(temp_dir) / "ComfyUI Model A" / "models"
+        root_b = Path(temp_dir) / "ComfyUI Model B" / "models"
         default_root.mkdir(parents=True)
-        diffusion_dir = registered_root / "diffusion_models"
-        text_dir = registered_root / "text_encoders"
-        diffusion_dir.mkdir(parents=True)
-        text_dir.mkdir()
-        (diffusion_dir / "model-a.safetensors").write_bytes(b"a")
-        (text_dir / "model-b.safetensors").write_bytes(b"b")
+        root_a_diffusion_dir = root_a / "diffusion_models"
+        root_a_text_dir = root_a / "text_encoders"
+        root_a_vae_dir = root_a / "vae"
+        root_b_diffusion_dir = root_b / "diffusion_models"
+        root_b_text_dir = root_b / "text_encoders"
+        root_b_vae_dir = root_b / "vae"
+        for directory in (
+            root_a_diffusion_dir,
+            root_a_text_dir,
+            root_a_vae_dir,
+            root_b_diffusion_dir,
+            root_b_text_dir,
+            root_b_vae_dir,
+        ):
+            directory.mkdir(parents=True)
+        (root_a_diffusion_dir / "model-a.safetensors").write_bytes(b"a")
+        (root_b_diffusion_dir / "model-a.safetensors").write_bytes(b"a")
+        (root_b_text_dir / "model-b.safetensors").write_bytes(b"b")
+        (root_b_vae_dir / "model-c.safetensors").write_bytes(b"c")
 
         folder_paths.models_dir = str(default_root)
         folder_paths.folder_names_and_paths = {
-            "diffusion_models": ([str(diffusion_dir)], set()),
-            "text_encoders": ([str(text_dir)], set()),
+            "diffusion_models": ([str(root_a_diffusion_dir), str(root_b_diffusion_dir)], set()),
+            "text_encoders": ([str(root_a_text_dir), str(root_b_text_dir)], set()),
+            "vae": ([str(root_a_vae_dir), str(root_b_vae_dir)], set()),
         }
         try:
             payload = module._build_payload(None, module._default_presets_state(), package, str(default_root))
-            explicit = module._build_payload(payload["roots"][0]["id"], module._default_presets_state(), package)
+            roots_by_path = {Path(root["path"]): root for root in payload["roots"]}
+            explicit_root_a = module._build_payload(
+                roots_by_path[root_a.resolve()]["id"],
+                module._default_presets_state(),
+                package,
+            )
+            invalid_root = module._build_payload(
+                "root_missing_legacy_id",
+                module._default_presets_state(),
+                package,
+            )
+            reversed_ids = {Path(root["path"]): root["id"] for root in module._collect_model_roots()}
+            folder_paths.folder_names_and_paths = {
+                "vae": ([str(root_b_vae_dir), str(root_a_vae_dir)], set()),
+                "text_encoders": ([str(root_b_text_dir), str(root_a_text_dir)], set()),
+                "diffusion_models": ([str(root_b_diffusion_dir), str(root_a_diffusion_dir)], set()),
+            }
+            reversed_payload = module._build_payload(None, module._default_presets_state(), package, str(default_root))
+            reversed_roots = module._collect_model_roots()
         finally:
             folder_paths.models_dir = original_models_dir
             folder_paths.folder_names_and_paths = original_folder_map
 
-    assert Path(payload["models_root"]) == default_root.resolve()
-    assert payload["existing_count"] == 2
+    roots_by_path = {Path(root["path"]): root for root in payload["roots"]}
+    assert roots_by_path[default_root.resolve()]["existing_count"] == 0
+    assert roots_by_path[root_a.resolve()]["existing_count"] == 1
+    assert roots_by_path[root_b.resolve()]["existing_count"] == 3
+    assert roots_by_path[default_root.resolve()]["local_existing_count"] == 0
+    assert roots_by_path[root_a.resolve()]["local_existing_count"] == 1
+    assert roots_by_path[root_b.resolve()]["local_existing_count"] == 3
+    assert Path(payload["models_root"]) == root_b.resolve()
+    assert payload["selected_root_existing_count"] == 3
+    assert payload["available_anywhere_count"] == 3
+    assert payload["existing_count"] == 3
     assert all(file["status"] == "exists" for file in payload["files"])
-    assert Path(explicit["models_root"]) == default_root.resolve()
-    assert explicit["existing_count"] == 2
-    assert all(file["status"] == "exists" for file in explicit["files"])
-    assert explicit["selection_mode"] == "explicit"
+    assert all(file["local_status"] == "exists" for file in payload["files"])
+
+    assert Path(explicit_root_a["models_root"]) == root_a.resolve()
+    assert explicit_root_a["selection_mode"] == "explicit"
+    assert explicit_root_a["selected_root_existing_count"] == 1
+    assert explicit_root_a["available_anywhere_count"] == 3
+    assert explicit_root_a["existing_count"] == 3
+    alpha = next(file for file in explicit_root_a["files"] if file["id"] == "alpha")
+    text = next(file for file in explicit_root_a["files"] if file["id"] == "text")
+    assert alpha["target_path"].startswith(str(root_a.resolve()))
+    assert text["target_path"].startswith(str(root_a.resolve()))
+    assert alpha["exists_in_selected_root"] is True
+    assert text["exists_in_selected_root"] is False
+    assert text["local_status"] == "missing"
+    assert text["status"] == "exists"
+    assert text["found_root_id"] == roots_by_path[root_b.resolve()]["id"]
+    assert text["found_path"].startswith(str(root_b.resolve()))
+
+    assert Path(invalid_root["models_root"]) == root_b.resolve()
+    assert invalid_root["selection_mode"] == "auto"
+    assert invalid_root["selection_reason"] == "invalid_explicit_root_fallback"
+    assert invalid_root["selected_root_existing_count"] == 3
+
+    reversed_roots_by_path = {Path(root["path"]): root for root in reversed_payload["roots"]}
+    assert Path(reversed_payload["models_root"]) == root_b.resolve()
+    assert reversed_roots_by_path[root_b.resolve()]["id"] == roots_by_path[root_b.resolve()]["id"]
+    assert reversed_ids[root_b.resolve()] == {Path(root["path"]): root["id"] for root in reversed_roots}[
+        root_b.resolve()
+    ]
+
+
+def test_ltx_model_setup_helper_counts_roots_in_single_pass(monkeypatch):
+    load_package()
+    module = sys.modules["comfyui_deno_custom_nodes.deno_ltx_model_downloader"]
+    folder_paths = sys.modules["folder_paths"]
+    original_models_dir = folder_paths.models_dir
+    original_folder_map = folder_paths.folder_names_and_paths
+    original_public_package_files = module._public_package_files
+    calls = []
+    package = {
+        "id": "tiny_pack",
+        "title": "Tiny Pack",
+        "files": [
+            {
+                "id": "alpha",
+                "url": "https://example.com/model-a.safetensors",
+                "target_subdir": "diffusion_models",
+                "filename": "model-a.safetensors",
+                "size": 1,
+            }
+        ],
+    }
+
+    def wrapped_public_package_files(models_root, package_value, roots=None):
+        calls.append(str(Path(models_root).resolve()))
+        return original_public_package_files(models_root, package_value, roots)
+
+    monkeypatch.setattr(module, "_public_package_files", wrapped_public_package_files)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        default_root = Path(temp_dir) / "ComfyUI" / "models"
+        root_a = Path(temp_dir) / "ComfyUI Model A" / "models"
+        root_b = Path(temp_dir) / "ComfyUI Model B" / "models"
+        for root in (default_root, root_a, root_b):
+            (root / "diffusion_models").mkdir(parents=True)
+
+        folder_paths.models_dir = str(default_root)
+        folder_paths.folder_names_and_paths = {
+            "diffusion_models": ([str(root_a / "diffusion_models"), str(root_b / "diffusion_models")], set()),
+        }
+        try:
+            payload = module._build_payload(None, module._default_presets_state(), package, str(default_root))
+        finally:
+            folder_paths.models_dir = original_models_dir
+            folder_paths.folder_names_and_paths = original_folder_map
+
+    call_counts = {path: calls.count(path) for path in set(calls)}
+    selected_path = str(Path(payload["models_root"]).resolve())
+    selected_root = next(root for root in payload["roots"] if Path(root["path"]).resolve() == Path(payload["models_root"]).resolve())
+    assert call_counts[selected_path] == 1
+    assert sorted(call_counts.values()) == [1, 1, 1]
+    assert payload["selected_root_existing_count"] == selected_root["existing_count"]
+    assert payload["available_anywhere_count"] == sum(1 for file in payload["files"] if file["status"] == "exists")
+
+
+def test_ltx_model_setup_helper_reports_partial_file_path():
+    load_package()
+    module = sys.modules["comfyui_deno_custom_nodes.deno_ltx_model_downloader"]
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        models_root = Path(temp_dir) / "models"
+        target_dir = models_root / "diffusion_models"
+        target_dir.mkdir(parents=True)
+        part = target_dir / "tiny-model.safetensors.part"
+        part.write_bytes(b"half")
+        result = module._resolve_target_file(
+            str(models_root),
+            "diffusion_models",
+            "tiny-model.safetensors",
+            8,
+            roots=[{
+                "id": "root_local",
+                "path": str(models_root.resolve()),
+                "canonical_path": str(models_root.resolve()),
+            }],
+        )
+
+    assert result["status"] == "partial"
+    assert result["local_status"] == "partial"
+    assert result["found_by"] == "partial"
+    assert result["found_path"].replace("\\", "/").endswith("diffusion_models/tiny-model.safetensors.part")
+    assert result["local_found_path"].replace("\\", "/").endswith("diffusion_models/tiny-model.safetensors.part")
+    assert result["found_root_id"] == "root_local"
+    assert result["local_found_root_id"] == "root_local"
 
 
 def test_ltx_model_setup_helper_uses_path_stable_root_ids_and_invalid_fallback():
@@ -2194,7 +2358,10 @@ def test_ltx_model_setup_helper_deep_scan_is_explicit_opt_in():
     assert default_result["status"] == "missing"
     assert scanned["status"] == "exists"
     assert scanned["found_by"] == "subfolder"
-    assert scanned["relative_path"].replace("\\", "/") == "diffusion_models/Flux/flux2-klein-9b-kv-fp8.safetensors"
+    assert scanned["relative_path"].replace("\\", "/") == "diffusion_models/flux2-klein-9b-kv-fp8.safetensors"
+    assert scanned["found_path"].replace("\\", "/").endswith(
+        "diffusion_models/Flux/flux2-klein-9b-kv-fp8.safetensors"
+    )
 
 
 def test_ltx_model_setup_helper_has_no_backend_download_code():
@@ -2211,21 +2378,45 @@ def test_ltx_model_setup_helper_has_no_backend_download_code():
 
 def test_ltx_model_setup_helper_frontend_keeps_auto_root_selection_available():
     script = (REPO_ROOT / "web" / "js" / "deno_ltx_model_downloader.js").read_text(encoding="utf-8")
+    save_editor_preset = script.split("function saveEditorPreset", 1)[1].split("function markWorkflowDirty", 1)[0]
 
-    assert "r2026.06.23-root-intent-c" in script
+    assert "r2026.06.25-phase2b-foundation-a" in script
     assert "rootMode" in script
     assert "explicitRootId" in script
     assert "effectiveRootId" in script
-    assert "refreshSequence" in script
+    assert "createLatestRequest" in script
+    assert "deno_frontend_core/storage.js" in script
+    assert "deno_frontend_core/lifecycle.js" in script
+    assert "deno_frontend_core/async_latest.js" in script
+    assert "upsertLibraryItem" in script
+    assert "writePresetLibraryItem" in script
+    assert "state.libraryPresetsState = writePresetLibraryItem(normalized);" in script
+    assert "function writePresetLibraryItem(packageValue)" in script
+    assert "const latestLibrary = readPresetLibraryState();" in script
+    assert "const latestView = mergePresetLibraryState(state.workflowPresetsState, latestLibrary);" in script
+    assert "state.libraryPresetsState = latestLibrary;" in script
+    assert "latestView.presets" in script
     assert 'return state.rootMode === "explicit" ? state.explicitRootId : "";' in script
+    assert "const localStatus = file.local_status || file.status;" in script
+    assert "payload.selected_root_existing_count" in script
     assert 'refreshButton.addEventListener("click", () => refreshInfo())' in script
     assert "selectRootByUser(rootInfo.id)" in script
     assert "resetRootToAuto();" in script
+    assert 'root.dataset.denoLtxDownloaderPanel = "true";' in script
+    assert 'getNodeLifecycleScope(this, "ltx-model-downloader")' in script
+    assert 'scope.addEventListener(document, "click", () =>' in script
+    assert script.count('scope.addEventListener(document, "click"') == 1
+    assert "closeModelPathMenus(root);" in script
     assert 'refreshButton.addEventListener("click", () => refreshInfo(state.selectedRootId))' not in script
+    assert "writePresetLibraryState(state.workflowPresetsState" not in script
+    assert "writePresetLibraryItem(state.libraryPresetsState" not in script
+    assert "state.viewPresetsState.presets" not in save_editor_preset
+    assert "scope?.addEventListener?.(document" not in script
     assert "userSelectedRootId" not in script
     assert "selectedRootId" not in script
-    assert "const sequence = ++state.refreshSequence;" in script
-    assert "sequence !== state.refreshSequence" in script
+    assert "refreshSequence" not in script
+    assert "signal," in script
+    assert 'payload.selection_reason === "invalid_explicit_root_fallback"' in script
 
 
 def test_ltx_multi_lora_loader_declares_compact_av_controls():

--- a/tests/test_public_workflow_migration.py
+++ b/tests/test_public_workflow_migration.py
@@ -156,19 +156,37 @@ def test_fixtures_present():
 # --------------------------------------------------------------------------
 def test_prompt_guide_js_has_legacy_configure_migration():
     src = JS_PATH.read_text(encoding="utf-8")
+    widget_state_src = (REPO_ROOT / "web" / "js" / "deno_frontend_core" / "widget_state.js").read_text(encoding="utf-8")
+    workflow_migration_src = (REPO_ROOT / "web" / "js" / "deno_frontend_core" / "workflow_migration.js").read_text(encoding="utf-8")
 
+    assert 'from "./deno_frontend_core/widget_state.js"' in src
+    assert 'from "./deno_frontend_core/workflow_migration.js"' in src
+    assert "createExactWidgetValueShapeMigration" in src
+    assert "installWorkflowWidgetMigration(nodeType, nodeData" in src
     assert "function getNormalizedLtxPromptGuideSerializedValues" in src
-    assert "function normalizeLtxPromptGuideLegacyWidgetValues" in src
     assert "function getLtxPromptGuideConfigureWidgetValues" in src
     assert "function applyLtxPromptGuideSerializedValuesToWidgets" in src
-    assert "ltx-prompt-guide-save-reload-v1" in src
+    assert "ltx-prompt-guide-save-reload-v2" in src
     # Normalization must run inside configure(), before LiteGraph restores
-    # widget values (not only in the post-restore onConfigure callback).
-    assert "nodeType.prototype.configure = function" in src
-    assert "normalizeLtxPromptGuideLegacyWidgetValues(info)" in src
-    assert "this.__denoLtxPromptGuideConfiguredWidgetValues = [...normalized]" in src
-    assert "info.widgets_values = getLtxPromptGuideConfigureWidgetValues(this, normalized)" in src
+    # widget values, and canonical compaction must run in onSerialize.
+    assert "pendingValuesKey: \"__denoLtxPromptGuideConfiguredWidgetValues\"" in src
+    assert "normalizeSerializedValues: getNormalizedLtxPromptGuideSerializedValues" in src
+    assert "getConfigureWidgetValues: getLtxPromptGuideConfigureWidgetValues" in src
+    assert "getCanonicalSerializationValues: getLtxPromptGuideSerializedValuesFromWidgets" in src
     assert "delete this.__denoLtxPromptGuideConfiguredWidgetValues" in src
+    assert "export function createExactWidgetValueShapeMigration" in workflow_migration_src
+    assert "export function installWorkflowWidgetMigration" in workflow_migration_src
+    assert 'Symbol.for("deno.frontend.workflow_widget_migration.installs")' in workflow_migration_src
+    assert "unknownConfiguredNodes = new WeakSet()" in workflow_migration_src
+    assert "hasOwnWidgetsValues" in workflow_migration_src
+    assert "originalWidgetsValues" in workflow_migration_src
+    assert "finally" in workflow_migration_src
+    assert "unknownConfiguredNodes.has(this)" in workflow_migration_src
+    assert "serialized.widgets_values = cloneValues(canonicalValues)" in workflow_migration_src
+    assert "export function findWidget" in widget_state_src
+    assert "export function canonicalOrderedSerializationValues" in widget_state_src
+    assert "missingCanonicalWidgetWarnings" in src
+    assert "required widgets are missing" in src
     # Display widgets must stay non-serializing, and the existing post-restore
     # setup path must remain intact.
     assert "serialize: false" in src
@@ -251,130 +269,20 @@ def _extract_js_declaration(src, name):
     return src[start:end + 1]
 
 
-def test_prompt_guide_normalizer_behaviour_in_node(tmp_path):
+def test_prompt_guide_frontend_foundation_host_harness_passes():
     node_bin = shutil.which("node")
     if not node_bin:
         pytest.skip("node runtime not available")
 
-    src = JS_PATH.read_text(encoding="utf-8")
-    const_line = _extract_js_const_line(src, "LTX_PROMPT_GUIDE_SERIALIZED_WIDGET_COUNT")
-    fn = _extract_js_function(src, "getNormalizedLtxPromptGuideSerializedValues")
-
-    harness = const_line + "\n" + fn + r"""
-function eq(a, b) { return JSON.stringify(a) === JSON.stringify(b); }
-function check(cond, msg) { if (!cond) { console.error("FAIL: " + msg); process.exit(1); } }
-
-// legacy v0.3.8 7-value -> 5 real widget values (drop index 0 and 4)
-check(eq(
-    getNormalizedLtxPromptGuideSerializedValues(["", "POS", "Korean", 24, "", true, "NEG"]),
-    ["POS", "Korean", 24, true, "NEG"]
-), "legacy 7 -> 5");
-
-// null display slots are treated like empty
-check(eq(
-    getNormalizedLtxPromptGuideSerializedValues([null, "P", "English", 30, null, false, "N"]),
-    ["P", "English", 30, false, "N"]
-), "legacy null slots");
-
-// current 5-value layout is returned unchanged
-check(eq(
-    getNormalizedLtxPromptGuideSerializedValues(["POS", "Korean", 24, true, "NEG"]),
-    ["POS", "Korean", 24, true, "NEG"]
-), "current passthrough");
-
-// a *current* 5-value array with an empty positive prompt must NOT be reshuffled
-check(eq(
-    getNormalizedLtxPromptGuideSerializedValues(["", "Auto", 25, false, ""]),
-    ["", "Auto", 25, false, ""]
-), "empty positive prompt preserved");
-
-// non-arrays -> null (leave restore untouched)
-check(getNormalizedLtxPromptGuideSerializedValues(null) === null, "null -> null");
-check(getNormalizedLtxPromptGuideSerializedValues(undefined) === null, "undefined -> null");
-check(getNormalizedLtxPromptGuideSerializedValues("nope") === null, "string -> null");
-
-console.log("OK");
-"""
-
-    harness_path = tmp_path / "ltx_prompt_guide_migration.mjs"
-    harness_path.write_text(harness, encoding="utf-8")
-
+    harness_path = REPO_ROOT / "tests" / "js" / "ltx_prompt_guide_workflow_migration_harness.mjs"
     result = subprocess.run(
         [node_bin, str(harness_path)],
         capture_output=True,
         text=True,
+        cwd=str(REPO_ROOT),
     )
     assert result.returncode == 0, f"node harness failed:\n{result.stdout}\n{result.stderr}"
-    assert "OK" in result.stdout
-
-
-def test_prompt_guide_configure_expands_saved_values_around_generated_widgets(tmp_path):
-    node_bin = shutil.which("node")
-    if not node_bin:
-        pytest.skip("node runtime not available")
-
-    src = JS_PATH.read_text(encoding="utf-8")
-    snippets = [
-        _extract_js_const_line(src, "GENERATED_PREFIX"),
-        _extract_js_const_line(src, "LTX_PROMPT_GUIDE_SERIALIZED_WIDGET_COUNT"),
-        _extract_js_function(src, "getNormalizedLtxPromptGuideSerializedValues"),
-        _extract_js_function(src, "hasGeneratedPromptGuideWidgets"),
-        _extract_js_function(src, "getLtxPromptGuideConfigureWidgetValues"),
-        _extract_js_function(src, "getWidget"),
-        _extract_js_function(src, "applyLtxPromptGuideSerializedValuesToWidgets"),
-    ]
-
-    harness = "\n".join(snippets) + r"""
-function eq(a, b) { return JSON.stringify(a) === JSON.stringify(b); }
-function check(cond, msg) { if (!cond) { console.error("FAIL: " + msg); process.exit(1); } }
-
-const core = ["POSITIVE SAVE", "Korean", 24, true, "NEGATIVE SAVE"];
-const legacy = ["", "POSITIVE SAVE", "Korean", 24, "", true, "NEGATIVE SAVE"];
-const nodeWithGenerated = {
-    widgets: [
-        { name: GENERATED_PREFIX + "dialogue_summary", value: "" },
-        { name: "positive_prompt", value: "" },
-        { name: "language", value: "Auto" },
-        { name: "frame_rate", value: 25 },
-        { name: GENERATED_PREFIX + "negative_toggle", value: "" },
-        { name: "show_negative_prompt", value: false },
-        { name: "negative_prompt", value: "" },
-    ],
-};
-const nodeWithoutGenerated = {
-    widgets: [
-        { name: "positive_prompt", value: "" },
-        { name: "language", value: "Auto" },
-        { name: "frame_rate", value: 25 },
-        { name: "show_negative_prompt", value: false },
-        { name: "negative_prompt", value: "" },
-    ],
-};
-
-check(eq(getNormalizedLtxPromptGuideSerializedValues(legacy), core), "legacy normalizes to core");
-check(eq(getLtxPromptGuideConfigureWidgetValues(nodeWithGenerated, core), legacy), "core expands around generated widgets");
-check(eq(getLtxPromptGuideConfigureWidgetValues(nodeWithoutGenerated, core), core), "core stays compact without generated widgets");
-
-applyLtxPromptGuideSerializedValuesToWidgets(nodeWithGenerated, core);
-check(nodeWithGenerated.widgets[1].value === "POSITIVE SAVE", "positive applied by name");
-check(nodeWithGenerated.widgets[2].value === "Korean", "language applied by name");
-check(nodeWithGenerated.widgets[3].value === 24, "frame rate applied by name");
-check(nodeWithGenerated.widgets[5].value === true, "show negative applied by name");
-check(nodeWithGenerated.widgets[6].value === "NEGATIVE SAVE", "negative applied by name");
-
-console.log("OK");
-"""
-
-    harness_path = tmp_path / "ltx_prompt_guide_configure_expand.mjs"
-    harness_path.write_text(harness, encoding="utf-8")
-
-    result = subprocess.run(
-        [node_bin, str(harness_path)],
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode == 0, f"node harness failed:\n{result.stdout}\n{result.stderr}"
-    assert "OK" in result.stdout
+    assert "OK ltx_prompt_guide_workflow_migration_harness" in result.stdout
 
 
 def test_ltx_model_loader_normalizer_keeps_current_gguf_extra_widget_layout(tmp_path):

--- a/tools/codex_gate.py
+++ b/tools/codex_gate.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    from tools import codex_task
+except ModuleNotFoundError:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from tools import codex_task
+
+
+ROOT = Path(os.environ.get("CODEX_HARNESS_REPO_ROOT", Path(__file__).resolve().parents[1]))
+STATE_DIR = Path(os.environ.get("CODEX_HARNESS_STATE_DIR", ROOT / ".codex" / "state"))
+RESULT_JSON = STATE_DIR / "GATE_RESULT.json"
+RESULT_MD = STATE_DIR / "GATE_RESULT.md"
+
+
+HARNESS_PATTERNS = [
+    "AGENTS.md",
+    ".agents/skills/**",
+    ".codex/hooks.json",
+    ".codex/hooks/**",
+    "tools/codex_*.py",
+    "tools/codex_*.ps1",
+    "docs/codex/**",
+    "docs/archive/**",
+    ".github/pull_request_template.md",
+    ".github/workflows/*codex*gate*.yml",
+    ".gitignore",
+    "tests/codex_harness/**",
+]
+
+PRODUCT_PATTERNS = [
+    "deno_*.py",
+    "web/js/deno_*.js",
+    "web/js/assets/**",
+    "node_list.json",
+    "pyproject.toml",
+    "CHANGELOG.md",
+    "README.md",
+    "docs/README.*.md",
+    "docs/images/**",
+]
+
+
+def norm(path: str) -> str:
+    return path.replace("\\", "/").strip()
+
+
+def matches(path: str, patterns: list[str]) -> bool:
+    n = norm(path)
+    return any(fnmatch.fnmatch(n, pattern) for pattern in patterns)
+
+
+def run(cmd: list[str], cwd: Path = ROOT) -> tuple[int, str]:
+    proc = subprocess.run(
+        cmd,
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    return proc.returncode, proc.stdout
+
+
+def changed_files() -> list[str]:
+    env_files = os.environ.get("CODEX_HARNESS_CHANGED_FILES")
+    if env_files is not None:
+        return [norm(item) for item in env_files.replace(";", "\n").splitlines() if item.strip()]
+    return codex_task.changed_files()
+
+
+def load_task() -> dict[str, Any]:
+    return codex_task.load_task() or {}
+
+
+def load_evidence() -> dict[str, Any]:
+    return codex_task.read_json(codex_task.TEST_EVIDENCE, {"tests": {}})
+
+
+def select_required_gates(files: list[str], tags: list[str], risk: str, mode: str = "local") -> list[str]:
+    selected: set[str] = set()
+    normalized = [norm(path) for path in files]
+
+    if not normalized or any(matches(path, HARNESS_PATTERNS) for path in normalized):
+        selected.add("instruction_budget")
+        selected.add("handoff_budget")
+
+    if any(path.endswith(".py") for path in normalized):
+        selected.add("py_compile")
+
+    if any(matches(path, ["tools/codex_*.py", ".codex/hooks/*.py", "tests/codex_harness/**"]) for path in normalized):
+        selected.add("harness_pytest")
+
+    if any(matches(path, ["web/js/*.js", "tests/js/*.mjs"]) for path in normalized):
+        selected.add("node_check")
+
+    if "saved_workflow" in tags:
+        selected.add("workflow_migration_fixture")
+    if "storage" in tags:
+        selected.add("storage_precedence")
+    if "async" in tags:
+        selected.add("async_latest")
+    if "dynamic_slots" in tags:
+        selected.add("dynamic_slots_real_links")
+    if "frontend" in tags or "runtime_sensitive" in tags:
+        selected.add("runtime_identity")
+    if risk == "RED" or "red_architecture" in tags:
+        selected.add("architecture_decision")
+    if mode == "release":
+        selected.add("release_unverified_block")
+
+    return sorted(selected)
+
+
+def instruction_budget_check() -> tuple[str, str]:
+    root_agents = ROOT / "AGENTS.md"
+    skill = ROOT / ".agents" / "skills" / "deno-comfyui-node" / "SKILL.md"
+    files = [path for path in [root_agents, skill] if path.exists()]
+    root_bytes = root_agents.stat().st_size if root_agents.exists() else 0
+    combined = sum(path.stat().st_size for path in files)
+    if root_bytes > 8192:
+        return "FAIL", f"AGENTS.md is {root_bytes} bytes, over 8192."
+    if combined > 16384:
+        return "FAIL", f"Autoload docs are {combined} bytes, over 16384."
+    return "PASS", f"AGENTS.md={root_bytes} bytes; autoload={combined} bytes."
+
+
+def handoff_budget_check() -> tuple[str, str]:
+    text = codex_task.generate_handoff()
+    lines = text.splitlines()
+    if len(lines) > 150:
+        return "FAIL", f"SESSION_HANDOFF.md has {len(lines)} lines, over 150."
+    return "PASS", f"SESSION_HANDOFF.md has {len(lines)} lines."
+
+
+def py_compile_check(files: list[str]) -> tuple[str, str]:
+    py_files = [path for path in files if path.endswith(".py") and (ROOT / path).exists()]
+    for required in ["tools/codex_task.py", "tools/codex_gate.py"]:
+        if (ROOT / required).exists() and required not in py_files:
+            py_files.append(required)
+    hook_dir = ROOT / ".codex" / "hooks"
+    if hook_dir.exists():
+        for path in hook_dir.glob("*.py"):
+            rel = norm(str(path.relative_to(ROOT)))
+            if rel not in py_files:
+                py_files.append(rel)
+    if not py_files:
+        return "PASS", "No Python files to compile."
+    code, output = run([sys.executable, "-m", "py_compile", *py_files])
+    return ("PASS" if code == 0 else "FAIL", output.strip() or f"Compiled {len(py_files)} Python files.")
+
+
+def harness_pytest_check() -> tuple[str, str]:
+    test_dir = ROOT / "tests" / "codex_harness"
+    if not test_dir.exists():
+        return "FAIL", "tests/codex_harness is missing."
+    code, output = run([sys.executable, "-m", "pytest", "tests/codex_harness", "-q"])
+    return ("PASS" if code == 0 else "FAIL", output.strip())
+
+
+def node_check(files: list[str]) -> tuple[str, str]:
+    js_files = [path for path in files if path.endswith((".js", ".mjs")) and (ROOT / path).exists()]
+    if not js_files:
+        return "PASS", "No JS files to check."
+    failures = []
+    for path in js_files:
+        code, output = run(["node", "--check", path])
+        if code != 0:
+            failures.append(f"{path}: {output.strip()}")
+    return ("FAIL", "\n".join(failures)) if failures else ("PASS", f"Checked {len(js_files)} JS files.")
+
+
+def evidence_gate(gate: str, evidence: dict[str, Any]) -> tuple[str, str]:
+    tests = evidence.get("tests", {})
+    if gate in tests:
+        status = str(tests[gate].get("status", "")).upper()
+        if status in {"PASS", "VERIFIED"}:
+            return "PASS", tests[gate].get("evidence", "recorded")
+        if status in {"EXECUTED", "SCENARIO_EXECUTED"}:
+            return "UNVERIFIED", "Scenario executed, but contract pass was not recorded."
+        return "FAIL", tests[gate].get("evidence", "recorded failure")
+    return "UNVERIFIED", "No evidence recorded."
+
+
+def architecture_decision_check() -> tuple[str, str]:
+    path = STATE_DIR / "ARCHITECTURE_DECISION.md"
+    if path.exists() and path.read_text(encoding="utf-8").strip():
+        return "PASS", "Architecture decision exists."
+    return "FAIL", ".codex/state/ARCHITECTURE_DECISION.md is required for RED risk."
+
+
+def product_scope_check(files: list[str], task: dict[str, Any]) -> tuple[str, list[str]]:
+    contract = task.get("contract", {})
+    allowed = contract.get("allowed_implementation_scope", [])
+    tags = set(contract.get("capability_tags", []))
+    if "harness" in tags:
+        offenders = [path for path in files if matches(path, PRODUCT_PATTERNS) and not matches(path, HARNESS_PATTERNS)]
+        return ("FAIL" if offenders else "PASS", offenders)
+
+    if allowed and allowed != ["task-specific product files after contract review"]:
+        offenders = [path for path in files if not matches(path, allowed)]
+        return ("FAIL" if offenders else "PASS", offenders)
+    return "PASS", []
+
+
+def evaluate(mode: str = "local", run_commands: bool = True) -> dict[str, Any]:
+    files = changed_files()
+    task = load_task()
+    contract = task.get("contract", {})
+    tags = contract.get("capability_tags", [])
+    risk = contract.get("risk_level", "GREEN")
+    required = select_required_gates(files, tags, risk, mode)
+    evidence = load_evidence()
+
+    checks: dict[str, dict[str, str]] = {}
+    scope_status, offenders = product_scope_check(files, task)
+    if scope_status != "PASS":
+        checks["product_scope"] = {
+            "status": "FAIL",
+            "detail": "Unrequested product files changed: " + ", ".join(offenders),
+        }
+
+    for gate in required:
+        if not run_commands:
+            checks[gate] = {"status": "PENDING", "detail": "dry run"}
+            continue
+        if gate == "instruction_budget":
+            status, detail = instruction_budget_check()
+        elif gate == "handoff_budget":
+            status, detail = handoff_budget_check()
+        elif gate == "py_compile":
+            status, detail = py_compile_check(files)
+        elif gate == "harness_pytest":
+            status, detail = harness_pytest_check()
+        elif gate == "node_check":
+            status, detail = node_check(files)
+        elif gate == "architecture_decision":
+            status, detail = architecture_decision_check()
+        else:
+            status, detail = evidence_gate(gate, evidence)
+        checks[gate] = {"status": status, "detail": detail}
+
+    statuses = [item["status"] for item in checks.values()]
+    missing = [name for name, item in checks.items() if item["status"] in {"UNVERIFIED", "PENDING"}]
+    failed = [name for name, item in checks.items() if item["status"] == "FAIL"]
+    evidence_status = "FAIL" if failed else ("UNVERIFIED" if missing else "PASS")
+    contract_status = "FAIL" if failed else ("UNVERIFIED" if missing else "PASS")
+
+    result = {
+        "mode": mode,
+        "branch": codex_task.current_branch(),
+        "head": codex_task.current_head(),
+        "changed_files": files,
+        "required_gates": required,
+        "checks": checks,
+        "evidence_status": evidence_status,
+        "contract_status": contract_status,
+        "missing": missing,
+        "failed": failed,
+    }
+    write_result(result)
+    return result
+
+
+def write_result(result: dict[str, Any]) -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    RESULT_JSON.write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    lines = [
+        "# Codex Gate Result",
+        "",
+        f"- Mode: `{result['mode']}`",
+        f"- Evidence status: `{result['evidence_status']}`",
+        f"- Contract status: `{result['contract_status']}`",
+        f"- Branch: `{result['branch']}`",
+        f"- HEAD: `{result['head']}`",
+        "",
+        "## Checks",
+        "",
+    ]
+    for name, item in result["checks"].items():
+        detail = item.get("detail", "").replace("\n", " ")[:500]
+        lines.append(f"- `{name}`: `{item.get('status')}` - {detail}")
+    RESULT_MD.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the deterministic Codex gate.")
+    parser.add_argument("--mode", choices=["local", "stop", "ci", "release"], default="local")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    result = evaluate(args.mode, run_commands=not args.dry_run)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0 if result["evidence_status"] == "PASS" and result["contract_status"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/codex_task.py
+++ b/tools/codex_task.py
@@ -1,0 +1,573 @@
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(os.environ.get("CODEX_HARNESS_REPO_ROOT", Path(__file__).resolve().parents[1]))
+STATE_DIR = Path(os.environ.get("CODEX_HARNESS_STATE_DIR", ROOT / ".codex" / "state"))
+
+ACTIVE_JSON = STATE_DIR / "ACTIVE_TASK.json"
+ACTIVE_MD = STATE_DIR / "ACTIVE_TASK.md"
+CHECKPOINT_MD = STATE_DIR / "CHECKPOINT.md"
+FAILURE_LEDGER = STATE_DIR / "FAILURE_LEDGER.json"
+ESCALATION_MD = STATE_DIR / "ESCALATION.md"
+TEST_EVIDENCE = STATE_DIR / "TEST_EVIDENCE.json"
+
+
+K_SAVE = "\uc800\uc7a5"
+K_OFFICIAL = "\uacf5\uc2dd"
+K_CONTINUE = "\uacc4\uc18d"
+K_NODE = "\ub178\ub4dc"
+
+
+def utc_now() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).replace(microsecond=0).isoformat()
+
+
+def ensure_state_dir() -> None:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def read_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, data: Any) -> None:
+    ensure_state_dir()
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def run_git(args: list[str], default: str = "") -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except OSError:
+        return default
+    return result.stdout.strip() if result.returncode == 0 else default
+
+
+def current_branch() -> str:
+    return run_git(["branch", "--show-current"], "unknown")
+
+
+def current_head() -> str:
+    return run_git(["rev-parse", "HEAD"], "unknown")
+
+
+def changed_files() -> list[str]:
+    env_files = os.environ.get("CODEX_HARNESS_CHANGED_FILES")
+    if env_files is not None:
+        return [item.strip().replace("\\", "/") for item in env_files.replace(";", "\n").splitlines() if item.strip()]
+
+    files: set[str] = set()
+    for line in run_git(["status", "--porcelain"]).splitlines():
+        if not line:
+            continue
+        if line.startswith("?? "):
+            path = line[3:].strip()
+        elif len(line) > 2 and line[2] == " ":
+            path = line[3:].strip()
+        else:
+            path = line[2:].strip()
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        files.add(path.replace("\\", "/"))
+    return sorted(files)
+
+
+def task_id_from_prompt(prompt: str) -> str:
+    seed = f"{utc_now()}:{prompt}".encode("utf-8")
+    return hashlib.sha1(seed).hexdigest()[:12]
+
+
+def risk_rank(risk: str) -> int:
+    return {"GREEN": 1, "YELLOW": 2, "RED": 3}.get(risk, 1)
+
+
+def higher_risk(a: str, b: str) -> str:
+    return a if risk_rank(a) >= risk_rank(b) else b
+
+
+def infer_contract(prompt: str, existing: dict[str, Any] | None = None) -> dict[str, Any]:
+    text = prompt.casefold()
+    tags: set[str] = set(existing.get("capability_tags", [])) if existing else set()
+    non_goals: list[str] = list(existing.get("inferred_non_goals", [])) if existing else []
+    assumptions: list[str] = list(existing.get("assumptions", [])) if existing else []
+    affected = existing.get("affected_product_surface", "unknown") if existing else "unknown"
+    risk = existing.get("risk_level", "GREEN") if existing else "GREEN"
+
+    if any(token in text for token in ["codex", "harness", "autopilot", "hook", "gate", ".codex"]):
+        tags.add("harness")
+        affected = "codex operating harness"
+        assumptions.append("This task changes operating surfaces, not production node behavior.")
+
+    if any(token in text for token in ["save", "saved", "workflow", K_SAVE]):
+        tags.add("saved_workflow")
+        risk = higher_risk(risk, "YELLOW")
+        affected = affected if affected != "unknown" else "saved workflow behavior"
+
+    frontend_tokens = ["frontend", " dom ", " button ", " panel "]
+    if any(token in text for token in frontend_tokens) or (K_NODE in text and "harness" not in tags):
+        tags.add("frontend")
+        risk = higher_risk(risk, "YELLOW")
+
+    if any(token in text for token in ["async", "fetch", "request", "stale"]):
+        tags.add("async")
+        risk = higher_risk(risk, "YELLOW")
+
+    if any(token in text for token in ["localstorage", "storage", "preset"]):
+        tags.add("storage")
+        risk = higher_risk(risk, "YELLOW")
+
+    red_tokens = [
+        "schema",
+        "widget order",
+        "target_slot",
+        "node.inputs",
+        "node.widgets",
+        "dynamic slot",
+        "migration",
+        "delete",
+        "remove data",
+    ]
+    if any(token in text for token in red_tokens):
+        risk = "RED"
+        tags.add("red_architecture")
+
+    if "official comfyui" in text or K_OFFICIAL in text:
+        assumptions.append("Official ComfyUI behavior is the baseline.")
+        if "third-party compatibility is not a goal unless explicitly requested." not in non_goals:
+            non_goals.append("Third-party compatibility is not a goal unless explicitly requested.")
+
+    if K_CONTINUE in text or "continue" in text:
+        assumptions.append("Continue the existing active task unless it is closed.")
+
+    if not tags:
+        tags.add("general")
+
+    if "harness" in tags:
+        allowed_scope = [
+            "AGENTS.md",
+            ".agents/skills/**",
+            ".codex/hooks.json",
+            ".codex/hooks/**",
+            "tools/codex_*.py",
+            "tools/codex_*.ps1",
+            "docs/codex/**",
+            "docs/archive/**",
+            ".github/pull_request_template.md",
+            ".github/workflows/*codex*gate*.yml",
+            ".gitignore",
+            "tests/codex_harness/**",
+        ]
+        verification = ["instruction_budget", "harness_pytest", "codex_gate"]
+    else:
+        allowed_scope = ["task-specific product files after contract review"]
+        verification = ["codex_gate"]
+
+    acceptance = []
+    if "saved_workflow" in tags:
+        acceptance.append(
+            {
+                "id": "saved-workflow-visible-state",
+                "description": "Saved raw values and visible restored values match after reload and re-save.",
+            }
+        )
+    if "harness" in tags:
+        acceptance.extend(
+            [
+                {"id": "natural-prompt-contract", "description": "Natural prompts update one internal task contract."},
+                {"id": "deterministic-gate", "description": "Gate selects checks and separates evidence from contract status."},
+                {"id": "two-strike-escalation", "description": "Two failed implementation attempts create escalation."},
+            ]
+        )
+    if not acceptance:
+        acceptance.append({"id": "requested-behavior", "description": "Requested user-visible behavior works without scope creep."})
+
+    return {
+        "goal": prompt.strip()[:240] or "Continue the active task.",
+        "user_visible_behavior": existing.get("user_visible_behavior", "User sees the requested behavior without extra required process.") if existing else "User sees the requested behavior without extra required process.",
+        "inferred_non_goals": sorted(set(non_goals)),
+        "assumptions": sorted(set(assumptions)),
+        "affected_product_surface": affected,
+        "canonical_state_owners": existing.get("canonical_state_owners", {}) if existing else {},
+        "risk_level": risk,
+        "capability_tags": sorted(tags),
+        "official_runtime_baseline": "Official ComfyUI contract and exact installed runtime when behavior is claimed.",
+        "saved_workflow_impact": "preserve and verify" if "saved_workflow" in tags else "none expected",
+        "acceptance_tests": acceptance,
+        "allowed_implementation_scope": allowed_scope,
+        "verification_plan": verification,
+        "release_status": existing.get("release_status", "local only") if existing else "local only",
+    }
+
+
+def render_task_md(task: dict[str, Any]) -> str:
+    contract = task.get("contract", {})
+    lines = [
+        "# Active Codex Task",
+        "",
+        f"- Task ID: `{task.get('task_id', 'unknown')}`",
+        f"- Status: `{task.get('status', 'active')}`",
+        f"- Branch: `{task.get('branch', current_branch())}`",
+        f"- HEAD: `{task.get('head', current_head())}`",
+        f"- Base: `{task.get('base_commit', 'unknown')}`",
+        f"- Latest intent: {task.get('latest_intent', '')}",
+        "",
+        "## Contract",
+        "",
+        f"- Goal: {contract.get('goal', '')}",
+        f"- Risk: `{contract.get('risk_level', 'GREEN')}`",
+        f"- Tags: `{', '.join(contract.get('capability_tags', []))}`",
+        f"- Surface: {contract.get('affected_product_surface', '')}",
+        f"- Saved workflow impact: {contract.get('saved_workflow_impact', '')}",
+        "",
+        "## Acceptance Tests",
+    ]
+    for item in contract.get("acceptance_tests", []):
+        lines.append(f"- `{item.get('id')}`: {item.get('description')}")
+    lines.extend(["", "## Next Action", "", task.get("next_action", "Run the deterministic gate before finalizing.")])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def save_task(task: dict[str, Any]) -> None:
+    write_json(ACTIVE_JSON, task)
+    ensure_state_dir()
+    ACTIVE_MD.write_text(render_task_md(task), encoding="utf-8")
+
+
+def load_task() -> dict[str, Any] | None:
+    return read_json(ACTIVE_JSON, None)
+
+
+def start_task(prompt: str, base: str | None = None, branch: str | None = None, worktree: str | None = None) -> dict[str, Any]:
+    task = {
+        "task_id": task_id_from_prompt(prompt),
+        "status": "active",
+        "created_at": utc_now(),
+        "updated_at": utc_now(),
+        "branch": branch or current_branch(),
+        "head": current_head(),
+        "base_commit": base or current_head(),
+        "worktree": worktree or str(ROOT),
+        "latest_intent": prompt,
+        "contract": infer_contract(prompt),
+        "journal": [{"at": utc_now(), "prompt": prompt}],
+        "decisions": [],
+        "changed_files": changed_files(),
+        "tests": [],
+        "blockers": [],
+        "next_action": "Implement within allowed scope, then run tools/codex_gate.py.",
+    }
+    save_task(task)
+    return task
+
+
+def update_task(prompt: str) -> dict[str, Any]:
+    existing = load_task()
+    if not existing or existing.get("status") == "closed":
+        return start_task(prompt)
+
+    existing["updated_at"] = utc_now()
+    existing["latest_intent"] = prompt
+    existing["head"] = current_head()
+    existing["branch"] = current_branch()
+    existing["changed_files"] = changed_files()
+    existing.setdefault("journal", []).append({"at": utc_now(), "prompt": prompt})
+    existing["contract"] = infer_contract(prompt, existing.get("contract", {}))
+    existing["next_action"] = "Continue from the updated contract and run the deterministic gate before finalizing."
+    save_task(existing)
+    return existing
+
+
+def record_decision(text: str, status: str = "accepted") -> dict[str, Any]:
+    task = load_task() or start_task("Record decision")
+    task.setdefault("decisions", []).append({"at": utc_now(), "status": status, "text": text})
+    task["updated_at"] = utc_now()
+    save_task(task)
+    return task
+
+
+def load_evidence() -> dict[str, Any]:
+    return read_json(TEST_EVIDENCE, {"tests": {}})
+
+
+def save_evidence(evidence: dict[str, Any]) -> None:
+    write_json(TEST_EVIDENCE, evidence)
+
+
+def load_failure_ledger() -> dict[str, Any]:
+    return read_json(FAILURE_LEDGER, {"failures": {}})
+
+
+def save_failure_ledger(ledger: dict[str, Any]) -> None:
+    write_json(FAILURE_LEDGER, ledger)
+
+
+def escalate(reason: str, acceptance_id: str | None = None) -> dict[str, Any]:
+    task = load_task() or start_task("Escalation")
+    task["status"] = "BLOCKED"
+    task.setdefault("blockers", []).append({"at": utc_now(), "reason": reason, "acceptance_id": acceptance_id})
+    task["next_action"] = "Resolve the escalation before additional product edits."
+    save_task(task)
+    lines = [
+        "# Codex Escalation",
+        "",
+        f"- Created: `{utc_now()}`",
+        f"- Task: `{task.get('task_id')}`",
+        f"- Acceptance ID: `{acceptance_id or 'n/a'}`",
+        f"- Reason: {reason}",
+        "",
+        "Further product edits are blocked until the architecture or acceptance failure is resolved.",
+    ]
+    ensure_state_dir()
+    ESCALATION_MD.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return task
+
+
+def record_test(test_id: str, status: str, evidence_path: str = "", attempt: str = "", code_change: bool = False) -> dict[str, Any]:
+    task = load_task() or start_task(f"Record test {test_id}")
+    entry = {
+        "at": utc_now(),
+        "id": test_id,
+        "status": status.upper(),
+        "evidence": evidence_path,
+        "attempt": attempt,
+        "code_change": bool(code_change),
+    }
+    task.setdefault("tests", []).append(entry)
+    task["updated_at"] = utc_now()
+
+    evidence = load_evidence()
+    evidence.setdefault("tests", {})[test_id] = entry
+    save_evidence(evidence)
+
+    if status.upper() in {"FAIL", "FAILED", "BLOCK"} and code_change:
+        ledger = load_failure_ledger()
+        failures = ledger.setdefault("failures", {})
+        item = failures.setdefault(test_id, {"attempt_count": 0, "attempts": [], "last_attempt": ""})
+        if attempt and attempt != item.get("last_attempt"):
+            item["attempt_count"] += 1
+            item["attempts"].append({"at": utc_now(), "attempt": attempt, "evidence": evidence_path})
+            item["last_attempt"] = attempt
+        save_failure_ledger(ledger)
+        if item["attempt_count"] >= 2:
+            escalate(
+                f"Acceptance test `{test_id}` failed after two separate code-change attempts.",
+                acceptance_id=test_id,
+            )
+            task = load_task() or task
+
+    save_task(task)
+    return task
+
+
+def checkpoint(note: str = "") -> str:
+    task = load_task()
+    files = changed_files()
+    lines = [
+        "# Codex Checkpoint",
+        "",
+        f"- Created: `{utc_now()}`",
+        f"- Branch: `{current_branch()}`",
+        f"- HEAD: `{current_head()}`",
+        f"- Note: {note or 'n/a'}",
+        "",
+        "## Active Task",
+        "",
+    ]
+    if task:
+        contract = task.get("contract", {})
+        lines.extend(
+            [
+                f"- Task ID: `{task.get('task_id')}`",
+                f"- Status: `{task.get('status')}`",
+                f"- Latest intent: {task.get('latest_intent')}",
+                f"- Risk: `{contract.get('risk_level')}`",
+                f"- Tags: `{', '.join(contract.get('capability_tags', []))}`",
+                f"- Next action: {task.get('next_action')}",
+            ]
+        )
+    else:
+        lines.append("- No active task.")
+    lines.extend(["", "## Dirty Files", ""])
+    lines.extend([f"- `{p}`" for p in files] or ["- None"])
+    text = "\n".join(lines) + "\n"
+    ensure_state_dir()
+    CHECKPOINT_MD.write_text(text, encoding="utf-8")
+    return text
+
+
+def generate_handoff() -> str:
+    task = load_task()
+    files = changed_files()
+    gate = read_json(STATE_DIR / "GATE_RESULT.json", {})
+    lines = [
+        "# SESSION_HANDOFF",
+        "",
+        f"- Generated: `{utc_now()}`",
+        f"- Branch: `{current_branch()}`",
+        f"- HEAD: `{current_head()}`",
+        "",
+        "## Dirty Files",
+        "",
+    ]
+    lines.extend([f"- `{p}`" for p in files[:40]] or ["- None"])
+    if len(files) > 40:
+        lines.append(f"- ... {len(files) - 40} more")
+    lines.extend(["", "## Active Task", ""])
+    if task:
+        contract = task.get("contract", {})
+        lines.extend(
+            [
+                f"- Task ID: `{task.get('task_id')}`",
+                f"- Status: `{task.get('status')}`",
+                f"- Latest intent: {task.get('latest_intent')}",
+                f"- Risk: `{contract.get('risk_level')}`",
+                f"- Tags: `{', '.join(contract.get('capability_tags', []))}`",
+                f"- Surface: {contract.get('affected_product_surface')}",
+            ]
+        )
+    else:
+        lines.append("- No active task.")
+    lines.extend(["", "## Latest Gate", ""])
+    if gate:
+        lines.extend(
+            [
+                f"- Evidence: `{gate.get('evidence_status', 'UNKNOWN')}`",
+                f"- Contract: `{gate.get('contract_status', 'UNKNOWN')}`",
+            ]
+        )
+        missing = gate.get("missing", [])
+        if missing:
+            lines.append(f"- Missing: {', '.join(missing[:10])}")
+    else:
+        lines.append("- No gate result yet.")
+    lines.extend(["", "## Blockers", ""])
+    blockers = (task or {}).get("blockers", []) if task else []
+    lines.extend([f"- {b.get('reason')}" for b in blockers[-5:]] or ["- None"])
+    lines.extend(["", "## Next Action", "", (task or {}).get("next_action", "Start or update a task contract before editing.")])
+    text = "\n".join(lines).rstrip() + "\n"
+    (ROOT / "SESSION_HANDOFF.md").write_text(text, encoding="utf-8")
+    return text
+
+
+def session_context() -> str:
+    task = load_task()
+    if not task:
+        return "The user may speak naturally. Infer and persist the task contract before editing."
+    contract = task.get("contract", {})
+    return "\n".join(
+        [
+            "Continue from the repository-local Codex task state.",
+            f"Task ID: {task.get('task_id')}",
+            f"Status: {task.get('status')}",
+            f"Latest intent: {task.get('latest_intent')}",
+            f"Risk: {contract.get('risk_level')}",
+            f"Tags: {', '.join(contract.get('capability_tags', []))}",
+            f"Next action: {task.get('next_action')}",
+        ]
+    )
+
+
+def close_task() -> dict[str, Any]:
+    task = load_task() or start_task("Close task")
+    task["status"] = "closed"
+    task["updated_at"] = utc_now()
+    task["next_action"] = "Task closed."
+    save_task(task)
+    return task
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Maintain repository-local Codex task state.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    start = sub.add_parser("start")
+    start.add_argument("--prompt", required=True)
+    start.add_argument("--base")
+    start.add_argument("--branch")
+    start.add_argument("--worktree")
+
+    update = sub.add_parser("update")
+    update.add_argument("--prompt", required=True)
+
+    sub.add_parser("status").add_argument("--json", action="store_true")
+
+    record = sub.add_parser("record-test")
+    record.add_argument("--id", required=True)
+    record.add_argument("--status", required=True)
+    record.add_argument("--evidence", default="")
+    record.add_argument("--attempt", default="")
+    record.add_argument("--code-change", action="store_true")
+
+    decision = sub.add_parser("record-decision")
+    decision.add_argument("--text", required=True)
+    decision.add_argument("--status", default="accepted")
+
+    check = sub.add_parser("checkpoint")
+    check.add_argument("--note", default="")
+
+    esc = sub.add_parser("escalate")
+    esc.add_argument("--reason", required=True)
+    esc.add_argument("--acceptance-id", default="")
+
+    sub.add_parser("handoff")
+    sub.add_parser("session-context")
+    sub.add_parser("close")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "start":
+        result = start_task(args.prompt, args.base, args.branch, args.worktree)
+        print(render_task_md(result), end="")
+    elif args.command == "update":
+        result = update_task(args.prompt)
+        print(render_task_md(result), end="")
+    elif args.command == "status":
+        result = load_task()
+        if args.json:
+            print(json.dumps(result or {}, indent=2, ensure_ascii=False))
+        else:
+            print(render_task_md(result), end="") if result else print(session_context())
+    elif args.command == "record-test":
+        result = record_test(args.id, args.status, args.evidence, args.attempt, args.code_change)
+        print(render_task_md(result), end="")
+    elif args.command == "record-decision":
+        result = record_decision(args.text, args.status)
+        print(render_task_md(result), end="")
+    elif args.command == "checkpoint":
+        print(checkpoint(args.note), end="")
+    elif args.command == "escalate":
+        result = escalate(args.reason, args.acceptance_id or None)
+        print(render_task_md(result), end="")
+    elif args.command == "handoff":
+        print(generate_handoff(), end="")
+    elif args.command == "session-context":
+        print(session_context())
+    elif args.command == "close":
+        result = close_task()
+        print(render_task_md(result), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web/js/deno_frontend_core/async_latest.js
+++ b/web/js/deno_frontend_core/async_latest.js
@@ -1,0 +1,77 @@
+export function createLatestRequest(scope = null) {
+    let current = null;
+    let nextId = 0;
+
+    function isCurrent(token) {
+        return Boolean(token && current === token && !scope?.disposed && !token.signal.aborted);
+    }
+
+    function cancel() {
+        if (current) {
+            current.controller.abort();
+            current = null;
+        }
+    }
+
+    function begin() {
+        cancel();
+        if (scope?.disposed) {
+            return null;
+        }
+        const controller = new AbortController();
+        const token = {
+            id: ++nextId,
+            controller,
+            signal: controller.signal,
+        };
+        current = token;
+        return token;
+    }
+
+    async function run(task, handlers = {}) {
+        const token = begin();
+        if (!token) {
+            return undefined;
+        }
+        try {
+            const value = await task(token.signal, token);
+            if (!isCurrent(token)) {
+                return undefined;
+            }
+            const result = handlers.apply ? handlers.apply(value, token) : value;
+            if (current === token) {
+                current = null;
+            }
+            return result;
+        } catch (error) {
+            if (isAbortError(error) || !isCurrent(token)) {
+                return undefined;
+            }
+            if (handlers.onError) {
+                const result = handlers.onError(error, token);
+                if (current === token) {
+                    current = null;
+                }
+                return result;
+            }
+            if (current === token) {
+                current = null;
+            }
+            throw error;
+        }
+    }
+
+    scope?.onDispose?.(cancel);
+
+    return {
+        begin,
+        cancel,
+        isCurrent,
+        run,
+    };
+}
+
+export function isAbortError(error) {
+    return error?.name === "AbortError"
+        || (typeof DOMException !== "undefined" && error?.code === DOMException.ABORT_ERR);
+}

--- a/web/js/deno_frontend_core/lifecycle.js
+++ b/web/js/deno_frontend_core/lifecycle.js
@@ -1,0 +1,208 @@
+const NODE_LIFECYCLE_KEY = Symbol.for("deno.frontend.lifecycle.node");
+
+function ensureNodeLifecycle(node) {
+    if (!node) {
+        return null;
+    }
+    if (node[NODE_LIFECYCLE_KEY]) {
+        return node[NODE_LIFECYCLE_KEY];
+    }
+
+    const priorOnRemoved = node.onRemoved;
+    const lifecycle = {
+        scopes: new Map(),
+        priorOnRemoved,
+        disposed: false,
+    };
+
+    Object.defineProperty(node, NODE_LIFECYCLE_KEY, {
+        value: lifecycle,
+        enumerable: false,
+        configurable: false,
+        writable: false,
+    });
+
+    node.onRemoved = function denoLifecycleOnRemoved(...args) {
+        if (!lifecycle.disposed) {
+            lifecycle.disposed = true;
+            for (const scope of lifecycle.scopes.values()) {
+                scope.dispose();
+            }
+        }
+        return priorOnRemoved?.apply(this, args);
+    };
+
+    return lifecycle;
+}
+
+export function getNodeLifecycleScope(node, key = "default") {
+    const lifecycle = ensureNodeLifecycle(node);
+    if (!lifecycle) {
+        return createLifecycleScope();
+    }
+    if (lifecycle.disposed) {
+        return createDisposedLifecycleScope();
+    }
+
+    const existing = lifecycle.scopes.get(key);
+    if (existing && !existing.disposed) {
+        return existing;
+    }
+
+    const scope = createLifecycleScope();
+    lifecycle.scopes.set(key, scope);
+    scope.onDispose(() => {
+        if (lifecycle.scopes.get(key) === scope) {
+            lifecycle.scopes.delete(key);
+        }
+    });
+    return scope;
+}
+
+export function createDisposedLifecycleScope() {
+    let signal = null;
+    const scope = {
+        disposed: true,
+        get signal() {
+            if (!signal) {
+                const controller = new AbortController();
+                controller.abort();
+                signal = controller.signal;
+            }
+            return signal;
+        },
+        onDispose(cleanup) {
+            if (typeof cleanup === "function") {
+                cleanup();
+            }
+            return () => {};
+        },
+        addEventListener() {
+            return null;
+        },
+        observeMutation() {
+            return null;
+        },
+        setTimeout() {
+            return null;
+        },
+        requestAnimationFrame() {
+            return null;
+        },
+        createAbortController() {
+            const controller = new AbortController();
+            controller.abort();
+            return controller;
+        },
+        dispose() {},
+    };
+    Object.defineProperty(scope, "pendingCleanupCount", {
+        get() {
+            return 0;
+        },
+        enumerable: false,
+    });
+    return scope;
+}
+
+export function createLifecycleScope() {
+    const cleanups = [];
+    const removeCleanup = (cleanup) => {
+        const index = cleanups.indexOf(cleanup);
+        if (index >= 0) {
+            cleanups.splice(index, 1);
+        }
+    };
+    const scope = {
+        disposed: false,
+        get signal() {
+            if (!scope._controller) {
+                scope._controller = new AbortController();
+                scope.onDispose(() => scope._controller?.abort());
+            }
+            return scope._controller.signal;
+        },
+        onDispose(cleanup) {
+            if (typeof cleanup !== "function") {
+                return cleanup;
+            }
+            if (scope.disposed) {
+                cleanup();
+                return () => {};
+            }
+            cleanups.push(cleanup);
+            return () => removeCleanup(cleanup);
+        },
+        addEventListener(target, type, listener, options) {
+            if (!target?.addEventListener || !target?.removeEventListener || scope.disposed) {
+                return listener;
+            }
+            target.addEventListener(type, listener, options);
+            scope.onDispose(() => target.removeEventListener(type, listener, options));
+            return listener;
+        },
+        observeMutation(target, callback, options) {
+            if (typeof MutationObserver === "undefined" || !target || scope.disposed) {
+                return null;
+            }
+            const observer = new MutationObserver(callback);
+            observer.observe(target, options);
+            scope.onDispose(() => observer.disconnect());
+            return observer;
+        },
+        setTimeout(callback, delay = 0) {
+            if (scope.disposed) {
+                return null;
+            }
+            let unregisterCleanup = () => {};
+            const id = setTimeout(() => {
+                unregisterCleanup();
+                if (!scope.disposed) {
+                    callback();
+                }
+            }, delay);
+            unregisterCleanup = scope.onDispose(() => clearTimeout(id));
+            return id;
+        },
+        requestAnimationFrame(callback) {
+            if (scope.disposed || typeof requestAnimationFrame !== "function") {
+                return null;
+            }
+            let unregisterCleanup = () => {};
+            const id = requestAnimationFrame((time) => {
+                unregisterCleanup();
+                if (!scope.disposed) {
+                    callback(time);
+                }
+            });
+            unregisterCleanup = scope.onDispose(() => cancelAnimationFrame(id));
+            return id;
+        },
+        createAbortController() {
+            const controller = new AbortController();
+            scope.onDispose(() => controller.abort());
+            return controller;
+        },
+        dispose() {
+            if (scope.disposed) {
+                return;
+            }
+            scope.disposed = true;
+            while (cleanups.length) {
+                const cleanup = cleanups.pop();
+                try {
+                    cleanup();
+                } catch (error) {
+                    console.warn?.("[DENO] lifecycle cleanup failed:", error);
+                }
+            }
+        },
+    };
+    Object.defineProperty(scope, "pendingCleanupCount", {
+        get() {
+            return cleanups.length;
+        },
+        enumerable: false,
+    });
+    return scope;
+}

--- a/web/js/deno_frontend_core/storage.js
+++ b/web/js/deno_frontend_core/storage.js
@@ -1,0 +1,122 @@
+export function safeJsonParse(raw, fallback = null) {
+    if (typeof raw !== "string" || !raw.trim()) {
+        return fallback;
+    }
+    try {
+        return JSON.parse(raw);
+    } catch (_error) {
+        return fallback;
+    }
+}
+
+export function safeJsonStringify(value, fallback = "{}") {
+    try {
+        return JSON.stringify(value);
+    } catch (_error) {
+        return fallback;
+    }
+}
+
+export function readJsonStorage(storage, key, fallback = null) {
+    try {
+        return safeJsonParse(storage?.getItem?.(key), fallback);
+    } catch (_error) {
+        return fallback;
+    }
+}
+
+export function writeJsonStorage(storage, key, value) {
+    try {
+        storage?.setItem?.(key, JSON.stringify(value));
+        return true;
+    } catch (_error) {
+        return false;
+    }
+}
+
+export function readVersionedJsonStorage({
+    storage,
+    currentKey,
+    legacyKeys = [],
+    normalize = (value) => value,
+    fallback = null,
+}) {
+    for (const key of [currentKey, ...legacyKeys].filter(Boolean)) {
+        const parsed = readJsonStorage(storage, key, null);
+        if (parsed == null) {
+            continue;
+        }
+        try {
+            return normalize(parsed, { key, legacy: key !== currentKey });
+        } catch (_error) {
+            continue;
+        }
+    }
+    return fallback;
+}
+
+export function mergeLibraryByStableId(workflowItems = [], libraryItems = [], options = {}) {
+    const getId = options.getId || ((item) => item?.id);
+    const clone = options.clone || cloneSerializableValue;
+    const byId = new Map();
+
+    for (const item of workflowItems) {
+        const id = String(getId(item) || "");
+        if (id) {
+            byId.set(id, clone(item));
+        }
+    }
+    for (const item of libraryItems) {
+        const id = String(getId(item) || "");
+        if (id && !byId.has(id)) {
+            byId.set(id, clone(item));
+        }
+    }
+
+    return [...byId.values()];
+}
+
+export function promoteLibraryItem(workflowItems = [], libraryItem, options = {}) {
+    const getId = options.getId || ((item) => item?.id);
+    const clone = options.clone || cloneSerializableValue;
+    const promoted = clone(libraryItem);
+    const promotedId = String(getId(promoted) || "");
+    if (!promotedId) {
+        return workflowItems.map(clone);
+    }
+
+    const next = workflowItems.map(clone);
+    const index = next.findIndex((item) => String(getId(item) || "") === promotedId);
+    if (index >= 0) {
+        next[index] = promoted;
+    } else {
+        next.push(promoted);
+    }
+    return next;
+}
+
+export function upsertLibraryItem(libraryItems = [], libraryItem, options = {}) {
+    const getId = options.getId || ((item) => item?.id);
+    const clone = options.clone || cloneSerializableValue;
+    const upserted = clone(libraryItem);
+    const upsertedId = String(getId(upserted) || "");
+    const next = libraryItems.map(clone);
+    if (!upsertedId) {
+        return next;
+    }
+
+    const index = next.findIndex((item) => String(getId(item) || "") === upsertedId);
+    if (index >= 0) {
+        next[index] = upserted;
+    } else {
+        next.push(upserted);
+    }
+    return next;
+}
+
+export function cloneSerializableValue(value) {
+    if (value != null && typeof value === "object") {
+        return JSON.parse(JSON.stringify(value));
+    }
+    return value ?? null;
+}

--- a/web/js/deno_frontend_core/widget_state.js
+++ b/web/js/deno_frontend_core/widget_state.js
@@ -1,0 +1,54 @@
+export function findWidget(node, name) {
+    return (node?.widgets || []).find((widget) => widget?.name === name) || null;
+}
+
+function normalizeSpec(spec) {
+    return typeof spec === "string" ? { name: spec } : spec;
+}
+
+function resolveDefault(spec) {
+    if (typeof spec.defaultValue === "function") {
+        return spec.defaultValue();
+    }
+    return spec.defaultValue;
+}
+
+function normalizeValue(spec, value, node, widget) {
+    if (typeof spec.normalize === "function") {
+        return spec.normalize(value, { node, widget, spec });
+    }
+    return value;
+}
+
+function cloneSerializableValue(value) {
+    if (value != null && typeof value === "object") {
+        return JSON.parse(JSON.stringify(value));
+    }
+    return value ?? null;
+}
+
+export function readOrderedWidgetValues(node, specs) {
+    return specs.map((rawSpec) => {
+        const spec = normalizeSpec(rawSpec);
+        const widget = findWidget(node, spec.name);
+        const value = widget ? widget.value : resolveDefault(spec);
+        return normalizeValue(spec, value, node, widget);
+    });
+}
+
+export function applyOrderedWidgetValues(node, specs, values) {
+    if (!node || !Array.isArray(values)) {
+        return;
+    }
+
+    specs.map(normalizeSpec).forEach((spec, index) => {
+        const widget = findWidget(node, spec.name);
+        if (widget) {
+            widget.value = values[index];
+        }
+    });
+}
+
+export function canonicalOrderedSerializationValues(node, specs) {
+    return readOrderedWidgetValues(node, specs).map(cloneSerializableValue);
+}

--- a/web/js/deno_frontend_core/workflow_migration.js
+++ b/web/js/deno_frontend_core/workflow_migration.js
@@ -1,0 +1,182 @@
+function cloneSerializableValue(value) {
+    if (value != null && typeof value === "object") {
+        return JSON.parse(JSON.stringify(value));
+    }
+    return value ?? null;
+}
+
+function cloneValues(values) {
+    return values.map(cloneSerializableValue);
+}
+
+function isEmptyGeneratedSlot(value) {
+    return value === "" || value == null;
+}
+
+const INSTALL_MARKER = Symbol.for("deno.frontend.workflow_widget_migration.installs");
+
+function getInstallSet(prototype) {
+    if (!Object.prototype.hasOwnProperty.call(prototype, INSTALL_MARKER)) {
+        Object.defineProperty(prototype, INSTALL_MARKER, {
+            value: new Set(),
+            enumerable: false,
+            configurable: false,
+            writable: false,
+        });
+    }
+    return prototype[INSTALL_MARKER];
+}
+
+function warnOnce(warnedNodes, node, message) {
+    if (!node || warnedNodes.has(node)) {
+        return;
+    }
+    warnedNodes.add(node);
+    if (typeof console !== "undefined" && typeof console.warn === "function") {
+        console.warn(message);
+    }
+}
+
+export function createExactWidgetValueShapeMigration({ canonicalCount, legacyGeneratedSlots = [] }) {
+    const generatedSlots = [...legacyGeneratedSlots].sort((a, b) => a - b);
+    const generatedSlotSet = new Set(generatedSlots);
+    const legacyCount = canonicalCount + generatedSlots.length;
+
+    return function normalizeSerializedWidgetValues(values) {
+        if (!Array.isArray(values)) {
+            return null;
+        }
+
+        if (values.length === canonicalCount) {
+            return cloneValues(values);
+        }
+
+        if (values.length !== legacyCount) {
+            return null;
+        }
+
+        for (const slot of generatedSlots) {
+            if (!isEmptyGeneratedSlot(values[slot])) {
+                return null;
+            }
+        }
+
+        const canonical = [];
+        for (let index = 0; index < values.length; index++) {
+            if (!generatedSlotSet.has(index)) {
+                canonical.push(values[index]);
+            }
+        }
+
+        return canonical.length === canonicalCount ? cloneValues(canonical) : null;
+    };
+}
+
+export function expandCanonicalValuesForGeneratedSlots(canonicalValues, generatedSlots, displayValue = "") {
+    if (!Array.isArray(canonicalValues)) {
+        return null;
+    }
+
+    const generatedSlotSet = new Set(generatedSlots);
+    const expandedLength = canonicalValues.length + generatedSlotSet.size;
+    const expanded = [];
+    let canonicalIndex = 0;
+
+    for (let index = 0; index < expandedLength; index++) {
+        if (generatedSlotSet.has(index)) {
+            expanded[index] = displayValue;
+        } else {
+            expanded[index] = cloneSerializableValue(canonicalValues[canonicalIndex++]);
+        }
+    }
+
+    return expanded;
+}
+
+export function installWorkflowWidgetMigration(nodeType, nodeData, spec) {
+    if (!nodeType?.prototype) {
+        return false;
+    }
+    if (spec.nodeName && nodeData?.name !== spec.nodeName) {
+        return false;
+    }
+
+    const installKey = spec.installKey || spec.nodeName || nodeData?.name;
+    const installSet = getInstallSet(nodeType.prototype);
+    if (installKey && installSet.has(installKey)) {
+        return false;
+    }
+    if (installKey) {
+        installSet.add(installKey);
+    }
+
+    const unknownConfiguredNodes = new WeakSet();
+    const warnedUnknownNodes = new WeakSet();
+    const priorConfigure = nodeType.prototype.configure;
+    nodeType.prototype.configure = function (info) {
+        const hasInfo = info != null && typeof info === "object";
+        const hasOwnWidgetsValues = hasInfo && Object.prototype.hasOwnProperty.call(info, "widgets_values");
+        const originalWidgetsValues = hasInfo ? info.widgets_values : undefined;
+        const canonicalValues = spec.normalizeSerializedValues?.(info?.widgets_values, this, info) || null;
+        const isUnknownConfiguredArray = hasOwnWidgetsValues && Array.isArray(originalWidgetsValues) && !Array.isArray(canonicalValues);
+
+        if (Array.isArray(canonicalValues)) {
+            unknownConfiguredNodes.delete(this);
+            const canonicalCopy = cloneValues(canonicalValues);
+            if (spec.pendingValuesKey) {
+                this[spec.pendingValuesKey] = cloneValues(canonicalCopy);
+            }
+            if (hasInfo) {
+                info.widgets_values = spec.getConfigureWidgetValues?.(this, canonicalCopy, info) || canonicalCopy;
+            }
+        } else if (isUnknownConfiguredArray) {
+            unknownConfiguredNodes.add(this);
+            if (spec.pendingValuesKey) {
+                delete this[spec.pendingValuesKey];
+            }
+        }
+
+        let result;
+        try {
+            result = priorConfigure?.apply(this, arguments);
+        } finally {
+            if (Array.isArray(canonicalValues) && hasInfo) {
+                if (hasOwnWidgetsValues) {
+                    info.widgets_values = originalWidgetsValues;
+                } else {
+                    delete info.widgets_values;
+                }
+            }
+        }
+
+        if (Array.isArray(canonicalValues)) {
+            spec.applyCanonicalValues?.(this, cloneValues(canonicalValues), info);
+        } else if (isUnknownConfiguredArray && spec.warnOnUnknownShape !== false) {
+            warnOnce(
+                warnedUnknownNodes,
+                this,
+                `[DENO] ${spec.nodeName || nodeData?.name || "node"} kept an unknown widgets_values shape unchanged during workflow restore.`,
+            );
+        }
+
+        return result;
+    };
+
+    const priorOnSerialize = nodeType.prototype.onSerialize;
+    nodeType.prototype.onSerialize = function (serialized) {
+        const result = priorOnSerialize?.apply(this, arguments);
+        if (unknownConfiguredNodes.has(this)) {
+            return result;
+        }
+        const canonicalValues = spec.getCanonicalSerializationValues?.(this, serialized) || null;
+        if (Array.isArray(canonicalValues)) {
+            serialized.widgets_values = cloneValues(canonicalValues);
+            if (spec.syncNodeWidgetsValues !== false) {
+                this.widgets_values = cloneValues(canonicalValues);
+            }
+        }
+        return result;
+    };
+
+    return true;
+}

--- a/web/js/deno_ltx_model_downloader.js
+++ b/web/js/deno_ltx_model_downloader.js
@@ -1,17 +1,29 @@
 import { app } from "../../scripts/app.js";
 import { api } from "../../scripts/api.js";
+import { createLatestRequest } from "./deno_frontend_core/async_latest.js";
+import { getNodeLifecycleScope } from "./deno_frontend_core/lifecycle.js";
+import {
+    cloneSerializableValue,
+    mergeLibraryByStableId,
+    promoteLibraryItem,
+    readVersionedJsonStorage,
+    upsertLibraryItem,
+    writeJsonStorage,
+} from "./deno_frontend_core/storage.js";
 
 const NODE_NAME = "DenoLTXModelDownloader";
 const ROUTE = "/deno/ltx_model_downloader";
 const MIN_SIZE = [560, 430];
 const PANEL_MIN_HEIGHT = 352;
 const NODE_CHROME_HEIGHT = 62;
-const PRESET_STORAGE_KEY = "deno_ltx_model_downloader_presets_v3";
+const PRESET_LIBRARY_SCHEMA_VERSION = 4;
+const PRESET_LIBRARY_STORAGE_KEY = "deno_ltx_model_downloader_preset_library_v4";
 const LEGACY_PRESET_STORAGE_KEYS = [
+    "deno_ltx_model_downloader_presets_v3",
     "deno_ltx_model_downloader_presets_v1",
     "deno_ltx_model_downloader_presets_v2",
 ];
-const LTX_MODEL_DOWNLOADER_REV = "r2026.06.23-root-intent-c";
+const LTX_MODEL_DOWNLOADER_REV = "r2026.06.25-phase2b-foundation-a";
 
 const DEFAULT_PACKAGE = {
     id: "ltx_23_8gb_vram",
@@ -91,7 +103,10 @@ app.registerExtension({
         const onConfigure = nodeType.prototype.onConfigure;
         nodeType.prototype.onConfigure = function () {
             const result = onConfigure?.apply(this, arguments);
-            queueMicrotask(() => setupNode(this));
+            const scope = getNodeLifecycleScope(this, "ltx-model-downloader");
+            if (!scope.disposed) {
+                queueMicrotask(() => setupNode(this));
+            }
             return result;
         };
     },
@@ -99,6 +114,10 @@ app.registerExtension({
 
 function setupNode(node) {
     if (!node || node.type !== NODE_NAME) {
+        return;
+    }
+    const scope = getNodeLifecycleScope(node, "ltx-model-downloader");
+    if (scope.disposed) {
         return;
     }
     if (node.__denoLtxSetupReady) {
@@ -121,12 +140,17 @@ function setupNode(node) {
         }
     }
 
-    const ui = buildUi(node, rootWidget, presetsWidget);
+    const ui = buildUi(node, rootWidget, presetsWidget, scope);
     const domWidget = node.addDOMWidget("deno_ltx_setup_panel", "deno_ltx_setup_panel", ui.root, {
         serialize: false,
     });
     node.__denoLtxSetupUi = ui;
     domWidget.computeSize = () => ui.computeSize();
+    scope.onDispose(() => {
+        ui.root.remove();
+        delete node.__denoLtxSetupReady;
+        delete node.__denoLtxSetupUi;
+    });
     ui.applyNodeSize();
     ui.refreshInfo();
 }
@@ -141,8 +165,9 @@ function hideWidget(widget) {
     widget.computeSize = () => [0, -4];
 }
 
-function buildUi(node, rootWidget, presetsWidget) {
+function buildUi(node, rootWidget, presetsWidget, scope) {
     const root = document.createElement("div");
+    root.dataset.denoLtxDownloaderPanel = "true";
     root.style.cssText = `
         width:100%;
         box-sizing:border-box;
@@ -315,15 +340,18 @@ function buildUi(node, rootWidget, presetsWidget) {
         rootMode: "auto",
         explicitRootId: "",
         effectiveRootId: "",
-        refreshSequence: 0,
         roots: [],
         files: [],
         modelsRoot: "",
         modelSubdirs: [],
         editing: false,
-        presetsState: readPresetsState(presetsWidget),
+        workflowPresetsState: readWorkflowPresetsState(presetsWidget),
+        libraryPresetsState: readPresetLibraryState(),
+        viewPresetsState: normalizePresetsState(DEFAULT_STATE),
         editorPresetId: "",
     };
+    const refreshRequest = createLatestRequest(scope);
+    syncPresetView();
 
     function resetRootToAuto() {
         state.rootMode = "auto";
@@ -332,6 +360,32 @@ function buildUi(node, rootWidget, presetsWidget) {
 
     function requestedRootId() {
         return state.rootMode === "explicit" ? state.explicitRootId : "";
+    }
+
+    function syncPresetView() {
+        state.workflowPresetsState = normalizePresetsState(state.workflowPresetsState);
+        state.libraryPresetsState = normalizePresetLibraryState(state.libraryPresetsState);
+        state.viewPresetsState = mergePresetLibraryState(state.workflowPresetsState, state.libraryPresetsState);
+        return state.viewPresetsState;
+    }
+
+    function workflowOwnsPreset(presetId) {
+        return normalizePresetsState(state.workflowPresetsState).presets.some((item) => item.id === presetId);
+    }
+
+    function promotePresetToWorkflow(preset) {
+        const workflow = normalizePresetsState(state.workflowPresetsState);
+        const promotedPresets = promoteLibraryItem(workflow.presets, preset, {
+            clone: cloneSerializableValue,
+        });
+        state.workflowPresetsState = normalizePresetsState({
+            active_preset_id: preset.id,
+            presets: promotedPresets,
+        });
+        writeWorkflowPresetsState(presetsWidget, state.workflowPresetsState);
+        markWorkflowDirty();
+        syncPresetView();
+        return state.workflowPresetsState;
     }
 
     function selectRootByUser(rootId) {
@@ -352,11 +406,12 @@ function buildUi(node, rootWidget, presetsWidget) {
     }
 
     const editor = buildEditor(
-        () => currentPackage(state.presetsState),
+        () => currentPackage(state.workflowPresetsState),
         () => state.modelSubdirs,
         resolveCivitaiUrl,
         (nextPackage) => saveEditorPreset(nextPackage),
-        () => applyNodeSize()
+        () => applyNodeSize(),
+        scope
     );
     editor.root.style.display = "none";
 
@@ -414,15 +469,16 @@ function buildUi(node, rootWidget, presetsWidget) {
         return payload;
     }
 
-    async function postJson(path, body) {
+    async function postJson(path, body, signal = undefined) {
         return apiJson(path, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(body),
+            signal,
         });
     }
 
-    function setEditingMode(nextEditing, packageValue = currentPackage(state.presetsState)) {
+    function setEditingMode(nextEditing, packageValue = currentPackage(state.workflowPresetsState)) {
         state.editing = Boolean(nextEditing);
         for (const [section, displayValue] of viewSections) {
             section.style.display = state.editing ? "none" : displayValue;
@@ -443,21 +499,31 @@ function buildUi(node, rootWidget, presetsWidget) {
     }
 
     function renderPresetButton() {
-        const active = currentPackage(state.presetsState);
+        syncPresetView();
+        const active = currentPackage(state.workflowPresetsState);
         presetButton.textContent = `${active.title || "Custom Preset"} ▾`;
         presetMenu.replaceChildren();
 
-        for (const item of state.presetsState.presets) {
+        for (const item of state.viewPresetsState.presets) {
             const option = createMenuButton(item.title || "Custom Preset", () => {
-                state.presetsState.active_preset_id = item.id;
-                writePresetsState(presetsWidget, state.presetsState);
+                if (workflowOwnsPreset(item.id)) {
+                    state.workflowPresetsState = normalizePresetsState({
+                        ...state.workflowPresetsState,
+                        active_preset_id: item.id,
+                    });
+                    writeWorkflowPresetsState(presetsWidget, state.workflowPresetsState);
+                    markWorkflowDirty();
+                    syncPresetView();
+                } else {
+                    promotePresetToWorkflow(item);
+                }
                 markWorkflowDirty();
                 presetMenu.style.display = "none";
                 setEditingMode(false);
-                editor.load(currentPackage(state.presetsState));
+                editor.load(currentPackage(state.workflowPresetsState));
                 resetRootToAuto();
                 refreshInfo();
-            }, item.id === state.presetsState.active_preset_id);
+            }, item.id === state.workflowPresetsState.active_preset_id);
             presetMenu.append(option);
         }
     }
@@ -468,7 +534,7 @@ function buildUi(node, rootWidget, presetsWidget) {
         state.effectiveRootId = payload.selected_root_id || roots[0]?.id || "";
         state.modelsRoot = payload.models_root || "";
         state.modelSubdirs = payload.model_subdirs || state.modelSubdirs || [];
-        hint.textContent = payload.instructions || currentPackage(state.presetsState).description || "Open links, download with your browser, then move files into the shown target paths.";
+        hint.textContent = payload.instructions || currentPackage(state.workflowPresetsState).description || "Open links, download with your browser, then move files into the shown target paths.";
 
         rootSelect.replaceChildren();
         for (const rootInfo of roots) {
@@ -568,13 +634,15 @@ function buildUi(node, rootWidget, presetsWidget) {
 
             const target = document.createElement("div");
             target.style.cssText = "min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:#96caa6; font-size:10px;";
+            const localStatus = file.local_status || file.status;
             const foundSuffix = file.found_by === "subfolder" ? "found in subfolder" : "";
-            target.textContent = file.error || [file.filename || filenameFromRelative(file.relative_path) || "(set filename)", prettyBytes(file.size), foundSuffix].filter(Boolean).join(" - ");
+            const elsewhereSuffix = file.status === "exists" && localStatus !== "exists" ? "available in another root" : "";
+            target.textContent = file.error || [file.filename || filenameFromRelative(file.relative_path) || "(set filename)", prettyBytes(file.size), foundSuffix, elsewhereSuffix].filter(Boolean).join(" - ");
             nameWrap.append(label, target);
 
             const badge = document.createElement("div");
-            badge.style.cssText = `font-weight:800; color:${statusColor(file.status)}; min-width:48px; text-align:right;`;
-            badge.textContent = statusLabel(file.status);
+            badge.style.cssText = `font-weight:800; color:${statusColor(localStatus)}; min-width:48px; text-align:right;`;
+            badge.textContent = statusLabel(localStatus);
 
             const downButton = createMiniButton("Down");
             downButton.disabled = !file.url;
@@ -595,42 +663,53 @@ function buildUi(node, rootWidget, presetsWidget) {
     }
 
     function reloadFromWidgets() {
-        state.presetsState = readPresetsState(presetsWidget);
-        state.editorPresetId = currentPackage(state.presetsState).id;
+        state.workflowPresetsState = readWorkflowPresetsState(presetsWidget);
+        state.libraryPresetsState = readPresetLibraryState();
+        syncPresetView();
+        state.editorPresetId = currentPackage(state.workflowPresetsState).id;
         resetRootToAuto();
         renderPresetButton();
-        editor.load(currentPackage(state.presetsState));
+        editor.load(currentPackage(state.workflowPresetsState));
         setEditingMode(false);
         refreshInfo();
     }
 
     async function refreshInfo() {
-        const sequence = ++state.refreshSequence;
-        try {
+        return refreshRequest.run(async (signal) => {
             renderPresetButton();
             setStatus("Checking local model files...");
-            const active = currentPackage(state.presetsState);
+            const active = currentPackage(state.workflowPresetsState);
             const payload = await postJson(`${ROUTE}/check`, {
                 root_id: requestedRootId(),
                 model_root: rootWidget?.value || "",
-                presets_state: state.presetsState,
+                presets_state: state.workflowPresetsState,
                 package: active,
-            });
-            if (sequence !== state.refreshSequence) {
-                return;
-            }
-            renderRoots(payload);
-            renderFiles(payload.files || []);
-            const total = (payload.files || []).length;
-            const existing = (payload.files || []).filter((file) => file.status === "exists").length;
-            setProgress(existing, total);
-            setStatus(existing === total ? "All files found. Press R if model lists need refresh." : "Open missing links, then move files to the shown paths.");
-        } catch (error) {
-            if (sequence !== state.refreshSequence) {
-                return;
-            }
-            setStatus(error.message || String(error), true);
-        }
+            }, signal);
+            return payload;
+        }, {
+            apply(payload) {
+                const invalidExplicitFallback = payload.selection_mode === "auto"
+                    && payload.selection_reason === "invalid_explicit_root_fallback";
+                if (invalidExplicitFallback) {
+                    resetRootToAuto();
+                }
+                renderRoots(payload);
+                renderFiles(payload.files || []);
+                const total = (payload.files || []).length;
+                const existing = Number.isFinite(payload.selected_root_existing_count)
+                    ? payload.selected_root_existing_count
+                    : (payload.files || []).filter((file) => (file.local_status || file.status) === "exists").length;
+                setProgress(existing, total);
+                if (invalidExplicitFallback) {
+                    setStatus("Selected root is unavailable. Using the best detected root.");
+                } else {
+                    setStatus(existing === total ? "All files found. Press R if model lists need refresh." : "Open missing links, then move files to the shown paths.");
+                }
+            },
+            onError(error) {
+                setStatus(error.message || String(error), true);
+            },
+        });
     }
 
     async function resolveCivitaiUrl(url) {
@@ -648,23 +727,28 @@ function buildUi(node, rootWidget, presetsWidget) {
         const editingDefaultPreset = state.editorPresetId === DEFAULT_PACKAGE.id;
         const requestedId = normalized.id || slugify(normalized.title);
         const addingPreset = !state.editorPresetId;
+        const latestLibrary = readPresetLibraryState();
+        const latestView = mergePresetLibraryState(state.workflowPresetsState, latestLibrary);
+        state.libraryPresetsState = latestLibrary;
         const packageId = editingDefaultPreset || addingPreset
-            ? uniquePresetId(requestedId === DEFAULT_PACKAGE.id ? `${DEFAULT_PACKAGE.id}_custom` : requestedId, state.presetsState.presets)
+            ? uniquePresetId(requestedId === DEFAULT_PACKAGE.id ? `${DEFAULT_PACKAGE.id}_custom` : requestedId, latestView.presets)
             : state.editorPresetId;
         normalized.id = packageId;
 
-        const presets = ensureDefaultPreset(state.presetsState.presets);
+        const presets = ensureDefaultPreset(state.workflowPresetsState.presets);
         const existingIndex = presets.findIndex((item) => item.id === packageId);
         if (existingIndex >= 0) {
             presets[existingIndex] = normalized;
         } else {
             presets.push(normalized);
         }
-        state.presetsState = {
+        state.workflowPresetsState = {
             active_preset_id: packageId,
             presets,
         };
-        writePresetsState(presetsWidget, state.presetsState);
+        writeWorkflowPresetsState(presetsWidget, state.workflowPresetsState);
+        state.libraryPresetsState = writePresetLibraryItem(normalized);
+        syncPresetView();
         markWorkflowDirty();
         state.editorPresetId = packageId;
         setEditingMode(false);
@@ -692,21 +776,22 @@ function buildUi(node, rootWidget, presetsWidget) {
         presetMenu.style.display = presetMenu.style.display === "none" ? "block" : "none";
     });
     addPresetButton.addEventListener("click", openNewPresetEditor);
-    document.addEventListener("click", () => {
+    scope.addEventListener(document, "click", () => {
         presetMenu.style.display = "none";
+        closeModelPathMenus(root);
     });
     editButton.addEventListener("click", () => {
-        state.editorPresetId = currentPackage(state.presetsState).id;
+        state.editorPresetId = currentPackage(state.workflowPresetsState).id;
         setEditingMode(!state.editing);
     });
 
     renderPresetButton();
-    editor.load(currentPackage(state.presetsState));
+    editor.load(currentPackage(state.workflowPresetsState));
     setEditingMode(false);
     return { root, refreshInfo, computeSize, applyNodeSize, reloadFromWidgets };
 }
 
-function buildEditor(readPackage, getModelSubdirs, resolveCivitaiUrl, onSave, onLayoutChange) {
+function buildEditor(readPackage, getModelSubdirs, resolveCivitaiUrl, onSave, onLayoutChange, scope) {
     const root = document.createElement("div");
     root.style.cssText = `
         display:flex;
@@ -732,10 +817,18 @@ function buildEditor(readPackage, getModelSubdirs, resolveCivitaiUrl, onSave, on
 
     const rows = document.createElement("div");
     rows.style.cssText = "display:flex; flex-direction:column; gap:9px;";
-    const scheduleLayout = () => requestAnimationFrame(() => onLayoutChange?.(rows.children.length));
+    const scheduleLayout = () => {
+        if (scope?.disposed) {
+            return;
+        }
+        if (scope?.requestAnimationFrame) {
+            scope.requestAnimationFrame(() => onLayoutChange?.(rows.children.length));
+        } else {
+            requestAnimationFrame(() => onLayoutChange?.(rows.children.length));
+        }
+    };
     root.addEventListener("deno-layout-change", scheduleLayout);
-    const observer = new MutationObserver(scheduleLayout);
-    observer.observe(rows, { childList: true });
+    scope?.observeMutation?.(rows, scheduleLayout, { childList: true });
 
     const actions = document.createElement("div");
     actions.style.cssText = "display:flex; gap:8px; align-items:center;";
@@ -753,7 +846,7 @@ function buildEditor(readPackage, getModelSubdirs, resolveCivitaiUrl, onSave, on
         rows.replaceChildren();
         const files = packageData.files.length ? packageData.files : [{ url: "", target_subdir: "checkpoints", filename: "", size: 0 }];
         for (const file of files) {
-            rows.append(createFileEditorRow(file, rows.children.length + 1, getModelSubdirs(), resolveCivitaiUrl));
+            rows.append(createFileEditorRow(file, rows.children.length + 1, getModelSubdirs(), resolveCivitaiUrl, scope));
         }
         renumberRows(rows);
         scheduleLayout();
@@ -774,7 +867,7 @@ function buildEditor(readPackage, getModelSubdirs, resolveCivitaiUrl, onSave, on
     }
 
     addButton.addEventListener("click", () => {
-        rows.append(createFileEditorRow({ url: "", target_subdir: "checkpoints", filename: "", size: 0 }, rows.children.length + 1, getModelSubdirs(), resolveCivitaiUrl));
+        rows.append(createFileEditorRow({ url: "", target_subdir: "checkpoints", filename: "", size: 0 }, rows.children.length + 1, getModelSubdirs(), resolveCivitaiUrl, scope));
         renumberRows(rows);
         scheduleLayout();
     });
@@ -834,7 +927,7 @@ function buildExampleGuide(onUseExample) {
     return guide;
 }
 
-function createFileEditorRow(file, index, modelSubdirs = [], resolveCivitaiUrl = null) {
+function createFileEditorRow(file, index, modelSubdirs = [], resolveCivitaiUrl = null, scope = null) {
     const row = document.createElement("div");
     row.style.cssText = `
         display:flex;
@@ -870,7 +963,7 @@ function createFileEditorRow(file, index, modelSubdirs = [], resolveCivitaiUrl =
     const pathGrid = document.createElement("div");
     pathGrid.style.cssText = "display:grid; grid-template-columns:0.9fr 1fr; gap:6px;";
 
-    const targetSubdir = createModelPathField(file.target_subdir || "checkpoints", modelSubdirs);
+    const targetSubdir = createModelPathField(file.target_subdir || "checkpoints", modelSubdirs, scope);
 
     const filename = createLabeledField("File name", "for target path only; exact match not required");
     filename.input.dataset.field = "filename";
@@ -913,7 +1006,12 @@ function createFileEditorRow(file, index, modelSubdirs = [], resolveCivitaiUrl =
         const rawUrl = url.input.value.trim();
         if (!rawUrl) {
             civitaiButton.textContent = "No URL";
-            setTimeout(() => { civitaiButton.textContent = "Civitai"; }, 900);
+            const resetText = () => { civitaiButton.textContent = "Civitai"; };
+            if (scope?.setTimeout) {
+                scope.setTimeout(resetText, 900);
+            } else {
+                setTimeout(resetText, 900);
+            }
             return;
         }
         civitaiButton.disabled = true;
@@ -938,10 +1036,15 @@ function createFileEditorRow(file, index, modelSubdirs = [], resolveCivitaiUrl =
             console.warn("[DENO] Civitai link conversion failed:", error);
             civitaiButton.textContent = "Fail";
         } finally {
-            setTimeout(() => {
+            const resetButton = () => {
                 civitaiButton.disabled = false;
                 civitaiButton.textContent = "Civitai";
-            }, 900);
+            };
+            if (scope?.setTimeout) {
+                scope.setTimeout(resetButton, 900);
+            } else {
+                setTimeout(resetButton, 900);
+            }
         }
     };
     urlRow.append(url.root, civitaiButton);
@@ -981,7 +1084,7 @@ function resolveCivitaiLocally(rawUrl) {
     };
 }
 
-function createModelPathField(value, modelSubdirs = []) {
+function createModelPathField(value, modelSubdirs = [], scope = null) {
     const root = document.createElement("div");
     root.style.cssText = "display:flex; flex-direction:column; gap:4px; min-width:0; position:relative;";
     const label = document.createElement("div");
@@ -1053,14 +1156,11 @@ function createModelPathField(value, modelSubdirs = []) {
     button.addEventListener("click", (event) => {
         event.preventDefault();
         event.stopPropagation();
-        closeModelPathMenus(menu);
+        closeModelPathMenus(root.closest("[data-deno-ltx-downloader-panel]") || root, menu);
         menu.style.display = menu.style.display === "none" ? "block" : "none";
     });
     customInput.addEventListener("input", () => {
         valueInput.value = "";
-    });
-    document.addEventListener("click", () => {
-        menu.style.display = "none";
     });
 
     root.append(label, button, menu, valueInput, customInput);
@@ -1115,9 +1215,9 @@ function createMenuButton(label, onClick, active = false) {
     return button;
 }
 
-function closeModelPathMenus(exceptMenu = null) {
-    const owner = exceptMenu?.ownerDocument || document;
-    owner.querySelectorAll("[data-field='target_subdir_menu']").forEach((menu) => {
+function closeModelPathMenus(ownerRoot, exceptMenu = null) {
+    const owner = ownerRoot?.querySelectorAll ? ownerRoot : null;
+    owner?.querySelectorAll("[data-field='target_subdir_menu']").forEach((menu) => {
         if (menu !== exceptMenu) {
             menu.style.display = "none";
         }
@@ -1278,75 +1378,58 @@ function prettyBytes(value) {
     return "";
 }
 
-function readPresetsState(widget) {
+function readWorkflowPresetsState(widget) {
     let widgetState = null;
     try {
         widgetState = normalizePresetsState(JSON.parse(widget?.value || ""));
     } catch (_error) {
         widgetState = normalizePresetsState(DEFAULT_STATE);
     }
-    const storedState = readStoredPresetsState();
-    if (storedState && hasCustomPresets(storedState)) {
-        const mergedState = mergePresetLibrary(widgetState, storedState);
-        if (widget && JSON.stringify(normalizePresetsState(widgetState)) !== JSON.stringify(mergedState)) {
-            widget.value = JSON.stringify(mergedState, null, 2);
-        }
-        return mergedState;
-    }
     return widgetState;
 }
 
-function writePresetsState(widget, value) {
+function writeWorkflowPresetsState(widget, value) {
     const normalized = normalizePresetsState(value);
     if (widget) {
         widget.value = JSON.stringify(normalized, null, 2);
         widget.callback?.(widget.value);
     }
-    writeStoredPresetsState(normalized);
     return normalized;
 }
 
-function readStoredPresetsState() {
-    for (const key of [PRESET_STORAGE_KEY, ...LEGACY_PRESET_STORAGE_KEYS]) {
-        try {
-            const raw = localStorage.getItem(key);
-            if (!raw) {
-                continue;
-            }
-            const stored = normalizePresetsState(JSON.parse(raw));
-            return {
-                active_preset_id: DEFAULT_PACKAGE.id,
-                presets: stored.presets,
-            };
-        } catch (_error) {
-            // Ignore stale browser storage and keep the workflow as authority.
-        }
-    }
-    return null;
+function readPresetLibraryState() {
+    return readVersionedJsonStorage({
+        storage: window.localStorage,
+        currentKey: PRESET_LIBRARY_STORAGE_KEY,
+        legacyKeys: LEGACY_PRESET_STORAGE_KEYS,
+        normalize: normalizePresetLibraryState,
+        fallback: normalizePresetLibraryState(),
+    });
 }
 
-function writeStoredPresetsState(value) {
-    try {
-        const normalized = normalizePresetsState(value);
-        localStorage.setItem(PRESET_STORAGE_KEY, JSON.stringify({
-            active_preset_id: DEFAULT_PACKAGE.id,
-            presets: normalized.presets,
-        }));
-    } catch (_error) {
-        // Browser storage may be unavailable in hardened profiles; the workflow widget still saves.
-    }
+function writePresetLibraryState(value) {
+    const normalized = normalizePresetLibraryState(value);
+    writeJsonStorage(window.localStorage, PRESET_LIBRARY_STORAGE_KEY, normalized);
+    return normalized;
 }
 
-function mergePresetLibrary(workflowState, storedState) {
+function writePresetLibraryItem(packageValue) {
+    const latestLibrary = readPresetLibraryState();
+    const presets = upsertLibraryItem(latestLibrary.presets, normalizePackage(packageValue), {
+        clone: cloneSerializableValue,
+    });
+    return writePresetLibraryState({
+        schema_version: PRESET_LIBRARY_SCHEMA_VERSION,
+        presets,
+    });
+}
+
+function mergePresetLibraryState(workflowState, libraryState) {
     const workflow = normalizePresetsState(workflowState);
-    const stored = normalizePresetsState(storedState);
-    const byId = new Map(workflow.presets.map((item) => [item.id, item]));
-    for (const item of stored.presets) {
-        if (item.id !== DEFAULT_PACKAGE.id && !byId.has(item.id)) {
-            byId.set(item.id, item);
-        }
-    }
-    const presets = Array.from(byId.values());
+    const library = normalizePresetLibraryState(libraryState);
+    const presets = mergeLibraryByStableId(workflow.presets, library.presets, {
+        clone: cloneSerializableValue,
+    });
     const activeId = presets.some((item) => item.id === workflow.active_preset_id)
         ? workflow.active_preset_id
         : DEFAULT_PACKAGE.id;
@@ -1356,8 +1439,12 @@ function mergePresetLibrary(workflowState, storedState) {
     });
 }
 
-function hasCustomPresets(state) {
-    return normalizePresetsState(state).presets.some((item) => item.id !== DEFAULT_PACKAGE.id);
+function normalizePresetLibraryState(value = {}) {
+    const presets = Array.isArray(value.presets) ? value.presets.map(normalizePackage) : [];
+    return {
+        schema_version: PRESET_LIBRARY_SCHEMA_VERSION,
+        presets: presets.filter((item) => item.id !== DEFAULT_PACKAGE.id),
+    };
 }
 
 function normalizePresetsState(value = {}) {

--- a/web/js/deno_ltx_prompt_guide.js
+++ b/web/js/deno_ltx_prompt_guide.js
@@ -1,8 +1,18 @@
 import { app } from "../../scripts/app.js";
+import {
+    applyOrderedWidgetValues,
+    canonicalOrderedSerializationValues,
+    findWidget,
+} from "./deno_frontend_core/widget_state.js";
+import {
+    createExactWidgetValueShapeMigration,
+    expandCanonicalValuesForGeneratedSlots,
+    installWorkflowWidgetMigration,
+} from "./deno_frontend_core/workflow_migration.js";
 
 const NODE_NAME = "DenoLTXPromptGuide";
 const GENERATED_PREFIX = "deno_ltx_prompt_guide_";
-const SAVE_RESTORE_REV = "ltx-prompt-guide-save-reload-v1";
+const SAVE_RESTORE_REV = "ltx-prompt-guide-save-reload-v2";
 const PROMPT_MIN_HEIGHT = 50;
 const NEGATIVE_PROMPT_DEFAULT_HEIGHT = 110;
 const NEGATIVE_PROMPT_MIN_HEIGHT = 80;
@@ -29,43 +39,26 @@ const LANGUAGE_PROFILES = {
 // The current node keeps those display widgets as serialize:false custom
 // widgets, so it only expects the 5 real widget values:
 //   [positive_prompt, language, frame_rate, show_negative_prompt, negative_prompt]
-// ComfyUI graph save filters serialize:false generated widgets and writes the
-// 5 real values, but LiteGraph configure restores by the live widget order. By
-// the time configure runs, onNodeCreated may already have inserted the two
-// generated display widgets. Keep a 5-value core shape for saved workflows, and
-// expand only for the configure pass when generated widgets are present.
-const LTX_PROMPT_GUIDE_SERIALIZED_WIDGET_COUNT = 5;
+// Queue Prompt respects widget.options.serialize, but workflow persistence uses
+// widget.serialize and writes by live widget index before onSerialize runs. Keep
+// a 5-value core shape for saved workflows, expand only for the configure pass
+// when generated widgets are present, then compact again inside onSerialize.
+const LTX_PROMPT_GUIDE_WIDGET_SPECS = [
+    { name: "positive_prompt", defaultValue: "" },
+    { name: "language", defaultValue: LANGUAGE_AUTO, normalize: (value) => normalizeLanguage(value) },
+    { name: "frame_rate", defaultValue: 25, normalize: (value) => Number(value) || 25 },
+    { name: "show_negative_prompt", defaultValue: false, normalize: (value) => Boolean(value) },
+    { name: "negative_prompt", defaultValue: "" },
+];
+const LTX_PROMPT_GUIDE_GENERATED_WIDGET_SLOTS = [0, 4];
+const normalizeLtxPromptGuideWidgetValues = createExactWidgetValueShapeMigration({
+    canonicalCount: LTX_PROMPT_GUIDE_WIDGET_SPECS.length,
+    legacyGeneratedSlots: LTX_PROMPT_GUIDE_GENERATED_WIDGET_SLOTS,
+});
+const missingCanonicalWidgetWarnings = new WeakSet();
 
 function getNormalizedLtxPromptGuideSerializedValues(values) {
-    if (!Array.isArray(values)) {
-        return null;
-    }
-
-    // Legacy v0.3.8: two empty display-widget slots at index 0 and 4. Only
-    // remap this exact shape so we never reshuffle a current-layout array.
-    if (
-        values.length >= 7 &&
-        (values[0] === "" || values[0] == null) &&
-        (values[4] === "" || values[4] == null)
-    ) {
-        return [values[1], values[2], values[3], values[5], values[6]];
-    }
-
-    // Current layout already starts with the 5 real widget values; drop any
-    // trailing non-serialized leftovers without touching known-good values.
-    if (values.length >= LTX_PROMPT_GUIDE_SERIALIZED_WIDGET_COUNT) {
-        return values.slice(0, LTX_PROMPT_GUIDE_SERIALIZED_WIDGET_COUNT);
-    }
-
-    return null;
-}
-
-function normalizeLtxPromptGuideLegacyWidgetValues(info) {
-    const normalized = getNormalizedLtxPromptGuideSerializedValues(info?.widgets_values);
-    if (normalized) {
-        info.widgets_values = normalized;
-    }
-    return normalized;
+    return normalizeLtxPromptGuideWidgetValues(values);
 }
 
 function hasGeneratedPromptGuideWidgets(node) {
@@ -78,32 +71,17 @@ function getLtxPromptGuideConfigureWidgetValues(node, normalizedValues) {
     }
 
     if (!hasGeneratedPromptGuideWidgets(node)) {
-        return normalizedValues;
+        return [...normalizedValues];
     }
 
-    return [
-        "",
-        normalizedValues[0],
-        normalizedValues[1],
-        normalizedValues[2],
-        "",
-        normalizedValues[3],
-        normalizedValues[4],
-    ];
+    return expandCanonicalValuesForGeneratedSlots(
+        normalizedValues,
+        LTX_PROMPT_GUIDE_GENERATED_WIDGET_SLOTS,
+    );
 }
 
 function applyLtxPromptGuideSerializedValuesToWidgets(node, values) {
-    if (!node || !Array.isArray(values)) {
-        return;
-    }
-
-    const names = ["positive_prompt", "language", "frame_rate", "show_negative_prompt", "negative_prompt"];
-    for (let i = 0; i < names.length; i++) {
-        const widget = getWidget(node, names[i]);
-        if (widget) {
-            widget.value = values[i];
-        }
-    }
+    applyOrderedWidgetValues(node, LTX_PROMPT_GUIDE_WIDGET_SPECS, values);
 }
 
 function getLtxPromptGuideSerializedValuesFromWidgets(node) {
@@ -111,13 +89,20 @@ function getLtxPromptGuideSerializedValuesFromWidgets(node) {
         return null;
     }
 
-    return [
-        getWidgetValue(node, "positive_prompt", ""),
-        normalizeLanguage(getWidgetValue(node, "language", LANGUAGE_AUTO)),
-        Number(getWidgetValue(node, "frame_rate", 25)) || 25,
-        Boolean(getWidgetValue(node, "show_negative_prompt", false)),
-        getWidgetValue(node, "negative_prompt", ""),
-    ];
+    const missing = LTX_PROMPT_GUIDE_WIDGET_SPECS
+        .map((spec) => spec.name)
+        .filter((name) => !findWidget(node, name));
+    if (missing.length) {
+        if (!missingCanonicalWidgetWarnings.has(node)) {
+            missingCanonicalWidgetWarnings.add(node);
+            console.warn(
+                `[DENO] ${NODE_NAME} kept host workflow serialization because required widgets are missing: ${missing.join(", ")}`,
+            );
+        }
+        return null;
+    }
+
+    return canonicalOrderedSerializationValues(node, LTX_PROMPT_GUIDE_WIDGET_SPECS);
 }
 
 function syncLtxPromptGuideSerializedValues(node) {
@@ -134,23 +119,19 @@ app.registerExtension({
             return;
         }
 
-        const configure = nodeType.prototype.configure;
-        nodeType.prototype.configure = function (info) {
-            const normalized = normalizeLtxPromptGuideLegacyWidgetValues(info);
-            if (normalized) {
-                this.__denoLtxPromptGuideConfiguredWidgetValues = [...normalized];
-                info.widgets_values = getLtxPromptGuideConfigureWidgetValues(this, normalized);
-            }
-
-            const result = configure?.apply(this, arguments);
-            if (normalized) {
-                applyLtxPromptGuideSerializedValuesToWidgets(this, normalized);
-                syncLtxPromptGuideSerializedValues(this);
-                this.properties = this.properties || {};
-                this.properties.__deno_ltx_prompt_guide_save_restore = SAVE_RESTORE_REV;
-            }
-            return result;
-        };
+        installWorkflowWidgetMigration(nodeType, nodeData, {
+            nodeName: NODE_NAME,
+            pendingValuesKey: "__denoLtxPromptGuideConfiguredWidgetValues",
+            normalizeSerializedValues: getNormalizedLtxPromptGuideSerializedValues,
+            getConfigureWidgetValues: getLtxPromptGuideConfigureWidgetValues,
+            applyCanonicalValues(node, values) {
+                applyLtxPromptGuideSerializedValuesToWidgets(node, values);
+                syncLtxPromptGuideSerializedValues(node);
+                node.properties = node.properties || {};
+                node.properties.__deno_ltx_prompt_guide_save_restore = SAVE_RESTORE_REV;
+            },
+            getCanonicalSerializationValues: getLtxPromptGuideSerializedValuesFromWidgets,
+        });
 
         const onNodeCreated = nodeType.prototype.onNodeCreated;
         nodeType.prototype.onNodeCreated = function () {
@@ -601,7 +582,7 @@ function isNegativeOpen(node) {
 }
 
 function getWidget(node, name) {
-    return (node.widgets || []).find((widget) => widget.name === name);
+    return findWidget(node, name);
 }
 
 function getWidgetValue(node, name, fallback) {


### PR DESCRIPTION
## User-Visible Goal

Add a repository-local Codex autopilot harness so normal owner prompts can stay conversational while Codex maintains the internal task contract, deterministic gates, state checkpointing, and Draft PR review surface.

## Inferred Non-Goals

- No production node behavior changes.
- No version bump, Registry/Manager metadata change, release asset change, or public release.
- No paid API or model dependency.
- No modification to the existing Director/runtime worktrees.
- Root `AGENTS.md` remains local-only because the existing public-surface test forbids tracking it.

## Risk And Capability Tags

GREEN / harness.

## Official Runtime Baseline

This bootstrap changes operating surfaces only. Runtime behavior claims are out of scope.

## Saved-Workflow Impact

None expected. Product saved workflow behavior is untouched.

## Tests

- `python -m py_compile tools/codex_task.py tools/codex_gate.py .codex/hooks/common.py .codex/hooks/session_start.py .codex/hooks/user_prompt_submit.py .codex/hooks/pre_compact.py .codex/hooks/post_compact.py .codex/hooks/stop.py`
- `python -m pytest tests/codex_harness -q` -> 11 passed
- `python -m pytest tests/test_registry_metadata.py::test_public_git_surface_excludes_local_only_internal_docs -q` -> 1 passed
- `python -m pytest tests -q` -> 248 passed
- `git diff --cached --check`
- `python tools/codex_gate.py --mode local` -> evidence_status PASS, contract_status PASS

## Runtime Evidence

N/A. No product runtime behavior was changed.

## Unverified Or Out Of Scope

- Hook activation still requires one-time owner trust through Codex `/hooks` after review.
- Real future node tasks still need their own runtime evidence selected by the gate.

## Rollback

Revert commit `5da679d` to remove the harness files and restore the previous PR template/.gitignore behavior.

## Gate Result

- Evidence status: PASS
- Contract status: PASS
- Instruction budget: local AGENTS.md 3992 bytes, autoload 6976 bytes
- Generated SESSION_HANDOFF: 31 lines