### PR TITLE
Release 0.7.67 Local LLM and LTX guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This file intentionally stays short. Detailed engineering notes belong in privat
 
 ## Unreleased
 
+## 0.7.67 - 2026-07-03
+
+- Fixed `(Deno) Local LLM Loader` and `(Deno) Local LLM Reviewer` saved-workflow handling so provider URLs, prompts, thinking state, and reviewer state stay in the correct saved slots after workflow save, reload, copy, and provider changes.
+- Kept Local LLM server access local-first by default while allowing advanced users to opt in to a specific trusted LAN server with `DENO_LOCAL_LLM_ALLOWED_HOSTS=LAN-IP:port`.
+- Improved `(Deno) LTX High resolution Tiled Sampler` guide and mask conditioning stability with stricter spatial conditioning checks, clearer guide token-count mismatch errors, and pixel-mask crop validation.
+
 ## 0.7.66 - 2026-07-01
 
 - Fixed DENO Floating Tools Error Help so large ComfyUI failures keep the browser responsive, the report is prepared only when the user opens it, and the error icon returns to normal after the next confirmed idle run.

--- a/deno_local_llm_refiner.py
+++ b/deno_local_llm_refiner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import http.client
+import ipaddress
 import itertools
 from io import BytesIO
 import json
@@ -14,7 +15,7 @@ import re
 import threading
 import time
 import urllib.parse
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import numpy as np
 from PIL import Image
@@ -129,6 +130,7 @@ SHIFTED_MODEL_WIDGET_VALUES = {
     "ComfyUI VRAM",
     "Ollama Model",
     "LM Studio Model",
+    "Detected Models",
     "Legacy Model",
     "Custom Model",
     "Custom Server URL",
@@ -137,6 +139,9 @@ SHIFTED_MODEL_WIDGET_VALUES = {
 MISSING_SAVED_MODEL_PREFIX = "Missing saved model: "
 
 LOCAL_HOSTS = {"127.0.0.1", "localhost", "::1", "[::1]"}
+LOCAL_LLM_ALLOWED_HOSTS_ENV = "DENO_LOCAL_LLM_ALLOWED_HOSTS"
+LOCAL_LLM_BLOCKED_REMOTE_HOSTNAMES = {"metadata.google.internal"}
+LOCAL_LLM_BLOCKED_REMOTE_IPS = {ipaddress.ip_address("169.254.169.254")}
 PROGRESS_EVENT = "deno-local-llm-progress"
 THINK_TAG_RE = re.compile(r"<(?:think|thinking)>(.*?)</(?:think|thinking)>", re.IGNORECASE | re.DOTALL)
 FINAL_PROMPT_TAG_RE = re.compile(r"<final\\?_prompt>(.*?)</final\\?_prompt>", re.IGNORECASE | re.DOTALL)
@@ -159,17 +164,136 @@ def _json_response(payload: Dict[str, Any], status: int = 200):
     return web.json_response(payload, status=status)
 
 
+def _canonical_local_llm_host(host: str) -> str:
+    return str(host or "").strip().strip("[]").rstrip(".").lower()
+
+
+def _is_loopback_local_llm_host(host: str) -> bool:
+    return _canonical_local_llm_host(host) in {"127.0.0.1", "localhost", "::1"}
+
+
+LocalLLMIPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+
+
+def _local_llm_ip_literal(host: str) -> Optional[LocalLLMIPAddress]:
+    try:
+        return ipaddress.ip_address(_canonical_local_llm_host(host))
+    except ValueError:
+        return None
+
+
+def _is_allowed_lan_local_llm_address(address: LocalLLMIPAddress) -> bool:
+    return bool(
+        address.is_private
+        and not address.is_loopback
+        and not address.is_link_local
+        and not address.is_multicast
+        and not address.is_unspecified
+        and address not in LOCAL_LLM_BLOCKED_REMOTE_IPS
+    )
+
+
+def _default_local_llm_port(scheme: str) -> int:
+    return 443 if str(scheme or "").lower() == "https" else 80
+
+
+def _safe_local_llm_port(parsed: urllib.parse.ParseResult) -> int:
+    try:
+        return int(parsed.port or _default_local_llm_port(parsed.scheme))
+    except ValueError as exc:
+        raise RuntimeError("Local LLM server URL has an invalid port.") from exc
+
+
+def _is_blocked_remote_local_llm_host(host: str) -> bool:
+    normalized = _canonical_local_llm_host(host)
+    if normalized in LOCAL_LLM_BLOCKED_REMOTE_HOSTNAMES:
+        return True
+    address = _local_llm_ip_literal(normalized)
+    if address is None:
+        return False
+    return bool(
+        address in LOCAL_LLM_BLOCKED_REMOTE_IPS
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_unspecified
+    )
+
+
+def _parse_allowed_local_llm_host_token(token: str) -> Optional[Tuple[str, int]]:
+    value = str(token or "").strip()
+    if not value or "*" in value or "\\" in value:
+        return None
+    has_scheme = "://" in value
+    if has_scheme:
+        parsed = urllib.parse.urlparse(value)
+        if parsed.scheme not in {"http", "https"}:
+            return None
+        if parsed.path not in {"", "/"} or parsed.params or parsed.query or parsed.fragment:
+            return None
+    else:
+        if "/" in value:
+            return None
+        parsed = urllib.parse.urlparse(f"//{value}", scheme="http")
+    if parsed.username or parsed.password:
+        return None
+    host = _canonical_local_llm_host(parsed.hostname or "")
+    if not host or _is_loopback_local_llm_host(host) or _is_blocked_remote_local_llm_host(host):
+        return None
+    address = _local_llm_ip_literal(host)
+    if address is None or not _is_allowed_lan_local_llm_address(address):
+        return None
+    try:
+        port = parsed.port
+    except ValueError:
+        return None
+    if port is None:
+        if has_scheme:
+            port = _default_local_llm_port(parsed.scheme)
+        else:
+            return None
+    return str(address), int(port)
+
+
+def _allowed_remote_local_llm_hosts() -> Set[Tuple[str, int]]:
+    raw = os.environ.get(LOCAL_LLM_ALLOWED_HOSTS_ENV, "")
+    allowed: Set[Tuple[str, int]] = set()
+    for token in re.split(r"[,;\s]+", raw):
+        entry = _parse_allowed_local_llm_host_token(token)
+        if entry:
+            allowed.add(entry)
+    return allowed
+
+
+def _is_remote_local_llm_host_allowed(parsed: urllib.parse.ParseResult) -> bool:
+    host = _canonical_local_llm_host(parsed.hostname or "")
+    if not host or _is_blocked_remote_local_llm_host(host):
+        return False
+    address = _local_llm_ip_literal(host)
+    if address is None or not _is_allowed_lan_local_llm_address(address):
+        return False
+    return (str(address), _safe_local_llm_port(parsed)) in _allowed_remote_local_llm_hosts()
+
+
+def _remote_local_llm_allowlist_error() -> str:
+    return (
+        "Only local LLM servers are allowed for this DENO node by default. "
+        "Use 127.0.0.1 or localhost. "
+        f"To use a LAN LLM server, set {LOCAL_LLM_ALLOWED_HOSTS_ENV}=LAN-IP:port on the ComfyUI host. "
+        "Use only servers you own and trust; this opt-in is not stored in workflows."
+    )
+
+
 def _parse_local_llm_url(url: str) -> urllib.parse.ParseResult:
     parsed = urllib.parse.urlparse(str(url or "").strip())
     if parsed.scheme not in {"http", "https"}:
         raise RuntimeError("Use a local http:// or https:// server URL.")
-    host = parsed.hostname or ""
-    if host.lower() not in LOCAL_HOSTS:
-        raise RuntimeError(
-            "Only local LLM servers are allowed for this DENO node. "
-            "Use 127.0.0.1 or localhost."
-        )
-    return parsed
+    if parsed.username or parsed.password:
+        raise RuntimeError("Do not include username/password in a local LLM server URL.")
+    host = _canonical_local_llm_host(parsed.hostname or "")
+    _safe_local_llm_port(parsed)
+    if _is_loopback_local_llm_host(host) or _is_remote_local_llm_host_allowed(parsed):
+        return parsed
+    raise RuntimeError(_remote_local_llm_allowlist_error())
 
 
 def _assert_local_url(url: str) -> None:
@@ -183,9 +307,17 @@ def _open_local_llm_http_connection(
     host = parsed.hostname
     if not host:
         raise RuntimeError("Local LLM server URL is missing a host.")
-    port = parsed.port
+    canonical_host = _canonical_local_llm_host(host)
+    if canonical_host == "localhost":
+        connection_host = "127.0.0.1"
+    else:
+        address = _local_llm_ip_literal(canonical_host)
+        if address is None:
+            raise RuntimeError(_remote_local_llm_allowlist_error())
+        connection_host = str(address)
+    port = _safe_local_llm_port(parsed)
     connection_cls = http.client.HTTPSConnection if parsed.scheme == "https" else http.client.HTTPConnection
-    return connection_cls(host, port, timeout=timeout)
+    return connection_cls(connection_host, port, timeout=timeout)
 
 
 def _strip_trailing_slash(url: str) -> str:
@@ -1932,7 +2064,9 @@ class DenoLocalLLMRefiner:
         "Designed for prompt-batcher workflows: use the in-node Prompt field or connect STRING into Prompt, "
         "and this node processes the whole prompt batch in one execution so the local LLM can stay "
         "loaded until the batch is complete.\n\n"
-        "Only localhost / 127.0.0.1 servers are allowed."
+        "Only localhost / 127.0.0.1 servers are allowed by default. "
+        "Advanced users can allow a specific LAN LLM server with "
+        f"{LOCAL_LLM_ALLOWED_HOSTS_ENV}=LAN-IP:port on the ComfyUI host; this opt-in is not stored in workflows."
     )
 
     @classmethod

--- a/deno_ltx_tiled_nodes.py
+++ b/deno_ltx_tiled_nodes.py
@@ -32,6 +32,30 @@ class UnsupportedTiledConditioning(RuntimeError):
     """Raised when a conditioning feature cannot be spatially tiled safely."""
 
 
+KNOWN_SPATIAL_MODEL_COND_KEYS = frozenset({
+    "guide_mask",
+    "mask",
+    "pixel_mask",
+})
+
+KNOWN_NON_SPATIAL_MODEL_COND_KEYS = frozenset({
+    "attention_mask",
+    "c_crossattn",
+    "clip",
+    "clip_g",
+    "clip_l",
+    "crossattn",
+    "frame_rate",
+    "guide_attention_entries",
+    "keyframe_idxs",
+    "latent_shapes",
+    "pooled_output",
+    "ref_audio",
+})
+
+UPSCALER_MEMORY_BYTES_PER_TILE_ELEMENT = 3000.0
+
+
 def _runtime_module(name: str):
     return importlib.import_module(name)
 
@@ -112,6 +136,80 @@ def _crop_spatial_tensor(
     return tensor
 
 
+def _normalize_model_cond_key(key: Any) -> str:
+    return str(key).lower()
+
+
+def _crop_known_spatial_tensor(
+    key: Any,
+    tensor: torch.Tensor,
+    spec: TileSpec,
+    full_height: int,
+    full_width: int,
+) -> torch.Tensor:
+    if tensor.ndim < 4:
+        raise UnsupportedTiledConditioning(
+            f"model_conds[{key!r}] must be a spatial tensor with at least "
+            f"4 dimensions, got {tuple(tensor.shape)}."
+        )
+
+    spatial_shape = tuple(tensor.shape[-2:])
+    if spatial_shape == (full_height, full_width):
+        return tensor[..., spec.y0:spec.y1, spec.x0:spec.x1].contiguous()
+    if spatial_shape == (spec.height, spec.width):
+        return tensor
+
+    raise UnsupportedTiledConditioning(
+        f"model_conds[{key!r}] has unsupported spatial shape {spatial_shape}; "
+        f"expected full latent {full_height}x{full_width} or tile "
+        f"{spec.height}x{spec.width}."
+    )
+
+
+def _crop_known_spatial_value(
+    key: Any,
+    value: Any,
+    spec: TileSpec,
+    full_height: int,
+    full_width: int,
+) -> Any:
+    if isinstance(value, torch.Tensor):
+        return _crop_known_spatial_tensor(key, value, spec, full_height, full_width)
+
+    if isinstance(value, list):
+        if not all(isinstance(item, torch.Tensor) for item in value):
+            raise UnsupportedTiledConditioning(
+                f"model_conds[{key!r}] must be a tensor or a list of tensors "
+                "when used as spatial conditioning."
+            )
+        return [
+            _crop_known_spatial_tensor(key, item, spec, full_height, full_width)
+            for item in value
+        ]
+
+    if value is None:
+        return value
+
+    raise UnsupportedTiledConditioning(
+        f"model_conds[{key!r}] must be tensor-like spatial conditioning, "
+        f"got {type(value).__name__}."
+    )
+
+
+def _debug_unknown_model_cond_tensor(
+    key: Any,
+    value: torch.Tensor,
+    spec: TileSpec,
+    full_height: int,
+    full_width: int,
+) -> None:
+    print(
+        "[Deno LTX] Leaving unknown model_conds tensor unmodified: "
+        f"key={key!r}, shape={tuple(value.shape)}, "
+        f"full={full_height}x{full_width}, tile={spec.height}x{spec.width}."
+    )
+
+
 def _guide_entries_from_model_conds(model_conds: dict[str, Any]) -> list[dict] | None:
     wrapped = model_conds.get("guide_attention_entries")
     entries = _cond_payload(wrapped)
@@ -127,8 +225,19 @@ def _guide_token_counts(
     full_area = full_height * full_width
     if entries:
         counts = [int(entry.get("pre_filter_count", 0)) for entry in entries]
-        if all(count > 0 for count in counts) and sum(counts) == total_tokens:
-            return counts
+        if not all(count > 0 for count in counts):
+            raise UnsupportedTiledConditioning(
+                "guide_attention_entries contains invalid pre_filter_count "
+                f"values: {counts}."
+            )
+        count_sum = sum(counts)
+        if count_sum != total_tokens:
+            raise UnsupportedTiledConditioning(
+                "guide_attention_entries token count mismatch: "
+                f"sum(pre_filter_count)={count_sum}, "
+                f"keyframe_idxs tokens={total_tokens}."
+            )
+        return counts
 
     if total_tokens % full_area != 0:
         raise UnsupportedTiledConditioning(
@@ -254,10 +363,19 @@ def _crop_guide_entries(
             if py1 <= py0 or px1 <= px0:
                 raise UnsupportedTiledConditioning(
                     "guide_attention_entries pixel_mask is too small to crop for "
-                    f"tile {spec.index}: mask={mask_h}x{mask_w}, "
+                    f"tile r{spec.row}c{spec.col}: mask={mask_h}x{mask_w}, "
                     f"latent={full_height}x{full_width}."
                 )
-            original["pixel_mask"] = pixel_mask[..., py0:py1, px0:px1].contiguous()
+            cropped_pixel_mask = pixel_mask[..., py0:py1, px0:px1].contiguous()
+            expected_mask_shape = (py1 - py0, px1 - px0)
+            if tuple(cropped_pixel_mask.shape[-2:]) != expected_mask_shape:
+                raise UnsupportedTiledConditioning(
+                    "guide_attention_entries pixel_mask crop produced an "
+                    "unexpected spatial shape: "
+                    f"got={tuple(cropped_pixel_mask.shape[-2:])}, "
+                    f"expected={expected_mask_shape}."
+                )
+            original["pixel_mask"] = cropped_pixel_mask
 
         result.append(original)
     return result
@@ -269,6 +387,7 @@ def _crop_condition_list_for_tile(
     full_height: int,
     full_width: int,
     model: Any,
+    debug: bool = False,
 ) -> list[dict] | None:
     if cond_list is None:
         return None
@@ -338,9 +457,10 @@ def _crop_condition_list_for_tile(
         guide_entries = _guide_entries_from_model_conds(model_conds)
 
         for key, wrapped in list(model_conds.items()):
-            value = getattr(wrapped, "cond", None)
+            value = _cond_payload(wrapped)
+            normalized_key = _normalize_model_cond_key(key)
 
-            if key == "keyframe_idxs" and isinstance(value, torch.Tensor):
+            if normalized_key == "keyframe_idxs" and isinstance(value, torch.Tensor):
                 cropped = _crop_keyframe_indices(
                     value,
                     spec,
@@ -349,18 +469,44 @@ def _crop_condition_list_for_tile(
                     guide_entries,
                     model,
                 )
-                model_conds[key] = _copy_cond_value(wrapped, cropped)
+                model_conds[key] = _copy_conditioning_value(wrapped, cropped)
                 continue
 
-            if key == "guide_attention_entries" and isinstance(value, list):
+            if normalized_key == "guide_attention_entries" and isinstance(value, list):
                 cropped_entries = _crop_guide_entries(value, spec, full_height, full_width, model)
-                model_conds[key] = _copy_cond_value(wrapped, cropped_entries)
+                model_conds[key] = _copy_conditioning_value(wrapped, cropped_entries)
+                continue
+
+            if normalized_key in KNOWN_SPATIAL_MODEL_COND_KEYS:
+                cropped = _crop_known_spatial_value(
+                    key,
+                    value,
+                    spec,
+                    full_height,
+                    full_width,
+                )
+                if cropped is not value:
+                    model_conds[key] = _copy_conditioning_value(wrapped, cropped)
+                continue
+
+            if normalized_key in KNOWN_NON_SPATIAL_MODEL_COND_KEYS:
                 continue
 
             if isinstance(value, torch.Tensor):
                 cropped = _crop_spatial_tensor(value, spec, full_height, full_width)
                 if cropped is not value:
-                    model_conds[key] = _copy_cond_value(wrapped, cropped)
+                    model_conds[key] = _copy_conditioning_value(wrapped, cropped)
+                elif debug and value.ndim >= 4 and tuple(value.shape[-2:]) != (
+                    spec.height,
+                    spec.width,
+                ):
+                    _debug_unknown_model_cond_tensor(
+                        key,
+                        value,
+                        spec,
+                        full_height,
+                        full_width,
+                    )
                 continue
 
             if isinstance(value, list) and value and all(isinstance(item, torch.Tensor) for item in value):
@@ -369,7 +515,7 @@ def _crop_condition_list_for_tile(
                     for item in value
                 ]
                 if any(new is not old for new, old in zip(cropped_items, value)):
-                    model_conds[key] = _copy_cond_value(wrapped, cropped_items)
+                    model_conds[key] = _copy_conditioning_value(wrapped, cropped_items)
 
         cloned["model_conds"] = model_conds
         cropped_list.append(cloned)
@@ -383,9 +529,17 @@ def _crop_conds_for_tile(
     full_height: int,
     full_width: int,
     model: Any,
+    debug: bool = False,
 ) -> list[list[dict] | None]:
     return [
-        _crop_condition_list_for_tile(cond_list, spec, full_height, full_width, model)
+        _crop_condition_list_for_tile(
+            cond_list,
+            spec,
+            full_height,
+            full_width,
+            model,
+            debug=debug,
+        )
         for cond_list in conds
     ]
 
@@ -716,7 +870,10 @@ class DenoLTXTiledSpatialUpscaler:
         max_tile_w = max(spec.width for spec in plan)
         model_bytes = model_management.module_size(upscale_model)
         tile_elements = batch * channels * frames * max_tile_h * max_tile_w
-        model_management.free_memory(model_bytes + tile_elements * 3000.0, device)
+        model_management.free_memory(
+            model_bytes + tile_elements * UPSCALER_MEMORY_BYTES_PER_TILE_ELEMENT,
+            device,
+        )
 
         if debug:
             print(
@@ -943,7 +1100,14 @@ class StepFusedAVTilePredictor:
         for spec in self.plan:
             tile_video = video_x[:, :, :, spec.y0:spec.y1, spec.x0:spec.x1].contiguous()
             tile_packed, tile_shapes = _pack_latents([tile_video, audio_x])
-            tile_conds = _crop_conds_for_tile(conds, spec, self.full_height, self.full_width, model)
+            tile_conds = _crop_conds_for_tile(
+                conds,
+                spec,
+                self.full_height,
+                self.full_width,
+                model,
+                debug=self.debug,
+            )
             tile_conds = _replace_latent_shapes_in_conds(tile_conds, tile_shapes)
 
             tile_options = _clone_model_options(model_options)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "deno-custom-nodes"
 description = "DENO RTX node pack for ComfyUI: Ideogram Director visual JSON/bbox prompt builder, Local LLM Loader and Reviewer helpers, GPT/Gemini-ready Error Help reports, Prompt Only final prompt extraction, RTX Video Super Resolution, RTX Super Resolution, Video SR/VSR, NVIDIA VFX/nvvfx, RTX upscale helpers, LTX 2.3 workflows, LTX tiled second-pass refinement helpers, Bernini Prompt Guide, audio/image review gates, Bernini conditioning helpers, Wan 2.2 reference video edit workflows, image and video compare, video preview, Video to GIF/WebP tools, multi-image loading, resize tools, LoRA/model helpers, prompt guides, and visual workflow utilities."
-version = "0.7.66"
+version = "0.7.67"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = []

--- a/tests/test_image_resize_node.py
+++ b/tests/test_image_resize_node.py
@@ -5269,6 +5269,40 @@ def test_local_llm_refiner_normalizes_prompts_seed_modes_and_local_urls():
     assert calls == []
 
 
+def test_local_llm_refiner_lan_allowlist_requires_exact_private_ip_host_port(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+
+    monkeypatch.delenv("DENO_LOCAL_LLM_ALLOWED_HOSTS", raising=False)
+    assert module._parse_local_llm_url("http://127.0.0.1:8000/v1").hostname == "127.0.0.1"
+    with pytest.raises(RuntimeError, match="Only local LLM servers"):
+        module._parse_local_llm_url("http://192.168.100.100:8080/v1")
+
+    monkeypatch.setenv("DENO_LOCAL_LLM_ALLOWED_HOSTS", "192.168.100.100:8080")
+    parsed = module._parse_local_llm_url("http://192.168.100.100:8080/v1")
+    assert parsed.hostname == "192.168.100.100"
+    assert parsed.port == 8080
+    with pytest.raises(RuntimeError, match="Only local LLM servers"):
+        module._parse_local_llm_url("http://192.168.100.100:8081/v1")
+
+    monkeypatch.setenv(
+        "DENO_LOCAL_LLM_ALLOWED_HOSTS",
+        "192.168.100.*:8080 192.168.100.0/24:8080 lan-box.local:8080 metadata.google.internal:80 169.254.169.254:80 169.254.1.2:8080",
+    )
+    for blocked_url in [
+        "http://192.168.100.100:8080/v1",
+        "http://lan-box.local:8080/v1",
+        "http://metadata.google.internal/v1",
+        "http://169.254.169.254/v1",
+        "http://169.254.1.2:8080/v1",
+    ]:
+        with pytest.raises(RuntimeError, match="Only local LLM servers"):
+            module._parse_local_llm_url(blocked_url)
+
+    with pytest.raises(RuntimeError, match="username/password"):
+        module._parse_local_llm_url("http://user:pass@127.0.0.1:8000/v1")
+
+
 def test_resize_box_declares_comfyui_contract():
     package = load_package()
     node_cls = package.NODE_CLASS_MAPPINGS["DenoResolutionSetup"]

--- a/tests/test_local_llm_reviewer_graph_transform.py
+++ b/tests/test_local_llm_reviewer_graph_transform.py
@@ -107,6 +107,36 @@ def test_reviewer_graph_transform_submit_modes(tmp_path):
             const api = context.capturedApi;
             assert(api, "reviewer graph test API was not exposed");
             assert(context.capturedExtension, "Local LLM extension must register for configure/onSerialize hooks");
+            const normalizedReviewerValues = api.normalizeReviewerSerializedValues(["Pass", true, "REVIEWER STATE", null, null]);
+            assert(normalizedReviewerValues.length === 3, "Reviewer serialization must keep only the three backend widgets");
+            assert(normalizedReviewerValues[0] === "Pass", "Reviewer serialization must preserve Pass mode");
+            assert(normalizedReviewerValues[1] === true, "Reviewer serialization must preserve approve_once");
+            assert(normalizedReviewerValues[2] === "REVIEWER STATE", "Reviewer serialization must preserve reviewer_state");
+            const reviewerInfo = {{ widgets_values: ["Review", false, "STATE", null, null] }};
+            api.normalizeReviewerWidgetValues(reviewerInfo);
+            assert(reviewerInfo.widgets_values.length === 3, "Reviewer widget-value normalizer must strip generated custom widget nulls");
+            const gateNodeType = {{
+                prototype: {{
+                    configure(info) {{
+                        this.__baseConfigureValues = [...info.widgets_values];
+                        return "configured";
+                    }},
+                    onSerialize(info) {{
+                        info.widgets_values = ["Review", false, "SERIALIZED STATE", null, null];
+                        return "serialized";
+                    }},
+                }},
+            }};
+            context.capturedExtension.beforeRegisterNodeDef(gateNodeType, {{ name: "DenoAIReviewGate" }});
+            const configuredGate = {{}};
+            const configuredInfo = {{ widgets_values: ["Pass", false, "CONFIGURED STATE", null, null] }};
+            assert(gateNodeType.prototype.configure.call(configuredGate, configuredInfo) === "configured", "Reviewer configure wrapper must preserve the original return");
+            assert(configuredInfo.widgets_values.length === 3, "Reviewer configure wrapper must compact saved widget values before restore");
+            assert(configuredGate.__baseConfigureValues.length === 3, "Reviewer base configure must only receive canonical widget values");
+            const serializedGateInfo = {{ widgets_values: [] }};
+            assert(gateNodeType.prototype.onSerialize.call({{}}, serializedGateInfo) === "serialized", "Reviewer serialize wrapper must preserve the original return");
+            assert(serializedGateInfo.widgets_values.length === 3, "Reviewer serialize wrapper must strip generated widget nulls");
+            assert(serializedGateInfo.widgets_values[2] === "SERIALIZED STATE", "Reviewer serialize wrapper must keep reviewer_state");
             assert(api.previewTextDialogTitle({{ error: "bad" }}, "result") === "Error", "Result popup title must switch to Error when node state has an error");
             assert(api.previewTextDialogBody({{ answer: "final answer" }}, "result") === "final answer", "Result popup must read live answer text from node state");
             assert(api.previewTextDialogBody({{ thinking: "live thinking" }}, "thinking") === "live thinking", "Thinking popup must read live thinking text from node state");
@@ -460,6 +490,11 @@ def test_reviewer_graph_transform_submit_modes(tmp_path):
             assert(normalizedCloneClipboard[7] === 9876, "Loader clone clipboard serialization must keep seed in the seed slot");
             assert(normalizedCloneClipboard[10] === 5, "Loader clone clipboard serialization must recover keep minutes after clone shifting");
             assert(normalizedCloneClipboard[12] === "Prompt should survive copy", "Loader clone clipboard serialization must recover prompt after clone shifting");
+            api.resetLocalLLMGeneratedWidgetValues(clonedClipboardShiftNode);
+            assert(api.getWidget(clonedClipboardShiftNode, "deno_local_llm_refresh_models").value === "Refresh Models", "Loader reload cleanup must reset Refresh Models button value after ComfyUI shifts saved model text into it");
+            assert(api.getWidget(clonedClipboardShiftNode, "deno_local_llm_stop_llm").value === "Stop LLM", "Loader reload cleanup must reset Stop LLM button value after ComfyUI shifts saved URL into it");
+            assert(api.getWidget(clonedClipboardShiftNode, "deno_local_llm_unload_llm").value === "Unload LLM", "Loader reload cleanup must reset Unload LLM button value after ComfyUI shifts saved model text into it");
+            assert(api.getWidget(clonedClipboardShiftNode, "deno_local_llm_system_prompt_button").value === "System Prompt", "Loader reload cleanup must reset System Prompt button value after ComfyUI restore");
             function makeCopiedLoaderNode(id) {{
                 const node = {{
                     id,

--- a/tests/test_ltx_tiled_nodes_predictor.py
+++ b/tests/test_ltx_tiled_nodes_predictor.py
@@ -295,6 +295,215 @@ def test_av_predictor_tiles_video_with_full_audio_context(monkeypatch, fake_comf
     assert torch.allclose(uncond_audio, audio)
 
 
+def test_av_predictor_crops_known_spatial_model_conds_and_preserves_non_spatial(
+    monkeypatch,
+    fake_comfy_latent_utils,
+):
+    height, width = 6, 4
+    video = torch.zeros((1, 2, 3, height, width))
+    audio = torch.arange(16, dtype=torch.float32).reshape(1, 1, 4, 4)
+    packed, global_shapes = _fake_pack_latents([video, audio])
+    plan = build_tile_plan(height=height, width=width, vertical_tiles=2, horizontal_tiles=1, overlap=2)
+    full_mask = torch.arange(height * width, dtype=torch.float32).reshape(1, 1, 1, height, width)
+    full_regular_mask = torch.ones((1, 1, 1, height, width)) * 4.0
+    full_unknown = torch.ones((1, 1, 1, height, width)) * 2.0
+    tile_sized_mask = torch.ones((1, 1, 1, plan[0].height, plan[0].width)) * 3.0
+    branch_bias = torch.tensor([0.25])
+    seen = []
+
+    def fake_calc_cond_batch(_model, conds, x_in, _sigma, _model_options):
+        tile_shapes = conds[0][0]["model_conds"]["latent_shapes"].cond
+        tile_video, full_audio = _fake_unpack_latents(x_in, tile_shapes)
+        model_conds = conds[0][0]["model_conds"]
+        seen.append({
+            "tile_shape": tuple(tile_video.shape[-2:]),
+            "audio_shape": tuple(full_audio.shape),
+            "pixel_mask": model_conds["pixel_mask"],
+            "mask": model_conds["mask"].cond,
+            "guide_mask": model_conds["guide_mask"].cond,
+            "mystery_full": model_conds["mystery_full"].cond,
+            "branch_bias": model_conds["branch_bias"].cond,
+        })
+        packed_prediction, _ = _fake_pack_latents([tile_video + 1.0, full_audio])
+        return [packed_prediction]
+
+    monkeypatch.setattr(
+        "deno_ltx_tiled_nodes._comfy_samplers",
+        lambda: types.SimpleNamespace(calc_cond_batch=fake_calc_cond_batch),
+    )
+
+    predictor = StepFusedAVTilePredictor(
+        plan=plan,
+        full_height=height,
+        full_width=width,
+        global_video_shape=global_shapes[0],
+        global_audio_shape=global_shapes[1],
+        blend_mode="hann",
+    )
+    predictor({
+        "input": packed,
+        "sigma": torch.tensor([0.5]),
+        "model": _FakeModel(),
+        "conds": [[{
+            "model_conds": {
+                "latent_shapes": _FakeCond(global_shapes),
+                "pixel_mask": full_mask,
+                "mask": _FakeCond(full_regular_mask),
+                "guide_mask": _FakeCond(tile_sized_mask),
+                "mystery_full": _FakeCond(full_unknown),
+                "branch_bias": _FakeCond(branch_bias),
+            },
+        }]],
+        "model_options": {},
+    })
+
+    assert len(seen) == len(plan)
+    for spec, record in zip(plan, seen):
+        assert record["tile_shape"] == (spec.height, spec.width)
+        assert record["audio_shape"] == tuple(audio.shape)
+        assert tuple(record["pixel_mask"].shape[-2:]) == (spec.height, spec.width)
+        assert tuple(record["mask"].shape[-2:]) == (spec.height, spec.width)
+        assert tuple(record["mystery_full"].shape[-2:]) == (spec.height, spec.width)
+        assert tuple(record["guide_mask"].shape[-2:]) == (spec.height, spec.width)
+        assert torch.equal(record["branch_bias"], branch_bias)
+
+
+def test_av_predictor_preserves_text_attention_mask_as_non_spatial(
+    monkeypatch,
+    fake_comfy_latent_utils,
+):
+    height, width = 6, 4
+    video = torch.zeros((1, 2, 3, height, width))
+    audio = torch.ones((1, 1, 4, 4))
+    packed, global_shapes = _fake_pack_latents([video, audio])
+    attention_mask = torch.ones((1, 77), dtype=torch.float32)
+    full_spatial_mask = torch.ones((1, 1, 1, height, width), dtype=torch.float32)
+    seen_attention_masks = []
+
+    def fake_calc_cond_batch(_model, conds, x_in, _sigma, _model_options):
+        tile_shapes = conds[0][0]["model_conds"]["latent_shapes"].cond
+        tile_video, full_audio = _fake_unpack_latents(x_in, tile_shapes)
+        model_conds = conds[0][0]["model_conds"]
+        seen_attention_masks.append(model_conds["attention_mask"].cond)
+        assert tuple(model_conds["pixel_mask"].cond.shape[-2:]) == tuple(tile_video.shape[-2:])
+        packed_prediction, _ = _fake_pack_latents([tile_video + 1.0, full_audio])
+        return [packed_prediction]
+
+    monkeypatch.setattr(
+        "deno_ltx_tiled_nodes._comfy_samplers",
+        lambda: types.SimpleNamespace(calc_cond_batch=fake_calc_cond_batch),
+    )
+
+    predictor = StepFusedAVTilePredictor(
+        plan=build_tile_plan(height=height, width=width, vertical_tiles=2, horizontal_tiles=1, overlap=2),
+        full_height=height,
+        full_width=width,
+        global_video_shape=global_shapes[0],
+        global_audio_shape=global_shapes[1],
+        blend_mode="hann",
+    )
+    predictor({
+        "input": packed,
+        "sigma": torch.tensor([0.5]),
+        "model": _FakeModel(),
+        "conds": [[{
+            "model_conds": {
+                "latent_shapes": _FakeCond(global_shapes),
+                "attention_mask": _FakeCond(attention_mask),
+                "pixel_mask": _FakeCond(full_spatial_mask),
+            },
+        }]],
+        "model_options": {},
+    })
+
+    assert len(seen_attention_masks) == len(predictor.plan)
+    for seen_attention_mask in seen_attention_masks:
+        assert torch.equal(seen_attention_mask, attention_mask)
+
+
+def test_av_predictor_rejects_known_spatial_model_cond_shape_mismatch(
+    monkeypatch,
+    fake_comfy_latent_utils,
+):
+    height, width = 6, 4
+    video = torch.zeros((1, 2, 3, height, width))
+    audio = torch.ones((1, 1, 4, 4))
+    packed, global_shapes = _fake_pack_latents([video, audio])
+    bad_mask = torch.ones((1, 1, 1, height + 1, width))
+
+    def unexpected_calc_cond_batch(*_args, **_kwargs):
+        raise AssertionError("bad spatial model_conds should fail before model prediction")
+
+    monkeypatch.setattr(
+        "deno_ltx_tiled_nodes._comfy_samplers",
+        lambda: types.SimpleNamespace(calc_cond_batch=unexpected_calc_cond_batch),
+    )
+
+    predictor = StepFusedAVTilePredictor(
+        plan=build_tile_plan(height=height, width=width, vertical_tiles=2, horizontal_tiles=1, overlap=2),
+        full_height=height,
+        full_width=width,
+        global_video_shape=global_shapes[0],
+        global_audio_shape=global_shapes[1],
+        blend_mode="hann",
+    )
+
+    with pytest.raises(UnsupportedTiledConditioning, match="unsupported spatial shape"):
+        predictor({
+            "input": packed,
+            "sigma": torch.tensor([0.5]),
+            "model": _FakeModel(),
+            "conds": [[{
+                "model_conds": {
+                    "latent_shapes": _FakeCond(global_shapes),
+                    "pixel_mask": _FakeCond(bad_mask),
+                },
+            }]],
+            "model_options": {},
+        })
+
+
+@pytest.mark.parametrize(
+    ("entry_counts", "error_pattern"),
+    [
+        ([0, 24], "invalid pre_filter_count"),
+        ([8, 8], "token count mismatch"),
+    ],
+)
+def test_av_predictor_rejects_guide_entry_count_mismatch_before_fallback(
+    fake_comfy_latent_utils,
+    entry_counts,
+    error_pattern,
+):
+    height, width = 4, 6
+    video = torch.zeros((1, 2, 3, height, width))
+    audio = torch.ones((1, 1, 4, 4))
+    packed, global_shapes = _fake_pack_latents([video, audio])
+    entries = [{"pre_filter_count": count, "latent_shape": [1, height, width]} for count in entry_counts]
+
+    predictor = StepFusedAVTilePredictor(
+        plan=build_tile_plan(height=height, width=width, vertical_tiles=1, horizontal_tiles=2, overlap=2),
+        full_height=height,
+        full_width=width,
+        global_video_shape=global_shapes[0],
+        global_audio_shape=global_shapes[1],
+        blend_mode="hann",
+    )
+
+    with pytest.raises(UnsupportedTiledConditioning, match=error_pattern):
+        predictor({
+            "input": packed,
+            "sigma": torch.tensor([0.5]),
+            "model": _FakeModel(),
+            "conds": [[{
+                "keyframe_idxs": _FakeCond(_make_guide_keyframes(1, height, width)),
+                "guide_attention_entries": _FakeCond(entries),
+                "model_conds": {"latent_shapes": _FakeCond(global_shapes)},
+            }]],
+            "model_options": {},
+        })
+
+
 def test_av_predictor_one_by_one_matches_stock_video_predictions(
     monkeypatch,
     fake_comfy_latent_utils,

--- a/web/js/deno_local_llm_refiner.js
+++ b/web/js/deno_local_llm_refiner.js
@@ -10,6 +10,7 @@ const GATE_DISPLAY_NAME = "(Deno) Local LLM Reviewer";
 const GATE_LEGACY_DISPLAY_NAMES = new Set(["(Deno) AI Review Gate", "(Deno) Local LLM Gate"]);
 const GENERATED_PREFIX = "deno_local_llm_";
 const GATE_GENERATED_PREFIX = "deno_local_llm_gate_";
+const OPENAI_MODEL_PICKER_NAME = `${GENERATED_PREFIX}model_picker`;
 const DEFAULT_WIDTH = 560;
 const GATE_DEFAULT_WIDTH = 420;
 const PREVIEW_HEIGHT = 150;
@@ -82,9 +83,11 @@ const COMFY_VRAM_ALIASES = {
 };
 const SEED_MODE_VALUES = ["fixed", "increment", "decrement", "randomize"];
 const LOADER_SERIALIZED_WIDGET_COUNT = 13;
+const GATE_SERIALIZED_WIDGET_COUNT = 3;
 const LOADER_STATE_PROPERTY = "deno_local_llm_state";
 const LOADER_STATE_SCHEMA = 1;
 const LOADER_STATE_TEXT_LIMIT = 120000;
+const LOADER_SERVER_URLS_BY_PROVIDER_PROPERTY = "denoLocalLLMServerUrlsByProvider";
 const LOADER_SERIALIZED_WIDGET_NAMES = [
     "provider",
     "ollama_model",
@@ -102,6 +105,13 @@ const LOADER_SERIALIZED_WIDGET_NAMES = [
 ];
 const LOADER_GENERATED_BUTTON_VALUES = ["Refresh Models", "Stop LLM", "Unload LLM"];
 const LOADER_SYSTEM_PROMPT_BUTTON_VALUE = "System Prompt";
+const LOADER_GENERATED_WIDGET_RESET_VALUES = Object.freeze({
+    [`${GENERATED_PREFIX}refresh_models`]: "Refresh Models",
+    [`${GENERATED_PREFIX}stop_llm`]: "Stop LLM",
+    [`${GENERATED_PREFIX}unload_llm`]: "Unload LLM",
+    [`${GENERATED_PREFIX}preview`]: "",
+    [`${GENERATED_PREFIX}system_prompt_button`]: LOADER_SYSTEM_PROMPT_BUTTON_VALUE,
+});
 const MISSING_SAVED_MODEL_PREFIX = "Missing saved model: ";
 const LEGACY_CONTROL_AFTER_GENERATE_VALUES = new Set(["fixed", "randomize", "increment", "decrement", "random"]);
 const SHIFTED_MODEL_WIDGET_VALUES = new Set([
@@ -124,6 +134,7 @@ const SHIFTED_MODEL_WIDGET_VALUES = new Set([
     "ComfyUI VRAM",
     "Ollama Model",
     "LM Studio Model",
+    "Detected Models",
     "Legacy Model",
     "Custom Model",
     "Custom Server URL",
@@ -631,6 +642,12 @@ app.registerExtension({
     name: "Deno.LocalLLMRefiner",
     async beforeRegisterNodeDef(nodeType, nodeData) {
         if (nodeData.name === GATE_NODE_NAME) {
+            const configure = nodeType.prototype.configure;
+            nodeType.prototype.configure = function (info) {
+                normalizeReviewerWidgetValues(info);
+                return configure?.apply(this, arguments);
+            };
+
             const onNodeCreated = nodeType.prototype.onNodeCreated;
             nodeType.prototype.onNodeCreated = function () {
                 const result = onNodeCreated?.apply(this, arguments);
@@ -642,6 +659,13 @@ app.registerExtension({
             nodeType.prototype.onConfigure = function () {
                 const result = onConfigure?.apply(this, arguments);
                 queueMicrotask(() => setupGateNode(this));
+                return result;
+            };
+
+            const onSerialize = nodeType.prototype.onSerialize;
+            nodeType.prototype.onSerialize = function (info) {
+                const result = onSerialize?.apply(this, arguments);
+                normalizeReviewerWidgetValues(info);
                 return result;
             };
 
@@ -753,6 +777,30 @@ function normalizeLocalLLMLoaderWidgetValues(info) {
     return normalized;
 }
 
+function normalizeReviewerWidgetValues(info) {
+    if (!info || !Array.isArray(info.widgets_values)) {
+        return null;
+    }
+    const normalized = normalizeReviewerSerializedValues(info.widgets_values);
+    info.widgets_values = normalized;
+    return normalized;
+}
+
+function normalizeReviewerSerializedValues(values) {
+    if (!Array.isArray(values)) {
+        return null;
+    }
+    const normalized = values.slice(0, GATE_SERIALIZED_WIDGET_COUNT);
+    while (normalized.length < GATE_SERIALIZED_WIDGET_COUNT) {
+        normalized.push("");
+    }
+    const mode = String(normalized[0] || "Review");
+    normalized[0] = mode === "Pass" ? "Pass" : "Review";
+    normalized[1] = normalized[1] === true || String(normalized[1]).toLowerCase() === "true";
+    normalized[2] = normalized[2] == null ? "" : String(normalized[2]);
+    return normalized;
+}
+
 function normalizeLocalLLMLoaderSerializedValues(values) {
     if (!Array.isArray(values)) {
         return null;
@@ -764,7 +812,34 @@ function normalizeLocalLLMLoaderSerializedValues(values) {
         normalized = normalizeLocalLLMLoaderLegacyButtonValues(normalized);
         generatedButtonStart = findLocalLLMGeneratedButtonRunStart(normalized);
     }
+    normalized = normalizeLocalLLMLoaderGeneratedPickerValues(normalized);
     return normalized.slice(0, LOADER_SERIALIZED_WIDGET_COUNT);
+}
+
+function normalizeLocalLLMLoaderGeneratedPickerValues(values) {
+    const normalized = [...values];
+    const provider = normalizeProviderValue(normalized[0]);
+    const customModel = String(normalized[4] ?? "").trim();
+    const extraAfterCustomModel = String(normalized[5] ?? "").trim();
+    const shiftedSeed = normalized[8];
+    const likelyGeneratedPickerValue =
+        normalized.length > LOADER_SERIALIZED_WIDGET_COUNT &&
+        OPENAI_COMPATIBLE_PROVIDERS.has(provider) &&
+        customModel &&
+        (extraAfterCustomModel === customModel ||
+            extraAfterCustomModel === "Detected Models" ||
+            (
+                typeof normalized[6] === "string" &&
+                typeof normalized[7] === "boolean" &&
+                (typeof shiftedSeed === "number" || /^-?\d+(?:\.\d+)?$/.test(String(shiftedSeed ?? "").trim())) &&
+                SEED_MODE_VALUES.includes(String(normalized[9] ?? ""))
+            )) &&
+        typeof normalized[6] !== "boolean" &&
+        typeof normalized[7] === "boolean";
+    if (likelyGeneratedPickerValue) {
+        normalized.splice(5, 1);
+    }
+    return normalized;
 }
 
 function localLLMLoaderSerializedValuesFromWidgets(node, fallbackValues) {
@@ -945,6 +1020,27 @@ function applyLocalLLMLoaderSavedWidgetValues(node, values) {
             widget.value = value;
             changed = true;
         }
+    }
+    changed = resetLocalLLMGeneratedWidgetValues(node) || changed;
+    return changed;
+}
+
+function resetLocalLLMGeneratedWidgetValues(node) {
+    if (!node || !Array.isArray(node.widgets)) {
+        return false;
+    }
+    let changed = false;
+    for (const [name, value] of Object.entries(LOADER_GENERATED_WIDGET_RESET_VALUES)) {
+        const widget = getWidget(node, name);
+        if (!widget) {
+            continue;
+        }
+        if (widget.value !== value) {
+            widget.value = value;
+            changed = true;
+        }
+        widget.options = { ...(widget.options || {}), serialize: false };
+        widget.serializeValue = () => undefined;
     }
     return changed;
 }
@@ -1549,9 +1645,12 @@ if (typeof globalThis !== "undefined" && typeof globalThis.__DENO_LOCAL_LLM_REVI
         isLocalLLMOwnExecutionError,
         localLLMExecutionErrorMessage,
         nextLocalLLMSeedValue,
+        normalizeReviewerSerializedValues,
+        normalizeReviewerWidgetValues,
         normalizeLocalLLMLoaderSerializedValues,
         normalizeLocalLLMLoaderWidgetValues,
         localLLMLoaderSerializedValuesFromWidgets,
+        resetLocalLLMGeneratedWidgetValues,
         persistLocalLLMStateToProperties,
         restoreLocalLLMStateFromProperties,
         sanitizeLocalLLMState,
@@ -3806,6 +3905,7 @@ function ensureSingleSystemPromptButton(node) {
     if (anchor) {
         moveWidgetAfter(node, keep, anchor);
     }
+    resetLocalLLMGeneratedWidgetValues(node);
 }
 
 function positionPromptWidget(node) {
@@ -3945,7 +4045,15 @@ function repairSavedWidgetValues(node) {
     const customServerWidget = getWidget(node, "custom_server_url");
     if (customServerWidget) {
         const value = String(customServerWidget.value || "").trim();
-        customServerWidget.value = value && isLikelyUrl(value) ? value : LEGACY_CUSTOM_DEFAULT_URL;
+        if (value && isLikelyUrl(value)) {
+            customServerWidget.value = value;
+            if (value !== LEGACY_CUSTOM_DEFAULT_URL) {
+                delete customServerWidget.__denoLocalLLMRepairedBlankServerUrl;
+            }
+        } else {
+            customServerWidget.value = LEGACY_CUSTOM_DEFAULT_URL;
+            customServerWidget.__denoLocalLLMRepairedBlankServerUrl = true;
+        }
     }
 
     const seedWidget = getWidget(node, "seed");
@@ -3996,6 +4104,8 @@ function repairSavedWidgetValues(node) {
     if (thinkingWidget && typeof thinkingWidget.value !== "boolean") {
         thinkingWidget.value = String(thinkingWidget.value).toLowerCase() === "true";
     }
+
+    resetLocalLLMGeneratedWidgetValues(node);
 }
 
 function repairLegacyProviderValues(node) {
@@ -4017,7 +4127,10 @@ function repairLegacyProviderValues(node) {
     const shiftedFromOldTwoProviderNode =
         Boolean(customServerWidget) &&
         Boolean(customModelWidget) &&
-        (!isLikelyUrl(customServerValue) || isShiftedCustomModelValue(customModelValue));
+        (
+            (customServerValue && !isLikelyUrl(customServerValue)) ||
+            (customModelValue && isShiftedCustomModelValue(customModelValue))
+        );
 
     if (!shiftedFromOldTwoProviderNode) {
         return;
@@ -4282,18 +4395,163 @@ function defaultOpenAIProviderUrl(provider) {
 }
 
 function applyOpenAIProviderServerDefault(node, provider) {
-    if (!OPENAI_COMPATIBLE_PROVIDERS.has(provider)) {
-        return;
-    }
     const widget = getWidget(node, "custom_server_url");
-    if (!widget) {
+    const previousProviderRaw = String(node.__denoLocalLLMLastProvider || "").trim();
+    const previousProvider = previousProviderRaw ? normalizeProviderValue(previousProviderRaw) : "";
+    const current = String(widget?.value || "").trim();
+    if (previousProvider && previousProvider !== provider && OPENAI_COMPATIBLE_PROVIDERS.has(previousProvider)) {
+        rememberOpenAIProviderServerUrl(node, previousProvider, current);
+    }
+    if (!OPENAI_COMPATIBLE_PROVIDERS.has(provider)) {
+        node.__denoLocalLLMLastProvider = provider;
+        node.__denoLocalLLMProviderInitialized = true;
         return;
     }
-    const current = String(widget.value || "").trim();
-    const defaultUrls = new Set([LEGACY_CUSTOM_DEFAULT_URL, CUSTOM_DEFAULT_URL, VLLM_DEFAULT_URL, LLAMA_CPP_DEFAULT_URL]);
-    if (!current || defaultUrls.has(current)) {
-        widget.value = defaultOpenAIProviderUrl(provider);
+    if (!widget) {
+        node.__denoLocalLLMLastProvider = provider;
+        node.__denoLocalLLMProviderInitialized = true;
+        return;
     }
+    const providerDefault = defaultOpenAIProviderUrl(provider);
+    const cached = openAIProviderServerUrl(node, provider);
+    const providerChanged = Boolean(previousProvider && previousProvider !== provider);
+    const repairedBlankServerUrl = Boolean(widget.__denoLocalLLMRepairedBlankServerUrl);
+    if (cached && (providerChanged || !current)) {
+        widget.value = cached;
+        if (cached === providerDefault) {
+            widget.__denoLocalLLMAppliedServerDefault = providerDefault;
+        } else {
+            delete widget.__denoLocalLLMAppliedServerDefault;
+        }
+        delete widget.__denoLocalLLMRepairedBlankServerUrl;
+        rememberOpenAIProviderServerUrl(node, provider, widget.value);
+        node.__denoLocalLLMLastProvider = provider;
+        node.__denoLocalLLMProviderInitialized = true;
+        return;
+    }
+    const activeCurrent = String(widget.value || "").trim();
+    if (!current || repairedBlankServerUrl) {
+        widget.value = providerDefault;
+        widget.__denoLocalLLMAppliedServerDefault = providerDefault;
+    } else if (
+        widget.__denoLocalLLMAppliedServerDefault === activeCurrent ||
+        providerChanged
+    ) {
+        widget.value = providerDefault;
+        widget.__denoLocalLLMAppliedServerDefault = providerDefault;
+    } else if (String(widget.value || "").trim() !== providerDefault) {
+        delete widget.__denoLocalLLMAppliedServerDefault;
+    }
+    delete widget.__denoLocalLLMRepairedBlankServerUrl;
+    rememberOpenAIProviderServerUrl(node, provider, widget.value);
+    node.__denoLocalLLMLastProvider = provider;
+    node.__denoLocalLLMProviderInitialized = true;
+}
+
+function openAIProviderServerUrlCache(node) {
+    node.properties = node.properties || {};
+    const current = node.properties[LOADER_SERVER_URLS_BY_PROVIDER_PROPERTY];
+    if (current && typeof current === "object" && !Array.isArray(current)) {
+        return current;
+    }
+    const cache = {};
+    node.properties[LOADER_SERVER_URLS_BY_PROVIDER_PROPERTY] = cache;
+    return cache;
+}
+
+function openAIProviderServerUrl(node, provider) {
+    const cache = node?.properties?.[LOADER_SERVER_URLS_BY_PROVIDER_PROPERTY];
+    if (!cache || typeof cache !== "object" || Array.isArray(cache)) {
+        return "";
+    }
+    return String(cache[normalizeProviderValue(provider)] || "").trim();
+}
+
+function rememberOpenAIProviderServerUrl(node, provider, value) {
+    const providerKey = normalizeProviderValue(provider);
+    const url = String(value || "").trim();
+    if (!OPENAI_COMPATIBLE_PROVIDERS.has(providerKey) || !isLikelyUrl(url)) {
+        return;
+    }
+    const cache = openAIProviderServerUrlCache(node);
+    cache[providerKey] = url;
+}
+
+function openAIModelChoicesForProvider(node, provider) {
+    const providerKey = normalizeProviderValue(provider);
+    const stored = node?.properties?.denoLocalLLMModelChoicesByProvider?.[providerKey];
+    return normalizeModelChoices(Array.isArray(stored) ? stored : []);
+}
+
+function openAIModelPickerValues(choices) {
+    const seen = new Set();
+    const values = [];
+    for (const choice of choices || []) {
+        const id = String(choice?.id || "").trim();
+        if (!id || seen.has(id)) {
+            continue;
+        }
+        seen.add(id);
+        values.push(id);
+    }
+    return values;
+}
+
+function removeOpenAIModelPickerRows(node) {
+    node.widgets = (node.widgets || []).filter((widget) => {
+        if (String(widget?.name || "") !== OPENAI_MODEL_PICKER_NAME) {
+            return true;
+        }
+        removeWidgetElement(widget);
+        return false;
+    });
+}
+
+function syncOpenAIModelPicker(node, provider) {
+    const providerKey = normalizeProviderValue(provider);
+    const modelWidget = getWidget(node, "custom_model");
+    if (!OPENAI_COMPATIBLE_PROVIDERS.has(providerKey) || !modelWidget) {
+        removeOpenAIModelPickerRows(node);
+        return null;
+    }
+    const values = openAIModelPickerValues(openAIModelChoicesForProvider(node, providerKey));
+    if (!values.length) {
+        removeOpenAIModelPickerRows(node);
+        return null;
+    }
+    if (!hasUsableSavedModelValue(modelWidget.value)) {
+        modelWidget.value = values[0];
+    }
+    let picker = getWidget(node, OPENAI_MODEL_PICKER_NAME);
+    if (!picker) {
+        picker = node.addWidget?.("combo", "Detected Models", values[0], () => {
+            const selected = String(picker?.value || "").trim();
+            if (!selected) {
+                return;
+            }
+            modelWidget.value = selected;
+            setLocalLLMNodeState(node, {
+                provider: currentProvider(node),
+                model: selected,
+                status: "ready",
+                thinking: "Detected model copied into the Model field.",
+            });
+            refreshNode(node);
+        }, { values, list: values });
+        if (!picker) {
+            return null;
+        }
+    }
+    picker.name = OPENAI_MODEL_PICKER_NAME;
+    picker.label = "Detected Models";
+    picker.type = "combo";
+    picker.options = { ...(picker.options || {}), values, list: values, serialize: false };
+    picker.serializeValue = () => undefined;
+    const current = String(modelWidget.value || "").trim();
+    picker.value = values.includes(current) ? current : values[0];
+    setWidgetHidden(picker, false);
+    moveWidgetAfter(node, picker, modelWidget);
+    return picker;
 }
 
 function setActiveProviderModelVisibility(node) {
@@ -4321,6 +4579,7 @@ function setActiveProviderModelVisibility(node) {
         customModelWidget.type = usesOpenAICompatible ? "text" : customModelWidget.type;
         customModelWidget.label = "Model";
     }
+    syncOpenAIModelPicker(node, provider);
     const customServerWidget = getWidget(node, "custom_server_url");
     if (customServerWidget) {
         customServerWidget.label = "Server URL";
@@ -4488,9 +4747,13 @@ function ensureSingleRefreshButton(node) {
     const keep = refreshes[0];
     node.widgets = (node.widgets || []).filter((widget) => !isRefreshButtonWidget(widget) || widget === keep);
     const modelWidget = activeModelWidget(node);
-    if (modelWidget) {
+    const picker = getWidget(node, OPENAI_MODEL_PICKER_NAME);
+    if (picker) {
+        moveWidgetAfter(node, keep, picker);
+    } else if (modelWidget) {
         moveWidgetAfter(node, keep, modelWidget);
     }
+    resetLocalLLMGeneratedWidgetValues(node);
 }
 
 function ensureSingleStopButton(node) {
@@ -4507,6 +4770,7 @@ function ensureSingleStopButton(node) {
     } else if (modelWidget) {
         moveWidgetAfter(node, keep, modelWidget);
     }
+    resetLocalLLMGeneratedWidgetValues(node);
 }
 
 function ensureSingleUnloadButton(node) {
@@ -4526,6 +4790,7 @@ function ensureSingleUnloadButton(node) {
     } else if (modelWidget) {
         moveWidgetAfter(node, keep, modelWidget);
     }
+    resetLocalLLMGeneratedWidgetValues(node);
 }
 
 function ensureSinglePreviewWidget(node) {
@@ -4831,6 +5096,7 @@ function updateModelChoices(node, provider, choices) {
         if (widget && Array.isArray(choices) && choices.length && !hasUsableSavedModelValue(widget.value)) {
             widget.value = String(choices[0]?.id || "");
         }
+        syncOpenAIModelPicker(node, providerKey);
         return;
     }
     if (widget && Array.isArray(choices) && choices.length) {


### PR DESCRIPTION
## Release Scope

DENO Custom Nodes 0.7.67 release candidate.

- Fix Local LLM Loader / Reviewer saved-workflow persistence, provider URL cache, generated widget serialization, and Reviewer trailing nulls.
- Keep Local LLM server access local-first by default, with explicit `DENO_LOCAL_LLM_ALLOWED_HOSTS=LAN-IP:port` opt-in for trusted LAN servers.
- Add generated button internal-value reset after workflow reload so model/URL text does not remain inside Refresh/Stop/Unload buttons.
- Integrate LTX High resolution Tiled Sampler guide/mask conditioning guard fixes.
- Bump public package version and changelog to 0.7.67.

## Local Verification

- `node --check web/js/deno_local_llm_refiner.js`: PASS
- `python -m py_compile deno_local_llm_refiner.py deno_ltx_tiled_nodes.py tests/test_local_llm_reviewer_graph_transform.py tests/test_ltx_tiled_nodes_predictor.py`: PASS
- `python -m pytest tests/test_local_llm_reviewer_graph_transform.py tests/test_ltx_tiled_nodes_predictor.py -q`: 30 passed
- `python -m pytest tests/test_image_resize_node.py -q -k "local_llm_refiner_lan_allowlist or local_llm_refiner_normalizes_prompts_seed_modes_and_local_urls or custom_unload_is_not_fake_success"`: 3 passed
- `python -m pytest tests -q`: 339 passed
- Real ComfyUI runtime/canvas persistence check: PASS
- Independent release reviewer: PASS WITH NOTES, notes addressed before this PR except final CI/publish sequencing.

## Release Gate Notes

This PR is opened first so GitHub CI can run before the release commit is placed on `main` and before the Registry publish workflow is allowed to publish 0.7.67.
