### PR TITLE
Release 0.7.69 reliability fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This file intentionally stays short. Detailed engineering notes belong in privat
 
 ## Unreleased
 
+## 0.7.69 - 2026-07-18
+
+- Preserved saved workflows that used the retired video-only LTX tiled sampler by mapping them through ComfyUI's native node replacement flow while keeping current LTX AV sampler defaults, validation, outputs, and visible controls unchanged.
+- Fixed Local LLM cleanup and control races so failed or stopped runs still release an owned model once, late Refresh responses cannot overwrite a newer run, Stop and Unload requests finish safely, and negative reviewer verdicts are not mistaken for approval.
+- Fixed workflow-scoped Local LLM Reviewer snapshots, and hardened Video Preview file replacement and cleanup so parallel or saved previews do not overwrite or remove each other's state.
+- Fixed Video Compare batch alignment, fully disabled RTX two-pass passthrough, and exact LTX Sequencer no-op handling without changing results for already aligned or enabled workflows.
+- Hardened saved LoRA values, Bernini choices, Ideogram save paths, update/help caches, preview file replacement, and canvas cleanup so invalid or stale state fails clearly without changing normal controls or outputs.
+
 ## 0.7.68 - 2026-07-18
 
 - Fixed `(Deno) Ideogram Director` result-image restoration, panel cleanup, reroute backdrop lookup, queue preflight handling, and targeted pending-import events without changing normal generation settings or outputs.

--- a/__init__.py
+++ b/__init__.py
@@ -459,6 +459,40 @@ DENO_NODE_REPLACEMENTS = (
         ],
         "output_mapping": None,
     },
+    {
+        "old_node_id": "DenoLTXStepFusedTiledSampler",
+        "new_node_id": "DenoLTXAVStepFusedTiledSampler",
+        "old_widget_ids": [
+            "horizontal_tiles",
+            "vertical_tiles",
+            "overlap",
+            "blend_mode",
+            "aggressive_memory_cleanup",
+            "debug",
+        ],
+        "input_mapping": [
+            {"new_id": "noise", "old_id": "noise"},
+            {"new_id": "guider", "old_id": "guider"},
+            {"new_id": "sampler", "old_id": "sampler"},
+            {"new_id": "sigmas", "old_id": "sigmas"},
+            {"new_id": "latent_image", "old_id": "latent_image"},
+            {"new_id": "horizontal_tiles", "old_id": "horizontal_tiles"},
+            {"new_id": "vertical_tiles", "old_id": "vertical_tiles"},
+            {"new_id": "overlap", "old_id": "overlap"},
+            {"new_id": "audio_mode", "set_value": "freeze"},
+            {"new_id": "blend_mode", "old_id": "blend_mode"},
+            {
+                "new_id": "aggressive_memory_cleanup",
+                "old_id": "aggressive_memory_cleanup",
+            },
+            {"new_id": "debug", "old_id": "debug"},
+            {"new_id": "_deno_legacy_video_compat", "set_value": True},
+        ],
+        "output_mapping": [
+            {"old_idx": 0, "new_idx": 0},
+            {"old_idx": 1, "new_idx": 1},
+        ],
+    },
 )
 
 

--- a/deno_bernini_prompt_guide.py
+++ b/deno_bernini_prompt_guide.py
@@ -66,6 +66,13 @@ NEGATIVE_PRESETS = [
     NEGATIVE_PRESET_EMPTY,
 ]
 
+_KNOWN_TASK_TYPE_VALUES = frozenset(
+    [*TASK_TYPES, *SYSTEM_PROMPTS.keys(), TASK_TYPE_CUSTOM_LEGACY, "Custom System Prompt"]
+)
+_KNOWN_NEGATIVE_PRESET_VALUES = frozenset(
+    [*NEGATIVE_PRESETS, NEGATIVE_PRESET_CUSTOM, NEGATIVE_PRESET_OFFICIAL_CUSTOM]
+)
+
 OFFICIAL_WAN22_NEGATIVE_PROMPT = (
     "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，"
     "最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，"
@@ -188,6 +195,10 @@ class DenoBerniniPromptGuide:
 
     @classmethod
     def VALIDATE_INPUTS(cls, task_type=None, negative_preset=None):
+        if task_type is not None and str(task_type).strip() not in _KNOWN_TASK_TYPE_VALUES:
+            return f"Unknown Bernini System Prompt mode: {task_type}"
+        if negative_preset is not None and str(negative_preset).strip() not in _KNOWN_NEGATIVE_PRESET_VALUES:
+            return f"Unknown Bernini Negative Preset: {negative_preset}"
         return True
 
     def build(

--- a/deno_ideogram_director.py
+++ b/deno_ideogram_director.py
@@ -15,6 +15,7 @@ checks and unit tests outside a running ComfyUI.
 import json
 import hashlib
 import math
+import os
 import re
 
 try:
@@ -25,7 +26,6 @@ except Exception:  # pragma: no cover - direct import during local tests
 # ComfyUI is only importable inside a running ComfyUI process. Guard the imports so
 # this module stays importable for `python -m py_compile` and the standalone tests.
 try:
-    import os
     import shutil
     import folder_paths
     from server import PromptServer
@@ -48,6 +48,17 @@ INVALID_IMPORT_MESSAGE = (
     "The incoming JSON prompt is not valid JSON. The LLM may have generated the wrong format. "
     "Please regenerate it, or keep the current board and run again."
 )
+
+
+def _path_is_within_base(base, candidate):
+    """Resolve links and compare path components, not string prefixes."""
+    try:
+        base_real = os.path.normcase(os.path.realpath(base))
+        candidate_real = os.path.normcase(os.path.realpath(candidate))
+        return os.path.commonpath((base_real, candidate_real)) == base_real
+    except (TypeError, ValueError):
+        # ValueError covers Windows paths on different drives.
+        return False
 
 
 # --------------------------------------------------------------------------- #
@@ -1090,8 +1101,8 @@ if _HAS_COMFY and getattr(PromptServer, "instance", None) is not None:
         if not base or not filename:
             return web.json_response({"error": "bad source"}, status=400)
         # guard against path traversal
-        src = os.path.abspath(os.path.join(base, subfolder, filename))
-        if not src.startswith(os.path.abspath(base)) or not os.path.isfile(src):
+        src = os.path.realpath(os.path.join(base, subfolder, filename))
+        if not _path_is_within_base(base, src) or not os.path.isfile(src):
             return web.json_response({"error": "source not found"}, status=404)
 
         out_dir = folder_paths.get_output_directory()

--- a/deno_local_llm_refiner.py
+++ b/deno_local_llm_refiner.py
@@ -1287,6 +1287,25 @@ def _word_found(text: str, words: List[str]) -> Optional[str]:
     return None
 
 
+def _negated_word_found(text: str, words: List[str]) -> Optional[str]:
+    lowered = str(text or "").lower()
+    for word in words:
+        needle = str(word or "").strip().lower()
+        if not needle:
+            continue
+        escaped = re.escape(needle)
+        patterns = (
+            rf"\bnot\s+(?!(?:only|just)\b)(?:(?:a|an|the)\s+)?(?:be\s+)?{escaped}(?![A-Za-z0-9_])",
+            rf"\b(?:cannot|can't|cant)\s+(?:be\s+)?{escaped}(?![A-Za-z0-9_])",
+            rf"\b(?:do|does|did|would|should|could|can|is|are|was|were|have|has|had)\s+not\s+(?:(?:a|an|the)\s+)?(?:be\s+)?{escaped}(?![A-Za-z0-9_])",
+            rf"\bnever\s+(?:be\s+)?{escaped}(?![A-Za-z0-9_])",
+            rf"\b(?:unable|refuse(?:d|s)?|decline(?:d|s)?|fail(?:ed|s)?)\s+to\s+(?:be\s+)?{escaped}(?![A-Za-z0-9_])",
+        )
+        if any(re.search(pattern, lowered) for pattern in patterns):
+            return str(word).strip()
+    return None
+
+
 def _judge_review_text(
     review: Any,
     pass_words: Any,
@@ -1303,10 +1322,13 @@ def _judge_review_text(
         for key in ("verdict", "status", "result", "decision"):
             if key in parsed:
                 value = str(parsed.get(key) or "").strip()
+                negated_pass_hit = _negated_word_found(value, pass_tokens)
                 pass_hit = _word_found(value, pass_tokens)
                 reject_hit = _word_found(value, reject_tokens)
                 if reject_hit:
                     return False, "FAIL", reason or f"Reviewer returned {value}."
+                if negated_pass_hit:
+                    return False, "FAIL", _friendly_review_reason(reason, negated_pass_hit, False)
                 if pass_hit:
                     return True, "OK", reason or f"Reviewer returned {value}."
         for key in ("ok", "pass", "passed", "accepted", "save"):
@@ -1314,9 +1336,12 @@ def _judge_review_text(
                 return bool(parsed[key]), "OK" if parsed[key] else "FAIL", reason or f"Reviewer field {key}={parsed[key]}."
 
     reject_hit = _word_found(review_text, reject_tokens)
+    negated_pass_hit = _negated_word_found(review_text, pass_tokens)
     pass_hit = _word_found(review_text, pass_tokens)
     if reject_hit:
         return False, "FAIL", _friendly_review_reason(reason, reject_hit, False)
+    if negated_pass_hit:
+        return False, "FAIL", _friendly_review_reason(reason, negated_pass_hit, False)
     if pass_hit:
         return True, "OK", _friendly_review_reason(reason, pass_hit, True)
 
@@ -1447,25 +1472,62 @@ def _image_attachment_metadata(attachments: List[Dict[str, Any]]) -> List[Dict[s
     ]
 
 
-def _stable_reviewer_preview_path(unique_id: Any = None) -> Tuple[str, str, str]:
+def _reviewer_workflow_id_from_extra_pnginfo(extra_pnginfo: Any) -> Optional[str]:
+    candidates = extra_pnginfo if isinstance(extra_pnginfo, (list, tuple)) else [extra_pnginfo]
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            continue
+        workflow = candidate.get("workflow")
+        workflows = workflow if isinstance(workflow, (list, tuple)) else [workflow]
+        for item in workflows:
+            if not isinstance(item, dict):
+                continue
+            workflow_id = str(item.get("id") or "").strip()
+            if workflow_id:
+                return workflow_id
+            extra = item.get("extra")
+            workspace_info = extra.get("workspace_info") if isinstance(extra, dict) else None
+            workspace_id = str(workspace_info.get("id") or "").strip() if isinstance(workspace_info, dict) else ""
+            if workspace_id:
+                return f"workspace:{workspace_id}"
+    return None
+
+
+def _reviewer_storage_token(unique_id: Any = None, extra_pnginfo: Any = None) -> str:
+    node_key = str(_extract_scalar(unique_id, "node") or "node")
+    workflow_id = _reviewer_workflow_id_from_extra_pnginfo(extra_pnginfo)
+    if not workflow_id:
+        return "".join(c for c in node_key if c.isalnum()) or "node"
+    workflow_token = hashlib.sha256(workflow_id.encode("utf-8")).hexdigest()[:16]
+    node_token = hashlib.sha256(node_key.encode("utf-8")).hexdigest()[:16]
+    return f"{workflow_token}_{node_token}"
+
+
+def _stable_reviewer_preview_path(
+    unique_id: Any = None,
+    extra_pnginfo: Any = None,
+) -> Tuple[str, str, str]:
     import folder_paths
 
     temp_dir = folder_paths.get_temp_directory()
     abs_dir = os.path.join(temp_dir, REVIEWER_PREVIEW_SUBFOLDER)
     os.makedirs(abs_dir, exist_ok=True)
-    node_token = "".join(c for c in str(_extract_scalar(unique_id, "node")) if c.isalnum()) or "node"
-    filename = f"deno_llm_reviewer_{node_token}.jpg"
+    storage_token = _reviewer_storage_token(unique_id, extra_pnginfo)
+    filename = f"deno_llm_reviewer_{storage_token}.jpg"
     return os.path.join(abs_dir, filename), filename, REVIEWER_PREVIEW_SUBFOLDER
 
 
-def _stable_reviewer_snapshot_path(unique_id: Any = None) -> Tuple[str, str, str]:
+def _stable_reviewer_snapshot_path(
+    unique_id: Any = None,
+    extra_pnginfo: Any = None,
+) -> Tuple[str, str, str]:
     import folder_paths
 
     temp_dir = folder_paths.get_temp_directory()
     abs_dir = os.path.join(temp_dir, REVIEWER_PREVIEW_SUBFOLDER)
     os.makedirs(abs_dir, exist_ok=True)
-    node_token = "".join(c for c in str(_extract_scalar(unique_id, "node")) if c.isalnum()) or "node"
-    filename = f"deno_llm_reviewer_{node_token}.npy"
+    storage_token = _reviewer_storage_token(unique_id, extra_pnginfo)
+    filename = f"deno_llm_reviewer_{storage_token}.npy"
     return os.path.join(abs_dir, filename), filename, REVIEWER_PREVIEW_SUBFOLDER
 
 
@@ -1491,12 +1553,16 @@ def _normalize_image_array_for_snapshot(image: Any) -> Optional[np.ndarray]:
     return np.clip(arr, 0.0, 1.0).astype(np.float32, copy=False)
 
 
-def _save_reviewer_snapshot_image(image: Any, unique_id: Any = None) -> Optional[Dict[str, Any]]:
+def _save_reviewer_snapshot_image(
+    image: Any,
+    unique_id: Any = None,
+    extra_pnginfo: Any = None,
+) -> Optional[Dict[str, Any]]:
     try:
         arr = _normalize_image_array_for_snapshot(image)
         if arr is None:
             return None
-        out_path, filename, subfolder = _stable_reviewer_snapshot_path(unique_id)
+        out_path, filename, subfolder = _stable_reviewer_snapshot_path(unique_id, extra_pnginfo)
         np.save(out_path, arr, allow_pickle=False)
         return {
             "filename": filename,
@@ -1553,6 +1619,7 @@ def _load_reviewer_snapshot_image(reviewer_state: Any, unique_id: Any = None):
 def _save_reviewer_preview_image(
     image: Any,
     unique_id: Any = None,
+    extra_pnginfo: Any = None,
     max_side: int = 640,
 ) -> Optional[Dict[str, Any]]:
     image = _extract_media(image)
@@ -1584,7 +1651,7 @@ def _save_reviewer_preview_image(
         pil = Image.fromarray(arr, "RGB")
         original_width, original_height = pil.size
         pil.thumbnail((int(max_side), int(max_side)), Image.Resampling.LANCZOS)
-        out_path, filename, subfolder = _stable_reviewer_preview_path(unique_id)
+        out_path, filename, subfolder = _stable_reviewer_preview_path(unique_id, extra_pnginfo)
         pil.save(out_path, format="JPEG", quality=90)
         return {
             "filename": filename,
@@ -2027,6 +2094,32 @@ def unload_local_llm_model(provider: str, server_url: str, model: str) -> Dict[s
     raise RuntimeError("Provider must be Ollama, LM Studio, llama.cpp, vLLM, or Custom.")
 
 
+def _cleanup_aborted_local_llm_batch(provider: str, server_url: str, model: str) -> Dict[str, Any]:
+    """Best-effort cleanup for an unload-after-run batch that ended before its last request."""
+    try:
+        result = unload_local_llm_model(provider, server_url, model)
+        if isinstance(result, dict):
+            if not result.get("ok"):
+                logging.warning(
+                    "DENO Local LLM could not unload an aborted %s batch for %s: %s",
+                    provider,
+                    model,
+                    result.get("message") or result.get("error") or result,
+                )
+            return result
+        return {"ok": True, "result": result}
+    except Exception as cleanup_error:
+        logging.warning(
+            "DENO Local LLM cleanup after an aborted %s batch failed for %s: %s",
+            provider,
+            model,
+            cleanup_error,
+        )
+        return {"ok": False, "error": str(cleanup_error)}
+    finally:
+        _clear_local_llm_warm(provider, server_url, model)
+
+
 async def _handle_list_models(request):
     try:
         payload = await request.json()
@@ -2257,6 +2350,8 @@ class DenoLocalLLMRefiner:
         thinking_results: List[str] = []
         post_run_unload_warnings: List[str] = []
         total = len(prompts)
+        batch_request_started = False
+        batch_cleanup_state: Dict[str, bool] = {"provider_cleanup_attempted": False}
 
         _send_progress({
             "node_id": node_id,
@@ -2291,6 +2386,8 @@ class DenoLocalLLMRefiner:
                 current_seed = _seed_for_index(seed_value, seed_mode_value, index)
                 is_last = index == total - 1
                 active_key = _mark_local_llm_active(provider_value, server_value, model_value)
+                batch_request_started = True
+                batch_cleanup_state = {"provider_cleanup_attempted": False}
                 try:
                     answer, thought, raw = self._run_single(
                         provider=provider_value,
@@ -2307,6 +2404,7 @@ class DenoLocalLLMRefiner:
                         node_id=node_id,
                         index=index + 1,
                         total=total,
+                        cleanup_state=batch_cleanup_state,
                     )
                 finally:
                     _clear_local_llm_active(active_key)
@@ -2327,6 +2425,12 @@ class DenoLocalLLMRefiner:
                 results.append(answer)
                 thinking_results.append(thought)
         except Exception as exc:
+            if (
+                memory_value == MEMORY_UNLOAD_AFTER_RUN
+                and batch_request_started
+                and not batch_cleanup_state.get("provider_cleanup_attempted", False)
+            ):
+                _cleanup_aborted_local_llm_batch(provider_value, server_value, model_value)
             _send_progress({
                 "node_id": node_id,
                 "status": "error",
@@ -2388,6 +2492,7 @@ class DenoLocalLLMRefiner:
         node_id: str,
         index: int,
         total: int,
+        cleanup_state: Optional[Dict[str, bool]] = None,
     ) -> Tuple[str, str, Dict[str, Any]]:
         if provider == PROVIDER_LM_STUDIO:
             return self._run_lm_studio(
@@ -2404,6 +2509,7 @@ class DenoLocalLLMRefiner:
                 node_id,
                 index,
                 total,
+                cleanup_state,
             )
         if provider in OPENAI_COMPATIBLE_PROVIDERS:
             return self._run_openai_compatible(
@@ -2421,6 +2527,7 @@ class DenoLocalLLMRefiner:
                 node_id,
                 index,
                 total,
+                cleanup_state,
             )
         return self._run_ollama(
             server_url,
@@ -2436,6 +2543,7 @@ class DenoLocalLLMRefiner:
             node_id,
             index,
             total,
+            cleanup_state,
         )
 
     def _run_ollama(
@@ -2453,6 +2561,7 @@ class DenoLocalLLMRefiner:
         node_id: str,
         index: int,
         total: int,
+        cleanup_state: Optional[Dict[str, bool]] = None,
     ) -> Tuple[str, str, Dict[str, Any]]:
         base = _normalize_ollama_url(server_url)
         memory_value = _normalize_model_memory(model_memory)
@@ -2479,7 +2588,15 @@ class DenoLocalLLMRefiner:
         last_emit = 0.0
         cancel_key = _llm_state_key(PROVIDER_OLLAMA, base, model)
 
+        request_observed = False
         for chunk in _http_stream_json_lines(f"{base}/api/chat", payload, cancel_key=cancel_key):
+            if not request_observed:
+                request_observed = True
+                if _should_unload_after_run(memory_value, is_last) and cleanup_state is not None:
+                    # A provider response proves that the terminal Ollama request carrying
+                    # keep_alive=0m was accepted. Post-processing must not issue a second
+                    # unload request for that same completed provider-owned cleanup.
+                    cleanup_state["provider_cleanup_attempted"] = True
             if chunk.get("error"):
                 detail = str(chunk.get("error"))
                 if _looks_like_model_unavailable_error(detail):
@@ -2559,6 +2676,7 @@ class DenoLocalLLMRefiner:
         node_id: str,
         index: int,
         total: int,
+        cleanup_state: Optional[Dict[str, bool]] = None,
     ) -> Tuple[str, str, Dict[str, Any]]:
         provider = _normalize_provider(provider)
         server_root, openai_base = _normalize_openai_compatible_urls(provider, server_url)
@@ -2654,6 +2772,8 @@ class DenoLocalLLMRefiner:
                     )
         finally:
             if _should_unload_after_run(memory_value, is_last):
+                if cleanup_state is not None:
+                    cleanup_state["provider_cleanup_attempted"] = True
                 post_run_unload = self._openai_compatible_unload_after_run(provider, server_root, model)
 
         raw = {
@@ -2710,6 +2830,7 @@ class DenoLocalLLMRefiner:
         node_id: str,
         index: int,
         total: int,
+        cleanup_state: Optional[Dict[str, bool]] = None,
     ) -> Tuple[str, str, Dict[str, Any]]:
         native_base = _normalize_lm_native_url(server_url)
         openai_base = _normalize_lm_openai_url(server_url)
@@ -2738,41 +2859,41 @@ class DenoLocalLLMRefiner:
         # while the real request uses LM Studio's native chat endpoint.
         cancel_key = _llm_state_key(PROVIDER_LM_STUDIO, openai_base, model)
 
-        for event_name, chunk in _http_stream_sse(f"{native_base}/api/v1/chat", payload, cancel_key=cancel_key):
-            if chunk.get("error"):
-                error = chunk.get("error")
-                if isinstance(error, dict):
-                    detail = str(error.get("message") or error)
-                else:
-                    detail = str(error)
-                if _looks_like_model_unavailable_error(detail):
-                    raise RuntimeError(_model_unavailable_message(model, detail))
-                raise RuntimeError(detail)
-            event_type = str(chunk.get("type") or event_name or "")
-            content = str(chunk.get("content") or "") if event_type == "message.delta" else ""
-            thought = str(chunk.get("content") or "") if event_type == "reasoning.delta" else ""
-            if content:
-                answer_parts.append(content)
-            if thought and thinking:
-                thinking_parts.append(thought)
-            if event_type == "chat.end":
-                final_meta = chunk
-            now = time.monotonic()
-            if now - last_emit > 0.12 or content or thought:
-                last_emit = now
-                _send_progress({
-                    "node_id": node_id,
-                    "status": "running",
-                    "provider": PROVIDER_LM_STUDIO,
-                    "model": model,
-                    "index": index,
-                    "total": total,
-                    "answer": "".join(answer_parts),
-                    "thinking": "".join(thinking_parts),
-                })
-
         diagnostic_meta: Optional[Dict[str, Any]] = None
         try:
+            for event_name, chunk in _http_stream_sse(f"{native_base}/api/v1/chat", payload, cancel_key=cancel_key):
+                if chunk.get("error"):
+                    error = chunk.get("error")
+                    if isinstance(error, dict):
+                        detail = str(error.get("message") or error)
+                    else:
+                        detail = str(error)
+                    if _looks_like_model_unavailable_error(detail):
+                        raise RuntimeError(_model_unavailable_message(model, detail))
+                    raise RuntimeError(detail)
+                event_type = str(chunk.get("type") or event_name or "")
+                content = str(chunk.get("content") or "") if event_type == "message.delta" else ""
+                thought = str(chunk.get("content") or "") if event_type == "reasoning.delta" else ""
+                if content:
+                    answer_parts.append(content)
+                if thought and thinking:
+                    thinking_parts.append(thought)
+                if event_type == "chat.end":
+                    final_meta = chunk
+                now = time.monotonic()
+                if now - last_emit > 0.12 or content or thought:
+                    last_emit = now
+                    _send_progress({
+                        "node_id": node_id,
+                        "status": "running",
+                        "provider": PROVIDER_LM_STUDIO,
+                        "model": model,
+                        "index": index,
+                        "total": total,
+                        "answer": "".join(answer_parts),
+                        "thinking": "".join(thinking_parts),
+                    })
+
             answer = "".join(answer_parts).strip()
             thought = "".join(thinking_parts).strip()
             if not answer and not thought and final_meta:
@@ -2785,6 +2906,8 @@ class DenoLocalLLMRefiner:
                 )
         finally:
             if _should_unload_after_run(memory_value, is_last):
+                if cleanup_state is not None:
+                    cleanup_state["provider_cleanup_attempted"] = True
                 self._lm_unload_best_effort(native_base, model)
 
         raw = {
@@ -2835,6 +2958,7 @@ class DenoAIReviewGate:
             },
             "hidden": {
                 "unique_id": "UNIQUE_ID",
+                "extra_pnginfo": "EXTRA_PNGINFO",
             },
         }
 
@@ -2875,6 +2999,7 @@ class DenoAIReviewGate:
         unclear_result="Reject",
         unique_id=None,
         reviewer_state="",
+        extra_pnginfo=None,
     ):
         normalized_mode = str(review_mode or "Review").strip()
         if normalized_mode == "Pass" or bool(approve_once):
@@ -2889,6 +3014,7 @@ class DenoAIReviewGate:
                 source="Manual pass" if normalized_mode == "Pass" else "Approve once",
                 preview_image=image,
                 unique_id=unique_id,
+                extra_pnginfo=extra_pnginfo,
                 approve_once_consumed=bool(approve_once),
             )
 
@@ -2907,6 +3033,7 @@ class DenoAIReviewGate:
             source="Text review",
             preview_image=image,
             unique_id=unique_id,
+            extra_pnginfo=extra_pnginfo,
         )
 
     def _gate_result(
@@ -2923,6 +3050,7 @@ class DenoAIReviewGate:
         blocked_count: Optional[int] = None,
         preview_image=None,
         unique_id=None,
+        extra_pnginfo=None,
         approve_once_consumed: bool = False,
     ):
         blocker = ExecutionBlocker(None)
@@ -2940,10 +3068,18 @@ class DenoAIReviewGate:
             ui_info["blocked_count"] = int(blocked_count)
         if approve_once_consumed:
             ui_info["approve_once_consumed"] = True
-        preview_meta = _save_reviewer_preview_image(preview_image if preview_image is not None else image, unique_id)
+        preview_meta = _save_reviewer_preview_image(
+            preview_image if preview_image is not None else image,
+            unique_id,
+            extra_pnginfo,
+        )
         if preview_meta:
             ui_info["preview_image"] = preview_meta
-        snapshot_meta = _save_reviewer_snapshot_image(preview_image if preview_image is not None else image, unique_id)
+        snapshot_meta = _save_reviewer_snapshot_image(
+            preview_image if preview_image is not None else image,
+            unique_id,
+            extra_pnginfo,
+        )
         if snapshot_meta:
             ui_info["snapshot_image"] = snapshot_meta
 

--- a/deno_ltx_multi_lora_loader.py
+++ b/deno_ltx_multi_lora_loader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import Dict, List, Tuple
 
 import comfy.lora
@@ -59,6 +60,8 @@ def _validate_range(kwargs, key: str, label: str, minimum: float, maximum: float
         value = float(kwargs.get(key, 1.0))
     except Exception:
         return f"{label} must be a number."
+    if not math.isfinite(value):
+        return f"{label} must be a finite number."
     if value < minimum or value > maximum:
         return f"{label} must be between {minimum:g} and {maximum:g}."
     return None
@@ -209,6 +212,18 @@ class DenoLTXMultiLoraLoader:
                 continue
 
             lora_name = str(kwargs.get(_slot_key("lora", index), LORA_NONE_OPTION))
+            strength = float(kwargs.get(_slot_key("strength", index), 1.0))
+            audio_scale = float(kwargs.get(_slot_key("audio", index), 1.0))
+            video_scale = float(kwargs.get(_slot_key("video", index), 1.0))
+            for value, label in (
+                (strength, "strength"),
+                (audio_scale, "audio strength"),
+                (video_scale, "video strength"),
+            ):
+                if not math.isfinite(value):
+                    raise ValueError(
+                        f"LTX LoRA slot {index} {label} must be a finite number."
+                    )
 
             lora_sd = self._load_lora_dict(lora_name)
             if lora_sd is None:
@@ -223,11 +238,8 @@ class DenoLTXMultiLoraLoader:
             lora_converted = comfy.lora_convert.convert_lora(lora_sd)
             loaded = comfy.lora.load_lora(lora_converted, key_map)
 
-            audio_scale = float(kwargs.get(_slot_key("audio", index), 1.0))
-            video_scale = float(kwargs.get(_slot_key("video", index), 1.0))
             loaded = self._apply_av_scaling(loaded, audio_scale=audio_scale, video_scale=video_scale)
 
-            strength = float(kwargs.get(_slot_key("strength", index), 1.0))
             if current_model is not None:
                 patched_model = current_model.clone()
                 patched_model.add_patches(loaded, strength)

--- a/deno_ltx_sequencer_plus.py
+++ b/deno_ltx_sequencer_plus.py
@@ -63,6 +63,11 @@ class DenoLTXSequencer:
         if bypass:
             return (positive, negative, latent)
 
+        batch_size = int(multi_input.shape[0]) if multi_input is not None else 0
+        effective_count = max(0, min(int(num_images), batch_size))
+        if effective_count <= 0:
+            return (positive, negative, latent)
+
         scale_factors = vae.downscale_index_formula
         # Keep parity with Comfy's LTXVAddGuide base behavior:
         # avoid cloning a large latent tensor up-front because append_keyframe
@@ -71,8 +76,7 @@ class DenoLTXSequencer:
         noise_mask = get_noise_mask(latent)
 
         _, _, latent_length, latent_height, latent_width = latent_image.shape
-        batch_size = int(multi_input.shape[0]) if multi_input is not None else 0
-        effective_count = max(0, min(int(num_images), batch_size))
+        applied_count = 0
 
         for index in range(1, effective_count + 1):
             image = multi_input[index - 1:index]
@@ -128,5 +132,8 @@ class DenoLTXSequencer:
                 strength,
                 scale_factors,
             )
+            applied_count += 1
 
+        if applied_count == 0:
+            return (positive, negative, latent)
         return (positive, negative, {"samples": latent_image, "noise_mask": noise_mask})

--- a/deno_ltx_tiled_nodes.py
+++ b/deno_ltx_tiled_nodes.py
@@ -994,6 +994,169 @@ class DenoLTXTiledSpatialUpscaler:
         return (result,)
 
 
+class _LegacyVideoStepFusedTilePredictor:
+    """Compatibility predictor for retired video-only saved workflows."""
+
+    def __init__(
+        self,
+        plan: list[TileSpec],
+        full_height: int,
+        full_width: int,
+        blend_mode: BlendMode,
+        previous_calculator: Any = None,
+        aggressive_memory_cleanup: bool = False,
+        debug: bool = False,
+    ) -> None:
+        self.plan = plan
+        self.full_height = full_height
+        self.full_width = full_width
+        self.blend_mode = blend_mode
+        self.previous_calculator = previous_calculator
+        self.aggressive_memory_cleanup = aggressive_memory_cleanup
+        self.debug = debug
+        self.call_count = 0
+        self._window_cache: dict[tuple[str, int, int], torch.Tensor] = {}
+        self._seen_sigma_strings: set[str] = set()
+
+    def _window(self, spec: TileSpec, x: torch.Tensor) -> torch.Tensor:
+        key = (str(x.device), spec.row, spec.col)
+        cached = self._window_cache.get(key)
+        if cached is None:
+            cached = make_spec_window(
+                spec,
+                dtype=torch.float32,
+                device=x.device,
+                mode=self.blend_mode,
+            )
+            self._window_cache[key] = cached
+        return cached
+
+    def _cleanup(self, device: torch.device) -> None:
+        if not self.aggressive_memory_cleanup:
+            return
+        gc.collect()
+        if device.type == "cuda":
+            torch.cuda.empty_cache()
+
+    def __call__(self, args: dict) -> list[torch.Tensor]:
+        self.call_count += 1
+        x = args["input"]
+        sigma = args["sigma"]
+        model = args["model"]
+        conds = args["conds"]
+        model_options = args["model_options"]
+
+        if not isinstance(x, torch.Tensor) or x.ndim != 5:
+            raise RuntimeError(
+                "Legacy video-only tiled prediction expected [B,C,F,H,W], got "
+                f"{type(x).__name__} {getattr(x, 'shape', None)}."
+            )
+        if tuple(x.shape[-2:]) != (self.full_height, self.full_width):
+            raise RuntimeError(
+                "Latent spatial shape changed during sampling: expected "
+                f"{self.full_height}x{self.full_width}, got {tuple(x.shape[-2:])}."
+            )
+
+        sigma_value = float(sigma.flatten()[0].detach().cpu())
+        sigma_label = f"{sigma_value:.7g}"
+        if self.debug and sigma_label not in self._seen_sigma_strings:
+            self._seen_sigma_strings.add(sigma_label)
+            print(
+                "[Deno LTX] legacy video step-fused prediction "
+                f"sigma={sigma_label}, tiles={len(self.plan)}"
+            )
+
+        accumulators: list[torch.Tensor] | None = None
+        weights = torch.zeros(
+            (1, 1, 1, self.full_height, self.full_width),
+            dtype=torch.float32,
+            device=x.device,
+        )
+
+        for spec in self.plan:
+            tile_x = x[:, :, :, spec.y0:spec.y1, spec.x0:spec.x1].contiguous()
+            tile_conds = _crop_conds_for_tile(
+                conds,
+                spec,
+                self.full_height,
+                self.full_width,
+                model,
+            )
+
+            tile_options = _clone_model_options(model_options)
+            tile_options.pop("sampler_calc_cond_batch_function", None)
+            transformer_options = tile_options.setdefault("transformer_options", {})
+            transformer_options["deno_ltx_tile"] = {
+                "row": spec.row,
+                "col": spec.col,
+                "origin": (spec.y0, spec.x0),
+                "tile_shape": (spec.height, spec.width),
+                "full_shape": (self.full_height, self.full_width),
+            }
+
+            if self.previous_calculator is not None:
+                tile_args = dict(args)
+                tile_args["input"] = tile_x
+                tile_args["conds"] = tile_conds
+                tile_args["model_options"] = tile_options
+                tile_predictions = self.previous_calculator(tile_args)
+            else:
+                tile_predictions = _comfy_samplers().calc_cond_batch(
+                    model,
+                    tile_conds,
+                    tile_x,
+                    sigma,
+                    tile_options,
+                )
+
+            if accumulators is None:
+                accumulators = [
+                    torch.zeros_like(x, dtype=torch.float32, device=x.device)
+                    for _ in tile_predictions
+                ]
+            if len(tile_predictions) != len(accumulators):
+                raise RuntimeError(
+                    "Conditional prediction count changed between tiles: "
+                    f"expected {len(accumulators)}, got {len(tile_predictions)}."
+                )
+
+            window = self._window(spec, x)
+            for accumulator, prediction in zip(accumulators, tile_predictions):
+                if tuple(prediction.shape) != tuple(tile_x.shape):
+                    raise RuntimeError(
+                        "Tile model prediction shape mismatch: "
+                        f"prediction={tuple(prediction.shape)}, tile={tuple(tile_x.shape)}."
+                    )
+                accumulator[:, :, :, spec.y0:spec.y1, spec.x0:spec.x1].add_(
+                    prediction.float() * window
+                )
+
+            weights[:, :, :, spec.y0:spec.y1, spec.x0:spec.x1].add_(window)
+
+            if self.debug:
+                print(
+                    f"  legacy r{spec.row}c{spec.col} "
+                    f"y={spec.y0}:{spec.y1} x={spec.x0}:{spec.x1}"
+                )
+
+            del tile_x, tile_conds, tile_options, tile_predictions, window
+            self._cleanup(x.device)
+
+        if accumulators is None:
+            raise RuntimeError("No tile predictions were produced.")
+        min_weight = float(weights.min().item())
+        if min_weight <= 1e-7:
+            raise RuntimeError(
+                f"Step-fused tile plan left uncovered pixels; min weight={min_weight}."
+            )
+
+        denominator = weights.clamp_min(1e-8)
+        return [
+            (accumulator / denominator).to(dtype=x.dtype)
+            for accumulator in accumulators
+        ]
+
+
 class StepFusedAVTilePredictor:
     """Tiled video prediction with full-audio context for packed LTX AV latents."""
 
@@ -1205,6 +1368,186 @@ class StepFusedAVTilePredictor:
         return packed_results
 
 
+class _LegacyVideoStepFusedTiledSampler:
+    """Execution-only bridge for the retired public video-only node ID."""
+
+    @staticmethod
+    def _validate_samples(samples: Any) -> torch.Tensor:
+        if _is_nested(samples):
+            raise TypeError(
+                "The retired DENO LTX video-only sampler cannot process AV nested latents."
+            )
+        if not isinstance(samples, torch.Tensor):
+            raise TypeError(
+                f"Expected torch.Tensor latent samples, got {type(samples).__name__}."
+            )
+        if samples.ndim != 5:
+            raise ValueError(
+                f"Expected [B,C,F,H,W] LTX video latent, got {tuple(samples.shape)}."
+            )
+        return samples
+
+    @staticmethod
+    def _fix_channels(guider: Any, latent: dict, samples: torch.Tensor) -> torch.Tensor:
+        return _comfy_sample().fix_empty_latent_channels(
+            guider.model_patcher,
+            samples,
+            latent.get("downscale_ratio_spacial", None),
+            latent.get("downscale_ratio_temporal", None),
+        )
+
+    def sample(
+        self,
+        noise,
+        guider,
+        sampler,
+        sigmas,
+        latent_image,
+        horizontal_tiles=1,
+        vertical_tiles=2,
+        overlap=8,
+        blend_mode: BlendMode = "hann",
+        aggressive_memory_cleanup=False,
+        debug=False,
+    ):
+        latent = latent_image.copy()
+        source = self._validate_samples(latent["samples"])
+        source = self._fix_channels(guider, latent, source)
+        latent["samples"] = source
+
+        _, _, _, height, width = source.shape
+        plan = build_tile_plan(
+            height=height,
+            width=width,
+            vertical_tiles=int(vertical_tiles),
+            horizontal_tiles=int(horizontal_tiles),
+            overlap=int(overlap),
+        )
+
+        if len(plan) == 1:
+            if debug:
+                print(
+                    "[Deno LTX] legacy video workflow requested one tile; "
+                    "using the stock guider.sample path."
+                )
+            return self._stock_sample(noise, guider, sampler, sigmas, latent)
+
+        tiled_guider = copy.copy(guider)
+        tiled_options = _clone_model_options(getattr(guider, "model_options", {}))
+        previous_calculator = tiled_options.get("sampler_calc_cond_batch_function")
+        predictor = _LegacyVideoStepFusedTilePredictor(
+            plan=plan,
+            full_height=height,
+            full_width=width,
+            blend_mode=blend_mode,
+            previous_calculator=previous_calculator,
+            aggressive_memory_cleanup=bool(aggressive_memory_cleanup),
+            debug=bool(debug),
+        )
+        tiled_options["sampler_calc_cond_batch_function"] = predictor
+        tiled_guider.model_options = tiled_options
+
+        noise_mask = latent.get("noise_mask")
+        x0_output: dict[str, Any] = {}
+        callback = _latent_preview().prepare_callback(
+            tiled_guider.model_patcher,
+            sigmas.shape[-1] - 1,
+            x0_output,
+        )
+        global_noise = noise.generate_noise(latent)
+
+        if debug:
+            print(
+                "[Deno LTX] legacy video step-fused sampler input="
+                f"{tuple(source.shape)}, tiles={vertical_tiles}x{horizontal_tiles}, "
+                f"overlap={overlap}, blend={blend_mode}"
+            )
+
+        samples = tiled_guider.sample(
+            global_noise,
+            source,
+            sampler,
+            sigmas,
+            denoise_mask=noise_mask,
+            callback=callback,
+            disable_pbar=not _comfy_utils().PROGRESS_BAR_ENABLED,
+            seed=noise.seed,
+        )
+
+        if predictor.call_count == 0:
+            raise RuntimeError(
+                "The supplied guider did not invoke ComfyUI's conditional-batch "
+                "calculation hook, so legacy video tiled prediction was not active."
+            )
+
+        intermediate_device = _comfy_model_management().intermediate_device()
+        samples = samples.to(intermediate_device)
+
+        output = latent.copy()
+        output.pop("downscale_ratio_spacial", None)
+        output.pop("downscale_ratio_temporal", None)
+        output["samples"] = samples
+        output["deno_ltx_step_fused_tiling"] = {
+            "horizontal_tiles": int(horizontal_tiles),
+            "vertical_tiles": int(vertical_tiles),
+            "overlap": int(overlap),
+            "blend_mode": str(blend_mode),
+            "prediction_calls": int(predictor.call_count),
+        }
+
+        if "x0" in x0_output:
+            x0 = tiled_guider.model_patcher.model.process_latent_out(
+                x0_output["x0"].cpu()
+            )
+            denoised = latent.copy()
+            denoised.pop("downscale_ratio_spacial", None)
+            denoised.pop("downscale_ratio_temporal", None)
+            denoised["samples"] = x0.to(intermediate_device)
+            denoised["deno_ltx_step_fused_tiling"] = output[
+                "deno_ltx_step_fused_tiling"
+            ].copy()
+        else:
+            denoised = output
+
+        return output, denoised
+
+    @staticmethod
+    def _stock_sample(noise, guider, sampler, sigmas, latent):
+        source = latent["samples"]
+        noise_mask = latent.get("noise_mask")
+        x0_output: dict[str, Any] = {}
+        callback = _latent_preview().prepare_callback(
+            guider.model_patcher,
+            sigmas.shape[-1] - 1,
+            x0_output,
+        )
+        samples = guider.sample(
+            noise.generate_noise(latent),
+            source,
+            sampler,
+            sigmas,
+            denoise_mask=noise_mask,
+            callback=callback,
+            disable_pbar=not _comfy_utils().PROGRESS_BAR_ENABLED,
+            seed=noise.seed,
+        ).to(_comfy_model_management().intermediate_device())
+
+        output = latent.copy()
+        output.pop("downscale_ratio_spacial", None)
+        output.pop("downscale_ratio_temporal", None)
+        output["samples"] = samples
+        if "x0" in x0_output:
+            denoised = latent.copy()
+            denoised.pop("downscale_ratio_spacial", None)
+            denoised.pop("downscale_ratio_temporal", None)
+            denoised["samples"] = guider.model_patcher.model.process_latent_out(
+                x0_output["x0"].cpu()
+            ).to(_comfy_model_management().intermediate_device())
+        else:
+            denoised = output
+        return output, denoised
+
+
 class DenoLTXAVStepFusedTiledSampler:
     DESCRIPTION = (
         "Refines the video half of an LTX AV latent with step-fused spatial tiles "
@@ -1252,6 +1595,9 @@ class DenoLTXAVStepFusedTiledSampler:
                 "blend_mode": (["hann", "cosine"], {"default": "hann"}),
                 "aggressive_memory_cleanup": ("BOOLEAN", {"default": True}),
                 "debug": ("BOOLEAN", {"default": False}),
+            },
+            "hidden": {
+                "_deno_legacy_video_compat": "DENO_LEGACY_VIDEO_COMPAT",
             },
         }
 
@@ -1348,7 +1694,26 @@ class DenoLTXAVStepFusedTiledSampler:
         blend_mode: BlendMode = "hann",
         aggressive_memory_cleanup=True,
         debug=False,
+        _deno_legacy_video_compat=False,
     ):
+        if _deno_legacy_video_compat is True:
+            # Compatibility-only path selected by the hidden migration marker
+            # inserted when DenoLTXStepFusedTiledSampler is replaced. Current
+            # AV nodes retain their original strict NestedTensor contract.
+            return _LegacyVideoStepFusedTiledSampler().sample(
+                noise,
+                guider,
+                sampler,
+                sigmas,
+                latent_image,
+                horizontal_tiles=horizontal_tiles,
+                vertical_tiles=vertical_tiles,
+                overlap=overlap,
+                blend_mode=blend_mode,
+                aggressive_memory_cleanup=aggressive_memory_cleanup,
+                debug=debug,
+            )
+
         if audio_mode != "freeze":
             raise ValueError(
                 "Deno LTX AV Step-Fused Tiled Sampler currently only supports "

--- a/deno_multi_lora_loader.py
+++ b/deno_multi_lora_loader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import Dict, List, Tuple
 
 import comfy.lora
@@ -51,6 +52,8 @@ def _validate_range(kwargs, key: str, label: str, minimum: float, maximum: float
         value = float(kwargs.get(key, 1.0))
     except Exception:
         return f"{label} must be a number."
+    if not math.isfinite(value):
+        return f"{label} must be a finite number."
     if value < minimum or value > maximum:
         return f"{label} must be between {minimum:g} and {maximum:g}."
     return None
@@ -153,6 +156,12 @@ class DenoMultiLoraLoader:
                 continue
 
             lora_name = str(kwargs.get(_slot_key("lora", index), LORA_NONE_OPTION))
+            model_strength = float(kwargs.get(_slot_key("model_strength", index), 1.0))
+            clip_strength = float(kwargs.get(_slot_key("clip_strength", index), 1.0))
+            if not math.isfinite(model_strength):
+                raise ValueError(f"LoRA slot {index} model strength must be a finite number.")
+            if not math.isfinite(clip_strength):
+                raise ValueError(f"LoRA slot {index} CLIP strength must be a finite number.")
             lora_sd = self._load_lora_dict(lora_name)
             if lora_sd is None:
                 continue
@@ -165,9 +174,6 @@ class DenoMultiLoraLoader:
 
             lora_converted = comfy.lora_convert.convert_lora(lora_sd)
             loaded = comfy.lora.load_lora(lora_converted, key_map)
-
-            model_strength = float(kwargs.get(_slot_key("model_strength", index), 1.0))
-            clip_strength = float(kwargs.get(_slot_key("clip_strength", index), 1.0))
 
             if current_model is not None and abs(model_strength) > 1e-9:
                 patched_model = current_model.clone()

--- a/deno_rtx_vfx_video_finisher.py
+++ b/deno_rtx_vfx_video_finisher.py
@@ -148,6 +148,12 @@ class DenoRTXVFXVideoFinisher:
         ratio_preset: str,
         resize_method: str,
     ):
+        # A fully disabled finisher is a true pass-through. Return before any
+        # CUDA / RTX VFX probing so CPU-only workflows can leave the node in
+        # place without changing tensor identity, dtype, device, or channels.
+        if first_pass == "Off" and upscale_pass == "Off":
+            return (images,)
+
         if not torch.cuda.is_available():
             raise RuntimeError("NVIDIA RTX VFX requires CUDA. This ComfyUI Python does not currently see CUDA.")
 

--- a/deno_video_compare.py
+++ b/deno_video_compare.py
@@ -130,9 +130,22 @@ def _composite_frames(mode, video_a, video_b, split_position, swap, toggle_image
     if b is None:
         return a.clamp(0.0, 1.0)
 
-    n = min(int(a.shape[0]), int(b.shape[0]))
-    a = a[:n]
-    b = b[:n]
+    count_a = int(a.shape[0])
+    count_b = int(b.shape[0])
+    n = min(count_a, count_b)
+    if count_a == count_b:
+        # Keep the long-standing equal-batch path bit-for-bit direct.
+        a = a[:n]
+        b = b[:n]
+    else:
+        # The output length remains the shorter batch for saved-workflow and
+        # downstream compatibility, but the longer clip now spans its whole
+        # timeline instead of silently dropping every frame after ``n``.
+        # Keep the shorter clip on its direct slice and resample only the
+        # longer side. For a one-frame output _sample_indices returns [0],
+        # preserving the historical first-frame result.
+        a = a[_sample_indices(count_a, n)] if count_a > n else a[:n]
+        b = b[_sample_indices(count_b, n)] if count_b > n else b[:n]
 
     if mode == "Side by Side":
         h = max(int(a.shape[1]), int(b.shape[1]))

--- a/deno_video_preview.py
+++ b/deno_video_preview.py
@@ -19,6 +19,9 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import glob
+import threading
+import uuid
 from fractions import Fraction
 
 import numpy as np
@@ -26,6 +29,7 @@ import torch
 
 
 PREVIEW_SUBFOLDER = "deno_vprev"
+DIRECT_PROMPT_PREVIEW_LIMIT = 4
 
 
 def _require_av():
@@ -68,6 +72,24 @@ def _workflow_id_from_extra_pnginfo(extra_pnginfo):
     return "legacy-workflow"
 
 
+def _active_prompt_id():
+    try:
+        from comfy_execution.utils import get_executing_context
+
+        context = get_executing_context()
+        return str(getattr(context, "prompt_id", "") or "").strip()
+    except Exception:
+        return ""
+
+
+def _preview_workflow_identity(extra_pnginfo):
+    workflow_id = _workflow_id_from_extra_pnginfo(extra_pnginfo)
+    if workflow_id != "legacy-workflow":
+        return workflow_id
+    prompt_id = _active_prompt_id()
+    return f"prompt:{prompt_id}" if prompt_id else workflow_id
+
+
 def _stable_preview_path(unique_id, workflow_id=None):
     import folder_paths
 
@@ -78,8 +100,40 @@ def _stable_preview_path(unique_id, workflow_id=None):
     workflow_token = hashlib.sha256(workflow_key.encode("utf-8")).hexdigest()[:16]
     node_key = str(unique_id) or "node"
     node_token = hashlib.sha256(node_key.encode("utf-8")).hexdigest()[:16]
-    filename = f"deno_vprev_{workflow_token}_{node_token}.mp4"
+    prefix = "deno_vprev_prompt" if workflow_key.startswith("prompt:") else "deno_vprev"
+    filename = f"{prefix}_{workflow_token}_{node_token}.mp4"
     return os.path.join(abs_dir, filename), filename, PREVIEW_SUBFOLDER
+
+
+def _unique_partial_preview_path(out_path):
+    token = f"{os.getpid()}-{threading.get_ident()}-{uuid.uuid4().hex}"
+    return f"{out_path}.partial-{token}.mp4"
+
+
+def _remove_file_best_effort(path):
+    try:
+        if path and os.path.isfile(path):
+            os.remove(path)
+    except OSError:
+        pass
+
+
+def _prune_direct_prompt_previews(out_path, limit=DIRECT_PROMPT_PREVIEW_LIMIT):
+    """Bound prompt-id fallback files without touching persistent workflows."""
+    filename = os.path.basename(out_path)
+    if not filename.startswith("deno_vprev_prompt_"):
+        return
+    node_token = filename.rsplit("_", 1)[-1].removesuffix(".mp4")
+    pattern = os.path.join(os.path.dirname(out_path), f"deno_vprev_prompt_*_{node_token}.mp4")
+    candidates = []
+    for path in glob.glob(pattern):
+        try:
+            candidates.append((os.stat(path).st_mtime_ns, path))
+        except OSError:
+            continue
+    candidates.sort(reverse=True)
+    for _mtime, path in candidates[max(1, int(limit)):]:
+        _remove_file_best_effort(path)
 
 
 def _extract_waveform_and_sr(audio):
@@ -259,10 +313,18 @@ class DenoVideoPreview:
         if out_w <= 0 or out_h <= 0:
             raise ValueError("(Deno) Video Preview needs frames at least 2x2.")
 
-        workflow_id = _workflow_id_from_extra_pnginfo(extra_pnginfo)
+        workflow_id = _preview_workflow_identity(extra_pnginfo)
         out_path, filename, subfolder = _stable_preview_path(unique_id, workflow_id)
+        partial_path = _unique_partial_preview_path(out_path)
+        container = None
+        encode_error = None
+        has_audio = False
+        try:
+            container = av.open(partial_path, mode="w", options={"movflags": "+faststart"})
+        except BaseException:
+            _remove_file_best_effort(partial_path)
+            raise
 
-        container = av.open(out_path, mode="w", options={"movflags": "+faststart"})
         try:
             stream = container.add_stream("libx264", rate=fps)
             stream.width = out_w
@@ -297,14 +359,28 @@ class DenoVideoPreview:
                 _encode_audio(av, container, audio_ctx)
                 if audio_ctx is not None else False
             )
+        except BaseException as exc:
+            encode_error = exc
         finally:
-            container.close()
+            try:
+                container.close()
+            except BaseException as exc:
+                if encode_error is None:
+                    encode_error = exc
 
-        if not os.path.isfile(out_path) or os.path.getsize(out_path) <= 0:
-            raise RuntimeError(
-                "(Deno) Video Preview produced no output file. The frames "
-                "may be an unsupported shape, or PyAV failed to encode H.264."
-            )
+        try:
+            if encode_error is not None:
+                raise encode_error.with_traceback(encode_error.__traceback__)
+            if not os.path.isfile(partial_path) or os.path.getsize(partial_path) <= 0:
+                raise RuntimeError(
+                    "(Deno) Video Preview produced no output file. The frames "
+                    "may be an unsupported shape, or PyAV failed to encode H.264."
+                )
+            os.replace(partial_path, out_path)
+        except BaseException:
+            _remove_file_best_effort(partial_path)
+            raise
+        _prune_direct_prompt_previews(out_path)
 
         return {
             "ui": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "deno-custom-nodes"
 description = "DENO RTX node pack for ComfyUI: Ideogram Director visual JSON/bbox prompt builder, Local LLM Loader and Reviewer helpers, GPT/Gemini-ready Error Help reports, Prompt Only final prompt extraction, RTX Video Super Resolution, RTX Super Resolution, Video SR/VSR, NVIDIA VFX/nvvfx, RTX upscale helpers, LTX 2.3 workflows, LTX tiled second-pass refinement helpers, Bernini Prompt Guide, audio/image review gates, Bernini conditioning helpers, Wan 2.2 reference video edit workflows, image and video compare, video preview, Video to GIF/WebP tools, multi-image loading, resize tools, LoRA/model helpers, prompt guides, and visual workflow utilities."
-version = "0.7.68"
+version = "0.7.69"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = []

--- a/tests/fixtures/public_workflows/legacy_ltx_step_fused_sampler_v0762.json
+++ b/tests/fixtures/public_workflows/legacy_ltx_step_fused_sampler_v0762.json
@@ -1,0 +1,150 @@
+{
+  "id": "deno-legacy-ltx-step-fused-v0762",
+  "revision": 0,
+  "last_node_id": 21,
+  "last_link_id": 8,
+  "nodes": [
+    {
+      "id": 10,
+      "type": "FixtureNoiseSource",
+      "pos": [-300, 20],
+      "size": [180, 60],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [{"name": "noise", "type": "NOISE", "links": [1]}],
+      "properties": {}
+    },
+    {
+      "id": 11,
+      "type": "FixtureGuiderSource",
+      "pos": [-300, 100],
+      "size": [180, 60],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [{"name": "guider", "type": "GUIDER", "links": [2]}],
+      "properties": {}
+    },
+    {
+      "id": 12,
+      "type": "FixtureSamplerSource",
+      "pos": [-300, 180],
+      "size": [180, 60],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [{"name": "sampler", "type": "SAMPLER", "links": [3]}],
+      "properties": {}
+    },
+    {
+      "id": 13,
+      "type": "FixtureSigmasSource",
+      "pos": [-300, 260],
+      "size": [180, 60],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [{"name": "sigmas", "type": "SIGMAS", "links": [4]}],
+      "properties": {}
+    },
+    {
+      "id": 14,
+      "type": "FixtureLatentSource",
+      "pos": [-300, 340],
+      "size": [180, 60],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [{"name": "latent", "type": "LATENT", "links": [5]}],
+      "properties": {}
+    },
+    {
+      "id": 15,
+      "type": "FixtureComboSource",
+      "pos": [-300, 420],
+      "size": [180, 60],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [{"name": "blend", "type": "COMBO", "links": [6]}],
+      "properties": {}
+    },
+    {
+      "id": 1,
+      "type": "DenoLTXStepFusedTiledSampler",
+      "pos": [100, 100],
+      "size": [360, 310],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {"name": "noise", "type": "NOISE", "link": 1},
+        {"name": "guider", "type": "GUIDER", "link": 2},
+        {"name": "sampler", "type": "SAMPLER", "link": 3},
+        {"name": "sigmas", "type": "SIGMAS", "link": 4},
+        {"name": "latent_image", "type": "LATENT", "link": 5},
+        {"name": "horizontal_tiles", "type": "INT", "widget": {"name": "horizontal_tiles"}, "link": null},
+        {"name": "vertical_tiles", "type": "INT", "widget": {"name": "vertical_tiles"}, "link": null},
+        {"name": "overlap", "type": "INT", "widget": {"name": "overlap"}, "link": null},
+        {"name": "blend_mode", "type": "COMBO", "widget": {"name": "blend_mode"}, "link": 6},
+        {"name": "aggressive_memory_cleanup", "type": "BOOLEAN", "widget": {"name": "aggressive_memory_cleanup"}, "link": null},
+        {"name": "debug", "type": "BOOLEAN", "widget": {"name": "debug"}, "link": null}
+      ],
+      "outputs": [
+        {"name": "output", "type": "LATENT", "links": [7]},
+        {"name": "denoised_output", "type": "LATENT", "links": [8]}
+      ],
+      "properties": {
+        "cnr_id": "deno-custom-nodes",
+        "ver": "0.7.62",
+        "Node name for S&R": "DenoLTXStepFusedTiledSampler"
+      },
+      "widgets_values": [1, 2, 8, "hann", false, false]
+    },
+    {
+      "id": 20,
+      "type": "FixtureLatentSink",
+      "pos": [600, 120],
+      "size": [180, 60],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [{"name": "latent", "type": "LATENT", "link": 7}],
+      "outputs": [],
+      "properties": {}
+    },
+    {
+      "id": 21,
+      "type": "FixtureLatentSink",
+      "pos": [600, 220],
+      "size": [180, 60],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [{"name": "latent", "type": "LATENT", "link": 8}],
+      "outputs": [],
+      "properties": {}
+    }
+  ],
+  "links": [
+    [1, 10, 0, 1, 0, "NOISE"],
+    [2, 11, 0, 1, 1, "GUIDER"],
+    [3, 12, 0, 1, 2, "SAMPLER"],
+    [4, 13, 0, 1, 3, "SIGMAS"],
+    [5, 14, 0, 1, 4, "LATENT"],
+    [6, 15, 0, 1, 8, "COMBO"],
+    [7, 1, 0, 20, 0, "LATENT"],
+    [8, 1, 1, 21, 0, "LATENT"]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {"frontendVersion": "1.45.14"},
+  "version": 0.4
+}

--- a/tests/js/floating_tools_update_cache_harness.mjs
+++ b/tests/js/floating_tools_update_cache_harness.mjs
@@ -109,6 +109,9 @@ function makeHarness({ system, latestVersions, failLatestMetadata = false, syste
       if (textUrl.includes("/ComfyUI/releases/latest")) {
         return makeResponse({ tag_name: latestVersions.comfyui });
       }
+      if (textUrl.includes("/ComfyUI/tags?")) {
+        return makeResponse(latestVersions.comfyui ? [{ name: latestVersions.comfyui }] : []);
+      }
       if (textUrl.includes("/comfyui-workflow-templates/json")) {
         return makeResponse({ info: { version: latestVersions.templates } });
       }
@@ -272,6 +275,56 @@ const expiredTime = latestFetchedAt + UPDATE_CACHE_TTL_MS + 1;
     ],
     "remote latest failure should keep live installed versions and mark latest values unknown",
   );
+}
+
+{
+  const harness = makeHarness({
+    system: {
+      comfyui_version: "0.26.2",
+      installed_templates_version: "0.10.7",
+      comfy_package_versions: [{ name: "comfyui-frontend-package", installed: "1.45.19" }],
+    },
+    latestVersions: {
+      comfyui: "",
+      templates: "0.10.7",
+      frontend: "1.45.19",
+    },
+  });
+
+  harness.setNow(oneHourLater);
+  await harness.hooks.checkUpdates(true);
+  const state = harness.getCachedState();
+  assert.equal(state.status, "error", "malformed HTTP 200 metadata must not render Latest");
+  assert.match(state.error, /incomplete/i);
+}
+
+{
+  const harness = makeHarness({
+    system: {
+      comfyui_version: "0.26.2",
+      installed_templates_version: "0.10.7",
+      comfy_package_versions: [{ name: "comfyui-frontend-package", installed: "1.45.19" }],
+    },
+    latestVersions: {
+      comfyui: "v0.26.2",
+      templates: "0.10.7",
+      frontend: "1.45.19",
+    },
+  });
+  harness.setCachedState({
+    status: "latest",
+    checkedAt: oneHourLater + 1,
+    latestCheckedAt: oneHourLater + 1,
+    items: [
+      { id: "comfyui", latest: "0.26.2" },
+      { id: "templates", latest: "0.10.7" },
+      { id: "frontend", latest: "1.45.19" },
+    ],
+  });
+
+  harness.setNow(oneHourLater);
+  await harness.hooks.checkUpdates(false);
+  assert.equal(harness.fetchCalls.length, 3, "future metadata timestamps must force a fresh fetch");
 }
 
 {

--- a/tests/js/frontend_lifecycle_race_harness.mjs
+++ b/tests/js/frontend_lifecycle_race_harness.mjs
@@ -1,0 +1,361 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import vm from "node:vm";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readSource(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function loadHooks(relativePath, hookName, overrides = {}) {
+  let hooks = null;
+  const context = {
+    console,
+    AbortController,
+    URL,
+    URLSearchParams,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+    requestAnimationFrame() { return 1; },
+    cancelAnimationFrame() {},
+    queueMicrotask,
+    app: { registerExtension() {} },
+    api: { addEventListener() {} },
+    LiteGraph: {},
+    ...overrides,
+  };
+  context.window = context;
+  context.globalThis = context;
+  context[hookName] = (registered) => {
+    hooks = registered;
+  };
+
+  const source = readSource(relativePath).replace(/^import .*;\r?\n/gm, "");
+  vm.runInNewContext(source, context, { filename: relativePath });
+  assert.ok(hooks, `${relativePath} did not expose ${hookName}`);
+  return hooks;
+}
+
+function loadExtension(relativePath, overrides = {}) {
+  let extension = null;
+  const context = {
+    console,
+    AbortController,
+    URL,
+    URLSearchParams,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+    requestAnimationFrame() { return 1; },
+    cancelAnimationFrame() {},
+    queueMicrotask,
+    app: {
+      registerExtension(registered) {
+        extension = registered;
+      },
+    },
+    api: { addEventListener() {} },
+    LiteGraph: {},
+    ...overrides,
+  };
+  context.window = context;
+  context.globalThis = context;
+  const source = readSource(relativePath).replace(/^import .*;\r?\n/gm, "");
+  vm.runInNewContext(source, context, { filename: relativePath });
+  assert.ok(extension, `${relativePath} did not register an extension`);
+  return extension;
+}
+
+function assertLatestRequestGate(createGate, label) {
+  const gate = createGate();
+  const first = gate.start();
+  assert.equal(first.signal.aborted, false, `${label}: first request should start active`);
+  assert.equal(first.isCurrent(), true, `${label}: first request should be current`);
+
+  const second = gate.start();
+  assert.equal(first.signal.aborted, true, `${label}: a newer request must abort the previous request`);
+  assert.equal(first.isCurrent(), false, `${label}: the previous request must become stale`);
+  assert.equal(second.isCurrent(), true, `${label}: the newest request should remain current`);
+
+  gate.dispose();
+  assert.equal(second.signal.aborted, true, `${label}: disposal must abort the active request`);
+  assert.equal(second.isCurrent(), false, `${label}: disposal must invalidate the active request`);
+}
+
+const extraHooks = loadHooks("web/js/deno_extra_nodes.js", "__DENO_EXTRA_NODES_TEST_HOOK__");
+assertLatestRequestGate(extraHooks.createLatestRequestGate, "Multi Image folder browser");
+
+const advancedHooks = loadHooks(
+  "web/js/deno_advanced_image_source_loader.js",
+  "__DENO_ADVANCED_IMAGE_SOURCE_TEST_HOOK__",
+);
+assertLatestRequestGate(advancedHooks.createLatestRequestGate, "Advanced Image folder browser");
+
+let downloaderExtension = null;
+const downloaderHooks = loadHooks(
+  "web/js/deno_ltx_model_downloader.js",
+  "__DENO_LTX_MODEL_DOWNLOADER_TEST_HOOK__",
+  {
+    app: {
+      registerExtension(extension) {
+        downloaderExtension = extension;
+      },
+    },
+  },
+);
+assertLatestRequestGate(downloaderHooks.createLatestRequestGate, "LTX Model Downloader refresh");
+assert.ok(downloaderExtension, "LTX Model Downloader extension should register");
+class FakeDownloaderNode {}
+let originalRemovedCalls = 0;
+FakeDownloaderNode.prototype.onRemoved = function () {
+  originalRemovedCalls += 1;
+  return "removed";
+};
+await downloaderExtension.beforeRegisterNodeDef(FakeDownloaderNode, { name: "DenoLTXModelDownloader" });
+const downloaderNode = new FakeDownloaderNode();
+let disposeCalls = 0;
+downloaderNode.__denoLtxSetupUi = { dispose() { disposeCalls += 1; } };
+downloaderNode.__denoLtxSetupReady = true;
+assert.equal(downloaderNode.onRemoved(), "removed", "node removal should preserve the original callback result");
+assert.equal(disposeCalls, 1, "node removal should dispose the downloader UI exactly once");
+assert.equal(originalRemovedCalls, 1, "node removal should still call the original lifecycle callback");
+assert.equal(downloaderNode.__denoLtxSetupUi, null, "node removal should release the UI reference");
+assert.equal(downloaderNode.__denoLtxSetupDisposed, true, "node removal should block queued setup work");
+
+let nextTimerId = 1;
+const intervals = new Map();
+const timeouts = new Map();
+const cancelledFrames = [];
+let videoExtension = null;
+const videoHooks = loadHooks("web/js/deno_video_compare.js", "__DENO_VIDEO_COMPARE_TEST_HOOK__", {
+  app: {
+    registerExtension(extension) {
+      videoExtension = extension;
+    },
+  },
+  setInterval(callback) {
+    const id = nextTimerId++;
+    intervals.set(id, callback);
+    return id;
+  },
+  clearInterval(id) {
+    intervals.delete(id);
+  },
+  setTimeout(callback) {
+    const id = nextTimerId++;
+    timeouts.set(id, callback);
+    return id;
+  },
+  clearTimeout(id) {
+    timeouts.delete(id);
+  },
+  cancelAnimationFrame(id) {
+    cancelledFrames.push(id);
+  },
+});
+
+const state = {
+  beginRun: 0,
+  beginInterval: null,
+  beginTimeout: null,
+  destroyed: false,
+};
+let beginCalls = 0;
+const firstFrame = { ready: false };
+videoHooks.schedulePlaybackBegin(state, firstFrame, () => { beginCalls += 1; });
+const readyCallback = intervals.get(state.beginInterval);
+const fallbackCallback = timeouts.get(state.beginTimeout);
+assert.equal(typeof readyCallback, "function", "Video Compare should poll for its first decoded frame");
+assert.equal(typeof fallbackCallback, "function", "Video Compare should retain its 1.5 second fallback");
+
+firstFrame.ready = true;
+readyCallback();
+assert.equal(beginCalls, 1, "first-frame readiness should begin playback once");
+assert.equal(state.beginInterval, null, "successful begin should clear the polling interval");
+assert.equal(state.beginTimeout, null, "successful begin should clear the fallback timeout");
+fallbackCallback();
+assert.equal(beginCalls, 1, "a stale fallback callback must not begin playback twice");
+
+const staleFrame = { ready: false };
+videoHooks.schedulePlaybackBegin(state, staleFrame, () => { beginCalls += 10; });
+const staleInterval = intervals.get(state.beginInterval);
+const staleTimeout = timeouts.get(state.beginTimeout);
+const latestFrame = { ready: false };
+videoHooks.schedulePlaybackBegin(state, latestFrame, () => { beginCalls += 1; });
+const latestTimeout = timeouts.get(state.beginTimeout);
+staleFrame.ready = true;
+staleInterval();
+staleTimeout();
+assert.equal(beginCalls, 1, "callbacks from an older execution must not affect newer output");
+latestTimeout();
+assert.equal(beginCalls, 2, "the newest execution fallback should begin exactly once");
+
+const cancelledFrame = { ready: false };
+videoHooks.schedulePlaybackBegin(state, cancelledFrame, () => { beginCalls += 100; });
+const cancelledInterval = intervals.get(state.beginInterval);
+videoHooks.cancelPendingPlaybackBegin(state);
+cancelledFrame.ready = true;
+cancelledInterval();
+assert.equal(beginCalls, 2, "node cleanup must invalidate already queued playback callbacks");
+
+assert.ok(videoExtension, "Video Compare extension should register");
+class FakeVideoCompareNode {}
+let videoOriginalRemovedCalls = 0;
+FakeVideoCompareNode.prototype.onRemoved = function () {
+  videoOriginalRemovedCalls += 1;
+  return "video removed";
+};
+await videoExtension.beforeRegisterNodeDef(FakeVideoCompareNode, { name: "DenoVideoCompare" });
+const removalState = {
+  beginRun: 0,
+  beginInterval: null,
+  beginTimeout: null,
+  destroyed: false,
+  playing: true,
+  transientCleanups: new Set(),
+  raf: 777,
+  audioController: null,
+  audioRun: 0,
+  srcA: null,
+  srcB: null,
+  actx: null,
+  master: {},
+  gA: {},
+  gB: {},
+  bufA: {},
+  bufB: {},
+  cache: new Map([["frame", { img: { src: "frame.webp" } }]]),
+  dom: null,
+};
+videoHooks.schedulePlaybackBegin(removalState, { ready: false }, () => {});
+let interactionCleanupCalls = 0;
+removalState.transientCleanups.add(() => { interactionCleanupCalls += 1; });
+let audioAbortCalls = 0;
+let audioCloseCalls = 0;
+removalState.audioController = { abort() { audioAbortCalls += 1; } };
+removalState.actx = { close() { audioCloseCalls += 1; } };
+const videoNode = new FakeVideoCompareNode();
+videoNode.__dvp = removalState;
+assert.equal(videoNode.onRemoved(), "video removed", "Video Compare should preserve its original removal result");
+assert.equal(videoOriginalRemovedCalls, 1, "Video Compare should still call its original removal callback");
+assert.equal(removalState.destroyed, true, "Video Compare removal should mark the state destroyed");
+assert.equal(removalState.playing, false, "Video Compare removal should stop playback");
+assert.equal(removalState.beginInterval, null, "Video Compare removal should clear first-frame polling");
+assert.equal(removalState.beginTimeout, null, "Video Compare removal should clear the first-frame fallback");
+assert.equal(interactionCleanupCalls, 1, "Video Compare removal should clear window-level drag handlers");
+assert.equal(audioAbortCalls, 1, "Video Compare removal should abort audio loading");
+assert.equal(audioCloseCalls, 1, "Video Compare removal should close its audio context");
+assert.equal(removalState.bufA, null, "Video Compare removal should release decoded A audio");
+assert.equal(removalState.bufB, null, "Video Compare removal should release decoded B audio");
+assert.equal(removalState.cache.size, 0, "Video Compare removal should release cached frames");
+assert.ok(cancelledFrames.includes(777), "Video Compare removal should cancel its animation frame");
+
+const extraSource = readSource("web/js/deno_extra_nodes.js");
+assert.match(extraSource, /__denoCloseInputFolderBrowser\?\.\(\)/);
+assert.match(extraSource, /fetchInputFolderImages\(nextPath, request\.signal\)/);
+assert.match(extraSource, /this\.__denoCloseInputFolderBrowser = null/);
+
+const advancedSource = readSource("web/js/deno_advanced_image_source_loader.js");
+assert.match(advancedSource, /ownerNode\?\.__denoCloseAdvancedFolderBrowser\?\.\(\)/);
+assert.match(advancedSource, /options\.fetchEntries\(folderPath, request\.signal\)/);
+assert.match(advancedSource, /this\.__denoCloseAdvancedFolderBrowser = null/);
+assert.match(advancedSource, /showSourceTextDialog\(node, setPaths, getPaths\)/);
+
+const videoSource = readSource("web/js/deno_video_compare.js");
+assert.match(videoSource, /stopDetachedVideoCompare\(node, s\)/);
+assert.match(videoSource, /state\.audioController\?\.abort\(\)/);
+assert.match(videoSource, /clearTransientInteractions\(state\)/);
+
+const downloaderSource = readSource("web/js/deno_ltx_model_downloader.js");
+assert.match(downloaderSource, /document\.removeEventListener\("click", onDocumentClick\)/);
+assert.match(downloaderSource, /observer\.disconnect\(\)/);
+assert.match(downloaderSource, /cancelAnimationFrame\(layoutFrame\)/);
+assert.doesNotMatch(downloaderSource, /document\.addEventListener\("click", \(\) =>/);
+
+async function assertLoraRemovalLifecycle(relativePath, nodeName, prefix) {
+  const extension = loadExtension(relativePath);
+  class FakeNode {}
+  let originalRemovedCalls = 0;
+  FakeNode.prototype.onRemoved = function () {
+    originalRemovedCalls += 1;
+    return `${prefix} removed`;
+  };
+  await extension.beforeRegisterNodeDef(FakeNode, { name: nodeName });
+  const node = new FakeNode();
+  let menuCloseCalls = 0;
+  let menuRootRemoveCalls = 0;
+  let infoCloseCalls = 0;
+  node[`__deno${prefix}ContextMenu`] = {
+    close() { menuCloseCalls += 1; },
+    root: { remove() { menuRootRemoveCalls += 1; } },
+  };
+  node[`__deno${prefix}InfoClose`] = () => { infoCloseCalls += 1; };
+  const result = node.onRemoved();
+  assert.equal(result, `${prefix} removed`, `${prefix}: preserve original onRemoved result`);
+  assert.equal(originalRemovedCalls, 1, `${prefix}: preserve original onRemoved call`);
+  assert.equal(menuCloseCalls, 1, `${prefix}: close the owned ContextMenu`);
+  assert.equal(menuRootRemoveCalls, 1, `${prefix}: remove the owned ContextMenu root`);
+  assert.equal(infoCloseCalls, 1, `${prefix}: close the owned Info editor`);
+  assert.equal(node[`__deno${prefix}Removed`], true, `${prefix}: mark node removed`);
+}
+
+await assertLoraRemovalLifecycle(
+  "web/js/deno_multi_lora.js",
+  "DenoMultiLoraLoader",
+  "MultiLora",
+);
+await assertLoraRemovalLifecycle(
+  "web/js/deno_ltx_multi_lora.js",
+  "DenoLTXMultiLoraLoader",
+  "LtxMultiLora",
+);
+
+const genericLoraSource = readSource("web/js/deno_multi_lora.js");
+assert.match(genericLoraSource, /generation !== node\.__denoMultiLoraChooserGeneration/);
+assert.match(genericLoraSource, /node\.__denoMultiLoraInfoClose\?\.\(\)/);
+const ltxLoraSource = readSource("web/js/deno_ltx_multi_lora.js");
+assert.match(ltxLoraSource, /generation !== node\.__denoLtxMultiLoraChooserGeneration/);
+assert.match(ltxLoraSource, /node\.__denoLtxMultiLoraInfoClose\?\.\(\)/);
+
+const previewExtension = loadExtension("web/js/deno_video_preview.js");
+class FakePreviewNode {}
+let previewOriginalRemovedCalls = 0;
+FakePreviewNode.prototype.onRemoved = function () {
+  previewOriginalRemovedCalls += 1;
+  return "preview removed";
+};
+await previewExtension.beforeRegisterNodeDef(FakePreviewNode, { name: "DenoVideoPreview" });
+const previewNode = new FakePreviewNode();
+let previewPanCleanupCalls = 0;
+previewNode.__dvprev = { panCleanup() { previewPanCleanupCalls += 1; } };
+assert.equal(previewNode.onRemoved(), "preview removed");
+assert.equal(previewOriginalRemovedCalls, 1);
+assert.equal(previewPanCleanupCalls, 1, "Video Preview should clear active window pan listeners");
+assert.equal(previewNode.__dvprev.panCleanup, null);
+
+const berniniExtension = loadExtension("web/js/deno_bernini_prompt_guide.js");
+class FakeBerniniNode {}
+let berniniOriginalRemovedCalls = 0;
+FakeBerniniNode.prototype.onRemoved = function () {
+  berniniOriginalRemovedCalls += 1;
+  return "bernini removed";
+};
+await berniniExtension.beforeRegisterNodeDef(FakeBerniniNode, { name: "DenoBerniniPromptGuide" });
+const berniniNode = new FakeBerniniNode();
+let berniniCloseCalls = 0;
+berniniNode.__denoBerniniTaskInfoClose = () => { berniniCloseCalls += 1; };
+assert.equal(berniniNode.onRemoved(), "bernini removed");
+assert.equal(berniniOriginalRemovedCalls, 1);
+assert.equal(berniniCloseCalls, 1, "Bernini removal should close its Info panel");
+assert.equal(berniniNode.__denoBerniniTaskInfoClose, null);
+const berniniSource = readSource("web/js/deno_bernini_prompt_guide.js");
+assert.match(berniniSource, /existing\?\.__denoClose/);
+assert.match(berniniSource, /clearTimeout\(listenerTimer\)/);
+
+console.log("frontend_lifecycle_race_harness passed");

--- a/tests/js/local_llm_async_action_harness.mjs
+++ b/tests/js/local_llm_async_action_harness.mjs
@@ -1,0 +1,310 @@
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..", "..");
+const sourcePath = path.join(repoRoot, "web", "js", "deno_local_llm_refiner.js");
+const source = fs
+    .readFileSync(sourcePath, "utf8")
+    .replace(/^import\s+\{[^}]+\}\s+from\s+["'][^"']+["'];\r?\n/gm, "");
+
+const graph = {
+    _nodes: [],
+    getNodeById(id) {
+        return this._nodes.find((node) => String(node?.id) === String(id)) || null;
+    },
+    setDirtyCanvas() {},
+};
+
+const context = {
+    console,
+    process,
+    Date,
+    Math,
+    JSON,
+    Number,
+    String,
+    Boolean,
+    Array,
+    Object,
+    Set,
+    Map,
+    WeakMap,
+    WeakSet,
+    URL,
+    URLSearchParams,
+    AbortController,
+    app: {
+        graph,
+        canvas: { graph },
+        registerExtension(extension) {
+            context.capturedExtension = extension;
+        },
+    },
+    api: {
+        addEventListener() {},
+        apiURL(value) { return value; },
+    },
+    window: {
+        addEventListener() {},
+        setTimeout() { return 0; },
+        requestAnimationFrame() { return 0; },
+        cancelAnimationFrame() {},
+    },
+    queueMicrotask(callback) { callback(); },
+    document: {
+        addEventListener() {},
+        querySelectorAll() { return []; },
+        querySelector() { return null; },
+    },
+    LiteGraph: {
+        NODE_WIDGET_HEIGHT: 24,
+        WIDGET_BGCOLOR: "#222",
+        WIDGET_OUTLINE_COLOR: "#555",
+    },
+    Image: class {},
+    capturedApi: null,
+    capturedExtension: null,
+};
+context.globalThis = context;
+context.__DENO_LOCAL_LLM_REVIEWER_TEST_HOOK__ = (api) => {
+    context.capturedApi = api;
+};
+
+vm.createContext(context);
+vm.runInContext(source, context, { filename: sourcePath });
+
+const api = context.capturedApi;
+assert(api, "Local LLM async-action test API was not exposed");
+
+function assert(condition, message) {
+    if (!condition) {
+        throw new Error(message);
+    }
+}
+
+function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+}
+
+function response(payload, ok = true, status = 200) {
+    return {
+        ok,
+        status,
+        async json() { return payload; },
+    };
+}
+
+function makeWidget(name, value, values = []) {
+    return {
+        name,
+        label: name,
+        value,
+        type: values.length ? "combo" : "text",
+        options: values.length ? { values: [...values], list: [...values] } : {},
+    };
+}
+
+function makeNode(id) {
+    const node = {
+        id,
+        type: "DenoLocalLLMRefiner",
+        graph,
+        properties: {},
+        inputs: [],
+        outputs: [],
+        size: [560, 300],
+        __denoLocalLLMRefreshing: true,
+        widgets: [
+            makeWidget("provider", "Ollama", ["Ollama", "LM Studio", "llama.cpp", "vLLM", "Custom"]),
+            makeWidget("ollama_model", "qwen3", ["qwen3"]),
+            makeWidget("lm_studio_model", "google/gemma", ["google/gemma"]),
+            makeWidget("custom_server_url", "http://127.0.0.1:8000/v1"),
+            makeWidget("custom_model", "custom-model"),
+            makeWidget("model_memory", "Unload after run", ["Unload after run", "Keep for minutes", "Keep loaded"]),
+            makeWidget("keep_minutes", 5),
+        ],
+        addWidget(type, name, value, callback, options = {}) {
+            const widget = { type, name, label: name, value, callback, options };
+            this.widgets.push(widget);
+            return widget;
+        },
+        setDirtyCanvas() {},
+    };
+    return node;
+}
+
+const fetchCalls = [];
+context.fetch = (url, options = {}) => {
+    const pending = deferred();
+    fetchCalls.push({ url, options, pending });
+    return pending.promise;
+};
+
+const actionNode = makeNode(10);
+graph._nodes = [actionNode];
+const staleRefresh = api.refreshModels(actionNode);
+assert(fetchCalls.length === 1 && fetchCalls[0].url.endsWith("/models"), "Refresh must start the model-list request");
+const refreshSignal = fetchCalls[0].options.signal;
+const newerUnload = api.unloadLocalModel(actionNode);
+assert(fetchCalls.length === 2 && fetchCalls[1].url.endsWith("/unload"), "Unload must supersede the older refresh action");
+assert(refreshSignal?.aborted === true, "A superseded read-only Refresh request must be aborted");
+fetchCalls[1].pending.resolve(response({ ok: true, message: "newer unload finished" }));
+await newerUnload;
+assert(api.getLocalLLMNodeState(actionNode).status === "LLM unloaded", "The newer Unload response must own visible state");
+fetchCalls[0].pending.resolve(response({ models: [{ id: "stale-model" }] }));
+await staleRefresh;
+assert(api.getLocalLLMNodeState(actionNode).status === "LLM unloaded", "A late Refresh response must not overwrite a newer action");
+assert(
+    !actionNode.properties.denoLocalLLMModelChoicesByProvider?.Ollama,
+    "A late Refresh response must not mutate provider model choices",
+);
+
+const stopNode = makeNode(14);
+graph._nodes = [stopNode];
+const staleStop = api.stopLocalModel(stopNode);
+const staleStopCall = fetchCalls.at(-1);
+const newerStopRefresh = api.refreshModels(stopNode);
+const newerStopRefreshCall = fetchCalls.at(-1);
+assert(staleStopCall.options.signal?.aborted === false, "Superseding a Stop must not cancel its backend side effect");
+newerStopRefreshCall.pending.resolve(response({ models: [{ id: "fresh-after-stop" }] }));
+await newerStopRefresh;
+assert(api.getLocalLLMNodeState(stopNode).status === "1 models found", "The newer Refresh must own state after Stop");
+staleStopCall.pending.resolve(response({ ok: true, message: "late stop response" }));
+await staleStop;
+assert(api.getLocalLLMNodeState(stopNode).status === "1 models found", "A late Stop response must not overwrite a newer Refresh");
+
+const unloadNode = makeNode(15);
+graph._nodes = [unloadNode];
+const staleUnload = api.unloadLocalModel(unloadNode);
+const staleUnloadCall = fetchCalls.at(-1);
+const newerUnloadRefresh = api.refreshModels(unloadNode);
+const newerUnloadRefreshCall = fetchCalls.at(-1);
+assert(staleUnloadCall.options.signal?.aborted === false, "Superseding Unload must not cancel its backend side effect");
+newerUnloadRefreshCall.pending.resolve(response({ models: [{ id: "fresh-after-unload" }] }));
+await newerUnloadRefresh;
+assert(api.getLocalLLMNodeState(unloadNode).status === "1 models found", "The newer Refresh must own state after Unload");
+staleUnloadCall.pending.resolve(response({ ok: true, message: "late unload response" }));
+await staleUnload;
+assert(api.getLocalLLMNodeState(unloadNode).status === "1 models found", "A late Unload response must not overwrite a newer Refresh");
+
+const repeatedUnloadNode = makeNode(16);
+graph._nodes = [repeatedUnloadNode];
+const firstUnload = api.unloadLocalModel(repeatedUnloadNode);
+const firstUnloadCall = fetchCalls.at(-1);
+const fetchCountBeforeRepeat = fetchCalls.length;
+await api.unloadLocalModel(repeatedUnloadNode);
+assert(fetchCalls.length === fetchCountBeforeRepeat, "Clicking Unload again while it is pending must not duplicate the request");
+assert(firstUnloadCall.options.signal?.aborted === false, "A repeated Unload click must let the original unload finish");
+firstUnloadCall.pending.resolve(response({ ok: true, message: "original unload finished" }));
+await firstUnload;
+assert(api.getLocalLLMNodeState(repeatedUnloadNode).status === "LLM unloaded", "The in-flight Unload result must remain visible after a repeated click");
+
+const providerNode = makeNode(11);
+graph._nodes = [providerNode];
+const providerRefresh = api.refreshModels(providerNode);
+const providerRefreshCall = fetchCalls.at(-1);
+api.wrapProviderCallback(providerNode);
+const providerWidget = api.getWidget(providerNode, "provider");
+providerWidget.value = "LM Studio";
+providerWidget.callback?.("LM Studio");
+assert(providerRefreshCall.options.signal?.aborted === true, "Changing provider must abort its stale Refresh request");
+providerRefreshCall.pending.resolve(response({ models: [{ id: "old-ollama-model" }] }));
+await providerRefresh;
+assert(api.getLocalLLMNodeState(providerNode).provider === "LM Studio", "A late old-provider response must not restore the previous provider");
+assert(
+    !providerNode.properties.denoLocalLLMModelChoicesByProvider?.Ollama,
+    "A late old-provider response must not update hidden old-provider choices",
+);
+
+const executionNode = makeNode(12);
+const executionGraph = {
+    _nodes: [executionNode],
+    getNodeById(id) { return String(id) === "12" ? executionNode : null; },
+};
+executionNode.graph = executionGraph;
+graph._nodes = [executionNode];
+const executionRefresh = api.refreshModels(executionNode);
+const executionRefreshCall = fetchCalls.at(-1);
+api.rememberLocalLLMPromptGraph("prompt-12", executionGraph);
+assert(
+    api.invalidateLocalLLMAsyncActionsForExecutionDetail({ prompt_id: "prompt-12" }, "execution started") === 1,
+    "Execution start must invalidate every Loader in the submitted workflow",
+);
+api.setLocalLLMNodeState(executionNode, { status: "running", provider: "Ollama", model: "qwen3" });
+assert(executionRefreshCall.options.signal?.aborted === true, "Execution must abort a stale Refresh request");
+executionRefreshCall.pending.resolve(response({ models: [{ id: "too-late" }] }));
+await executionRefresh;
+assert(api.getLocalLLMNodeState(executionNode).status === "running", "A late Refresh response must not overwrite execution state");
+
+const removedNode = makeNode(13);
+graph._nodes = [removedNode];
+let previousRemovedCalls = 0;
+removedNode.onRemoved = () => { previousRemovedCalls += 1; };
+api.installLocalLLMNodeCleanup(removedNode);
+const removedRefresh = api.refreshModels(removedNode);
+const removedRefreshCall = fetchCalls.at(-1);
+removedNode.onRemoved();
+assert(previousRemovedCalls === 1, "Async cleanup must preserve the prior onRemoved callback");
+assert(removedRefreshCall.options.signal?.aborted === true, "Removing a Loader must abort its stale Refresh request");
+removedRefreshCall.pending.resolve(response({ models: [{ id: "removed-node-model" }] }));
+await removedRefresh;
+assert(
+    !removedNode.properties.denoLocalLLMModelChoicesByProvider?.Ollama,
+    "A removed node must ignore a late Refresh response",
+);
+
+const appQueueRequests = [];
+context.app.queuePrompt = function () {
+    const pending = deferred();
+    appQueueRequests.push(pending);
+    return pending.promise;
+};
+assert(
+    api.installLocalLLMAppQueuePromptHook(context.app) === true,
+    "The app-level queue hook must install at the pre-serialization boundary",
+);
+
+const queueRaceNode = makeNode(17);
+graph._nodes = [queueRaceNode];
+const queueRaceRefresh = api.refreshModels(queueRaceNode);
+const queueRaceRefreshCall = fetchCalls.at(-1);
+const queuedFailure = context.app.queuePrompt(0, 1, null).then(
+    () => null,
+    (error) => error,
+);
+assert(
+    queueRaceRefreshCall.options.signal?.aborted === true,
+    "Queue submission must abort stale Refresh before graph serialization and HTTP response",
+);
+queueRaceRefreshCall.pending.resolve(response({ models: [{ id: "queue-race-stale" }] }));
+await queueRaceRefresh;
+assert(
+    !queueRaceNode.properties.denoLocalLLMModelChoicesByProvider?.Ollama,
+    "A late Refresh response must not change model choices even when queue submission fails",
+);
+appQueueRequests.at(-1).reject(new Error("queue rejected"));
+assert((await queuedFailure)?.message === "queue rejected", "The queue hook must preserve queue failures");
+
+const queueStopNode = makeNode(18);
+graph._nodes = [queueStopNode];
+const queueStop = api.stopLocalModel(queueStopNode);
+const queueStopCall = fetchCalls.at(-1);
+const queuedSuccess = context.app.queuePrompt(0, 1, null);
+assert(
+    queueStopCall.options.signal?.aborted === false,
+    "Queue submission must not cancel an in-flight Stop backend side effect",
+);
+queueStopCall.pending.resolve(response({ ok: true, message: "stop completed" }));
+appQueueRequests.at(-1).resolve(true);
+await Promise.all([queueStop, queuedSuccess]);
+
+console.log("local_llm_async_action_harness: ok");

--- a/tests/js/ltx_legacy_replacement_harness.mjs
+++ b/tests/js/ltx_legacy_replacement_harness.mjs
@@ -1,0 +1,172 @@
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+
+function assert(condition, message) {
+    if (!condition) {
+        throw new Error(message);
+    }
+}
+
+const replacement = JSON.parse(process.argv[2]);
+const fixture = JSON.parse(fs.readFileSync(process.argv[3], "utf8"));
+const oldNode = fixture.nodes.find((node) => node.type === replacement.old_node_id);
+assert(oldNode, "legacy fixture node is missing");
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..", "..");
+const compatSourcePath = path.join(repoRoot, "web", "js", "deno_ltx_tiled_sampler_compat.js");
+const compatSource = fs
+    .readFileSync(compatSourcePath, "utf8")
+    .replace(/^import\s+\{[^}]+\}\s+from\s+["'][^"']+["'];\r?\n/gm, "");
+
+const context = {
+    console,
+    capturedCompatApi: null,
+    capturedExtension: null,
+    app: {
+        registerExtension(extension) {
+            context.capturedExtension = extension;
+        },
+    },
+};
+context.globalThis = context;
+context.__DENO_LTX_TILED_COMPAT_TEST_HOOK__ = (api) => {
+    context.capturedCompatApi = api;
+};
+vm.createContext(context);
+vm.runInContext(compatSource, context, { filename: compatSourcePath });
+assert(context.capturedCompatApi, "compatibility marker helper was not exposed");
+
+const widgetNames = [
+    "horizontal_tiles",
+    "vertical_tiles",
+    "overlap",
+    "audio_mode",
+    "blend_mode",
+    "aggressive_memory_cleanup",
+    "debug",
+];
+const widgetDefaults = [2, 2, 8, "freeze", "hann", true, false];
+const newInputNames = [
+    "noise",
+    "guider",
+    "sampler",
+    "sigmas",
+    "latent_image",
+    "horizontal_tiles",
+    "vertical_tiles",
+    "overlap",
+    "audio_mode",
+    "blend_mode",
+    "aggressive_memory_cleanup",
+    "debug",
+];
+
+const newNode = {
+    id: oldNode.id,
+    type: replacement.new_node_id,
+    pos: [...oldNode.pos],
+    size: [...oldNode.size],
+    order: oldNode.order,
+    mode: oldNode.mode,
+    flags: { ...(oldNode.flags || {}) },
+    properties: { ...(oldNode.properties || {}) },
+    inputs: newInputNames.map((name) => ({ name, link: null })),
+    outputs: [
+        { name: "output", links: [] },
+        { name: "denoised_output", links: [] },
+    ],
+    widgets: widgetNames.map((name, index) => ({
+        name,
+        value: widgetDefaults[index],
+        options: {},
+    })),
+    addWidget(type, name, value, callback, options = {}) {
+        const widget = { type, name, value, callback, options };
+        this.widgets.push(widget);
+        return widget;
+    },
+};
+
+const marker = context.capturedCompatApi.ensureLegacyCompatibilityMarker(newNode);
+assert(marker?.value === false, "fresh current nodes must default the legacy marker to false");
+assert(marker.hidden === true, "the compatibility marker must not alter visible controls");
+assert(marker.computeSize()[1] < 0, "the compatibility marker must not consume node geometry");
+
+const links = new Map(
+    fixture.links.map(([id, originId, originSlot, targetId, targetSlot, type]) => [
+        id,
+        {
+            id,
+            origin_id: originId,
+            origin_slot: originSlot,
+            target_id: targetId,
+            target_slot: targetSlot,
+            type,
+        },
+    ]),
+);
+
+for (const inputMap of replacement.input_mapping) {
+    if (Object.prototype.hasOwnProperty.call(inputMap, "old_id")) {
+        const oldInputIndex = oldNode.inputs.findIndex((input) => input.name === inputMap.old_id);
+        const newInputIndex = newNode.inputs.findIndex((input) => input.name === inputMap.new_id);
+        if (oldInputIndex >= 0 && newInputIndex >= 0) {
+            const linkId = oldNode.inputs[oldInputIndex].link;
+            if (linkId != null) {
+                const link = links.get(linkId);
+                link.target_id = newNode.id;
+                link.target_slot = newInputIndex;
+                newNode.inputs[newInputIndex].link = linkId;
+            }
+        }
+
+        const oldWidgetIndex = replacement.old_widget_ids.indexOf(inputMap.old_id);
+        const newWidget = newNode.widgets.find((widget) => widget.name === inputMap.new_id);
+        if (oldWidgetIndex >= 0 && newWidget && oldNode.widgets_values[oldWidgetIndex] !== undefined) {
+            newWidget.value = oldNode.widgets_values[oldWidgetIndex];
+            newWidget.callback?.(newWidget.value);
+        }
+    } else {
+        const widget = newNode.widgets.find((candidate) => candidate.name === inputMap.new_id);
+        if (widget) {
+            widget.value = inputMap.set_value;
+            widget.callback?.(widget.value);
+        }
+    }
+}
+
+for (const outputMap of replacement.output_mapping) {
+    const oldLinks = oldNode.outputs[outputMap.old_idx]?.links || [];
+    for (const linkId of oldLinks) {
+        const link = links.get(linkId);
+        link.origin_id = newNode.id;
+        link.origin_slot = outputMap.new_idx;
+    }
+    newNode.outputs[outputMap.new_idx].links = [...oldLinks];
+}
+
+newNode.properties["Node name for S&R"] = replacement.new_node_id;
+
+assert(
+    JSON.stringify(newNode.widgets.map((widget) => widget.serializeValue?.() ?? widget.value)) ===
+        JSON.stringify([1, 2, 8, "freeze", "hann", false, false, true]),
+    "replacement must preserve six legacy values, insert audio freeze, and persist the hidden marker",
+);
+for (let linkId = 1; linkId <= 5; linkId += 1) {
+    const link = links.get(linkId);
+    assert(link.target_id === oldNode.id, `required input link ${linkId} target node changed`);
+    assert(link.target_slot === linkId - 1, `required input link ${linkId} target slot changed`);
+}
+assert(links.get(6).target_slot === 9, "linked blend widget must move from slot 8 to slot 9");
+assert(links.get(7).origin_slot === 0, "output link 0 must stay on output 0");
+assert(links.get(8).origin_slot === 1, "output link 1 must stay on output 1");
+assert(
+    newNode.properties["Node name for S&R"] === replacement.new_node_id,
+    "Node name for S&R must move to the current node ID",
+);
+assert(marker.value === true, "only replaced legacy nodes may enable video compatibility");
+
+console.log("ltx_legacy_replacement_harness: ok");

--- a/tests/js/node_help_version_harness.mjs
+++ b/tests/js/node_help_version_harness.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import vm from "node:vm";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const scriptPath = path.join(repoRoot, "web/js/deno_node_help.js");
+const VERSION_CACHE_KEY = "denoCustomNodes.versionStatus.v2";
+
+function makeHarness({ now = 1_000_000, payload = { version: "0.7.68" } } = {}) {
+  const storage = new Map();
+  const fetchCalls = [];
+  let currentPayload = payload;
+  let registeredExtension = null;
+
+  class FakeDate extends Date {
+    constructor(...args) {
+      super(...(args.length ? args : [now]));
+    }
+
+    static now() {
+      return now;
+    }
+  }
+
+  const context = {
+    console,
+    Date: FakeDate,
+    AbortController,
+    setTimeout,
+    clearTimeout,
+    requestAnimationFrame() { return 1; },
+    cancelAnimationFrame() {},
+    localStorage: {
+      getItem(key) {
+        return storage.has(key) ? storage.get(key) : null;
+      },
+      setItem(key, value) {
+        storage.set(key, String(value));
+      },
+    },
+    document: {
+      querySelectorAll() { return []; },
+    },
+    app: {
+      graph: { setDirtyCanvas() {} },
+      registerExtension(extension) {
+        registeredExtension = extension;
+      },
+    },
+    async fetch(url, options = {}) {
+      fetchCalls.push({ url: String(url), options });
+      return {
+        ok: true,
+        status: 200,
+        async json() { return currentPayload; },
+        async text() { return ""; },
+      };
+    },
+  };
+  context.window = context;
+  context.globalThis = context;
+
+  let source = fs.readFileSync(scriptPath, "utf8");
+  source = source.replace(/^import .*;\r?\n/gm, "");
+  source += `
+globalThis.__hooks = {
+  getNodeKey,
+  loadCachedVersionStatus,
+  refreshDenoVersionStatus,
+  setCurrentVersionFromDescription,
+  getVersionStatus: () => ({ ...denoVersionStatus }),
+};
+`;
+  vm.runInNewContext(source, context, { filename: scriptPath });
+  assert.equal(registeredExtension?.name, "Deno.NodeHelp");
+
+  return {
+    hooks: context.__hooks,
+    fetchCalls,
+    setNow(value) { now = value; },
+    setPayload(value) { currentPayload = value; },
+    setCachedStatus(value) { storage.set(VERSION_CACHE_KEY, JSON.stringify(value)); },
+  };
+}
+
+{
+  const harness = makeHarness();
+  const first = { id: 7, type: "DenoImageCompare" };
+  const second = { id: 7, type: "DenoImageCompare" };
+  assert.equal(harness.hooks.getNodeKey(first), harness.hooks.getNodeKey(first));
+  assert.notEqual(
+    harness.hooks.getNodeKey(first),
+    harness.hooks.getNodeKey(second),
+    "popup ownership must follow the node object, not a reused numeric id",
+  );
+}
+
+{
+  const harness = makeHarness({ now: 1_000_000 });
+  harness.setCachedStatus({
+    status: "latest",
+    current_version: "0.7.68",
+    latest_version: "0.7.68",
+    checked_at: 1_000_001,
+  });
+  assert.equal(
+    harness.hooks.loadCachedVersionStatus("0.7.68"),
+    null,
+    "a future cache timestamp must not be treated as fresh",
+  );
+}
+
+{
+  const harness = makeHarness({ payload: { status: "ok" } });
+  harness.hooks.setCurrentVersionFromDescription("DENO Custom Nodes v0.7.68");
+  const status = await harness.hooks.refreshDenoVersionStatus();
+  assert.equal(status.status, "unknown");
+  assert.equal(status.update_available, false);
+  assert.equal(status.latest_version, "");
+  assert.match(status.message, /valid version/i);
+  assert.equal(harness.fetchCalls.length, 1);
+  assert.ok(harness.fetchCalls[0].options.signal, "version requests must be abortable");
+}
+
+console.log("node-help version harness passed");

--- a/tests/test_frontend_lifecycle_races.py
+++ b/tests/test_frontend_lifecycle_races.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HARNESS_PATH = REPO_ROOT / "tests" / "js" / "frontend_lifecycle_race_harness.mjs"
+
+
+def test_frontend_lifecycle_race_harness() -> None:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node executable is required for the frontend lifecycle harness")
+
+    result = subprocess.run(
+        [node, str(HARNESS_PATH)],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"node harness failed:\n{result.stdout}\n{result.stderr}"
+    assert "frontend_lifecycle_race_harness passed" in result.stdout

--- a/tests/test_image_resize_node.py
+++ b/tests/test_image_resize_node.py
@@ -213,6 +213,60 @@ def test_video_preview_temp_file_is_scoped_by_workflow_id(tmp_path):
     assert module._workflow_id_from_extra_pnginfo({"workflow": {"extra": "malformed"}}) == "legacy-workflow"
     assert module._workflow_id_from_extra_pnginfo({"workflow": {"extra": {"workspace_info": []}}}) == "legacy-workflow"
 
+    original_active_prompt_id = module._active_prompt_id
+    module._active_prompt_id = lambda: "direct-prompt-a"
+    try:
+        assert module._preview_workflow_identity(None) == "prompt:direct-prompt-a"
+        assert module._preview_workflow_identity(workflow_a) == workflow_a_id
+    finally:
+        module._active_prompt_id = original_active_prompt_id
+
+    direct_paths = []
+    for index in range(module.DIRECT_PROMPT_PREVIEW_LIMIT + 2):
+        direct_path = Path(module._stable_preview_path("42", f"prompt:{index}")[0])
+        direct_path.write_bytes(f"prompt-{index}".encode("ascii"))
+        os.utime(direct_path, ns=(index + 1, index + 1))
+        direct_paths.append(direct_path)
+    module._prune_direct_prompt_previews(str(direct_paths[-1]))
+    assert sum(path.exists() for path in direct_paths) == module.DIRECT_PROMPT_PREVIEW_LIMIT
+
+
+def test_video_preview_atomic_failure_preserves_previous_stable_file(monkeypatch, tmp_path):
+    package = load_package()
+    module = importlib.import_module("comfyui_deno_custom_nodes.deno_video_preview")
+    sys.modules["folder_paths"].get_temp_directory = lambda: str(tmp_path)
+    workflow = {"workflow": {"id": "atomic-workflow"}}
+    workflow_id = module._workflow_id_from_extra_pnginfo(workflow)
+    out_path = Path(module._stable_preview_path("7", workflow_id)[0])
+    out_path.write_bytes(b"previous-stable-preview")
+
+    if hasattr(module.torch, "zeros"):
+        images = module.torch.zeros((1, 2, 2, 3), dtype=module.torch.float32)
+    else:
+        class FakeImages:
+            ndim = 4
+            shape = (1, 2, 2, 3)
+
+        images = FakeImages()
+
+    class FailingAv:
+        @staticmethod
+        def open(path, mode="w", options=None):
+            Path(path).write_bytes(b"incomplete-preview")
+            raise RuntimeError("simulated encode open failure")
+
+    monkeypatch.setattr(module, "_require_av", lambda: FailingAv)
+    with pytest.raises(RuntimeError, match="simulated encode open failure"):
+        package.DenoVideoPreview().preview(
+            images,
+            frame_rate=25,
+            unique_id="7",
+            extra_pnginfo=workflow,
+        )
+
+    assert out_path.read_bytes() == b"previous-stable-preview"
+    assert list(out_path.parent.glob(f"{out_path.name}.partial-*.mp4")) == []
+
 
 def test_local_llm_progress_event_includes_active_prompt_id(monkeypatch):
     package = load_package()
@@ -281,6 +335,40 @@ def test_node_registration_exports_expected_nodes():
                 {"new_id": "presets_json", "old_id": "presets_json"},
             ],
             "output_mapping": None,
+        },
+        {
+            "old_node_id": "DenoLTXStepFusedTiledSampler",
+            "new_node_id": "DenoLTXAVStepFusedTiledSampler",
+            "old_widget_ids": [
+                "horizontal_tiles",
+                "vertical_tiles",
+                "overlap",
+                "blend_mode",
+                "aggressive_memory_cleanup",
+                "debug",
+            ],
+            "input_mapping": [
+                {"new_id": "noise", "old_id": "noise"},
+                {"new_id": "guider", "old_id": "guider"},
+                {"new_id": "sampler", "old_id": "sampler"},
+                {"new_id": "sigmas", "old_id": "sigmas"},
+                {"new_id": "latent_image", "old_id": "latent_image"},
+                {"new_id": "horizontal_tiles", "old_id": "horizontal_tiles"},
+                {"new_id": "vertical_tiles", "old_id": "vertical_tiles"},
+                {"new_id": "overlap", "old_id": "overlap"},
+                {"new_id": "audio_mode", "set_value": "freeze"},
+                {"new_id": "blend_mode", "old_id": "blend_mode"},
+                {
+                    "new_id": "aggressive_memory_cleanup",
+                    "old_id": "aggressive_memory_cleanup",
+                },
+                {"new_id": "debug", "old_id": "debug"},
+                {"new_id": "_deno_legacy_video_compat", "set_value": True},
+            ],
+            "output_mapping": [
+                {"old_idx": 0, "new_idx": 0},
+                {"old_idx": 1, "new_idx": 1},
+            ],
         },
     )
     assert package.NODE_DISPLAY_NAME_MAPPINGS["DenoMultiLoraLoader"] == "(Deno) Multi LoRA Loader"
@@ -363,6 +451,14 @@ def test_ltx_tiled_tile_controls_use_readable_frame_labels():
             assert "fusion_safety_mode" not in optional
             assert "fusion_safety_strength" not in optional
             assert "debug_fusion_stats" not in optional
+            assert input_types["hidden"] == {
+                "_deno_legacy_video_compat": "DENO_LEGACY_VIDEO_COMPAT",
+            }
+            compat_js = (
+                REPO_ROOT / "web" / "js" / "deno_ltx_tiled_sampler_compat.js"
+            ).read_text(encoding="utf-8")
+            assert 'widget.hidden = true' in compat_js
+            assert 'widget.serializeValue = () => widget.value === true' in compat_js
 
 
 def test_ltx_tiled_node_help_markdown_uses_readable_frame_labels():
@@ -445,6 +541,19 @@ def test_deno_node_help_update_state_has_badge():
     assert "showStatusTooltip" not in script
     assert "deno-node-help-status-tip" not in script
     assert 'addEventListener("mouseenter"' not in script
+
+
+def test_deno_node_help_version_and_popup_ownership_harness():
+    node = shutil.which("node")
+    assert node, "node executable is required for the DENO Node Help harness"
+
+    subprocess.run(
+        [node, str(REPO_ROOT / "tests" / "js" / "node_help_version_harness.mjs")],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
 
 
 def test_public_ltx23_8gb_workflow_keeps_deno_node_contracts():
@@ -1096,6 +1205,8 @@ def test_deno_image_compare_contract_and_frontend_copy():
     assert "for SaveImage" not in script
     assert "save the selected view" not in script
     assert "Compare A and B with live visual modes." in script
+    assert 'type=${encodeURIComponent(data.type || "output")}' in script
+    assert 'subfolder=${encodeURIComponent(data.subfolder || "")}' in script
 
 
 def test_deno_image_compare_runtime_semantics_when_torch_available():
@@ -5248,7 +5359,7 @@ def test_ai_review_gate_passes_or_blocks_media_outputs_from_reviewer_text():
     assert gate_cls.OUTPUT_NODE is True
     assert list(input_types["required"]) == ["review", "review_mode", "approve_once"]
     assert list(input_types["optional"]) == ["image", "audio", "reviewer_state"]
-    assert list(input_types["hidden"]) == ["unique_id"]
+    assert list(input_types["hidden"]) == ["unique_id", "extra_pnginfo"]
     assert "pass_words" not in input_types["required"]
     assert "reject_words" not in input_types["required"]
     assert "unclear_result" not in input_types["required"]
@@ -5612,3 +5723,140 @@ def test_video_compare_validation_accepts_stale_hidden_combo_values():
     node_cls = package.NODE_CLASS_MAPPINGS["DenoVideoCompare"]
 
     assert node_cls.VALIDATE_INPUTS(mode="A/B", toggle_image="C") is True
+
+
+def test_multi_lora_loaders_reject_non_finite_active_strengths_but_ignore_disabled_slots():
+    package = load_package()
+    general_cls = package.NODE_CLASS_MAPPINGS["DenoMultiLoraLoader"]
+    ltx_cls = package.NODE_CLASS_MAPPINGS["DenoLTXMultiLoraLoader"]
+    model = object()
+    clip = object()
+
+    for field in ("model_strength_1", "clip_strength_1"):
+        result = general_cls.VALIDATE_INPUTS(active_loras=1, lora_1="__none__", **{field: float("nan")})
+        assert "finite number" in result
+    for field in ("strength_1", "audio_1", "video_1"):
+        result = ltx_cls.VALIDATE_INPUTS(active_loras=1, lora_1="__none__", **{field: float("inf")})
+        assert "finite number" in result
+
+    with pytest.raises(ValueError, match="finite number"):
+        general_cls().load_multi_lora(model, clip, 1, lora_1="__none__", model_strength_1=float("nan"))
+    with pytest.raises(ValueError, match="finite number"):
+        ltx_cls().load_multi_lora(model, clip, 1, lora_1="__none__", audio_1=float("-inf"))
+
+    assert general_cls.VALIDATE_INPUTS(
+        active_loras=1,
+        enabled_1=False,
+        lora_1="__none__",
+        model_strength_1=float("nan"),
+    ) is True
+    assert ltx_cls().load_multi_lora(
+        model,
+        clip,
+        1,
+        enabled_1=False,
+        lora_1="__none__",
+        video_1=float("nan"),
+    ) == (model, clip)
+
+
+def test_bernini_prompt_guide_rejects_unknown_combo_typos_without_rejecting_exact_legacy_aliases():
+    package = load_package()
+    node_cls = package.NODE_CLASS_MAPPINGS["DenoBerniniPromptGuide"]
+
+    for task_type in ("Default", "Reference Video Edit", "rv2v", "custom", "Custom System Prompt"):
+        assert node_cls.VALIDATE_INPUTS(task_type=task_type, negative_preset="Official Wan2.2") is True
+    assert node_cls.VALIDATE_INPUTS(task_type="Text to Vidoe", negative_preset="Official Wan2.2") == (
+        "Unknown Bernini System Prompt mode: Text to Vidoe"
+    )
+    assert node_cls.VALIDATE_INPUTS(task_type="Default", negative_preset="Official Wan 2.2") == (
+        "Unknown Bernini Negative Preset: Official Wan 2.2"
+    )
+
+
+def test_ltx_sequencer_noop_preserves_original_latent_metadata_and_identity():
+    package = load_package()
+    node_cls = package.NODE_CLASS_MAPPINGS["DenoLTXSequencer"]
+    positive = [{"positive": True}]
+    negative = [{"negative": True}]
+    sentinel = object()
+    latent = {
+        "samples": np.zeros((1, 1, 2, 1, 1), dtype=np.float32),
+        "batch_index": [9],
+        "custom_metadata": sentinel,
+    }
+    multi_input = np.zeros((1, 2, 2, 3), dtype=np.float32)
+
+    class VAE:
+        downscale_index_formula = (1, 1, 1)
+
+    zero_count = node_cls.execute(
+        positive, negative, VAE(), latent, multi_input, 0, "frames", 24, True, False
+    )
+    zero_strength = node_cls.execute(
+        positive,
+        negative,
+        VAE(),
+        latent,
+        multi_input,
+        1,
+        "frames",
+        24,
+        True,
+        False,
+        insert_frame_1=0,
+        strength_1=0.0,
+    )
+
+    for result in (zero_count, zero_strength):
+        assert result[0] is positive
+        assert result[1] is negative
+        assert result[2] is latent
+        assert result[2]["custom_metadata"] is sentinel
+
+
+def test_video_compare_unequal_batches_sample_only_the_longer_full_timeline():
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_video_compare"]
+    torch = sys.modules.get("torch")
+    if torch is None or not hasattr(torch, "tensor"):
+        pytest.skip("real torch is required for Video Compare tensor sampling")
+
+    short = torch.zeros((2, 1, 1, 3), dtype=torch.float32)
+    long_values = torch.tensor([0.0, 0.25, 0.5, 1.0], dtype=torch.float32).view(4, 1, 1, 1)
+    long = long_values.expand(-1, 1, 1, 3).clone()
+
+    long_b = module._composite_frames("Side by Side", short, long, 0.5, False, "B", 24.0)
+    assert tuple(long_b.shape) == (2, 1, 2, 3)
+    assert torch.equal(long_b[:, 0, 1, 0], torch.tensor([0.0, 1.0]))
+
+    long_a = module._composite_frames("Side by Side", long, short, 0.5, False, "B", 24.0)
+    assert torch.equal(long_a[:, 0, 0, 0], torch.tensor([0.0, 1.0]))
+
+    single = torch.zeros((1, 1, 1, 3), dtype=torch.float32)
+    one_frame = module._composite_frames("Side by Side", single, long, 0.5, False, "B", 24.0)
+    assert float(one_frame[0, 0, 1, 0]) == 0.0
+
+
+def test_rtx_video_finisher_off_off_is_exact_preflight_free_passthrough():
+    package = load_package()
+    finisher = package.NODE_CLASS_MAPPINGS["DenoRTXVFXVideoFinisher"]()
+    images = object()
+
+    result = finisher.apply_finisher(
+        images=images,
+        first_pass="Off",
+        first_quality="Retired Quality",
+        upscale_pass="Off",
+        upscale_quality="Retired Quality",
+        resize_type="Retired Resize",
+        scale=2.0,
+        megapixels=4.0,
+        width=3840,
+        height=2160,
+        divisible_by=8,
+        ratio_preset="1712:880",
+        resize_method="Retired Method",
+    )
+
+    assert result[0] is images

--- a/tests/test_local_llm_regressions.py
+++ b/tests/test_local_llm_regressions.py
@@ -1,0 +1,336 @@
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from test_image_resize_node import load_package
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _refine_kwargs(prompts):
+    return {
+        "provider": "Ollama",
+        "ollama_model": "qwen3",
+        "lm_studio_model": "google/gemma",
+        "custom_server_url": "http://127.0.0.1:8000/v1",
+        "custom_model": "custom-model",
+        "system_prompt": "",
+        "prompt": prompts,
+        "thinking": False,
+        "seed": 7,
+        "seed_mode": "fixed",
+        "model_memory": "Unload after run",
+        "keep_minutes": 5,
+        "comfy_vram_policy": "Never unload before LLM call",
+        "unique_id": "cleanup-node",
+    }
+
+
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        "mid-batch generation failed",
+        "Local LLM generation stopped.",
+    ],
+)
+def test_local_llm_unload_after_run_cleans_aborted_mid_batch_without_masking_error(monkeypatch, error_message):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    calls = []
+    unload_calls = []
+    events = []
+    original_error = RuntimeError(error_message)
+
+    monkeypatch.setattr(module, "_send_progress", lambda payload: events.append(dict(payload)))
+    monkeypatch.setattr(module, "_unload_other_warm_local_llms", lambda **_kwargs: {})
+    monkeypatch.setattr(module, "_prepare_comfy_vram_before_llm", lambda **_kwargs: {})
+
+    def run_single(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 2:
+            raise original_error
+        return "first answer", "", {}
+
+    def fail_cleanup(provider, server_url, model):
+        unload_calls.append((provider, server_url, model))
+        raise RuntimeError("cleanup endpoint failed")
+
+    monkeypatch.setattr(node, "_run_single", run_single)
+    monkeypatch.setattr(module, "unload_local_llm_model", fail_cleanup)
+
+    with pytest.raises(RuntimeError) as raised:
+        node.refine(**_refine_kwargs(["first", "second", "third"]))
+
+    assert raised.value is original_error
+    assert [call["is_last"] for call in calls] == [False, False]
+    assert unload_calls == [("Ollama", "http://127.0.0.1:11434", "qwen3")]
+    assert events[-1]["status"] == "error"
+    assert events[-1]["error"] == error_message
+
+
+def test_local_llm_terminal_preflight_failure_runs_fallback_cleanup_once(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    unload_calls = []
+    original_error = RuntimeError("terminal request failed")
+
+    monkeypatch.setattr(module, "_send_progress", lambda _payload: None)
+    monkeypatch.setattr(module, "_unload_other_warm_local_llms", lambda **_kwargs: {})
+    monkeypatch.setattr(module, "_prepare_comfy_vram_before_llm", lambda **_kwargs: {})
+    monkeypatch.setattr(node, "_run_single", lambda **_kwargs: (_ for _ in ()).throw(original_error))
+    monkeypatch.setattr(
+        module,
+        "unload_local_llm_model",
+        lambda *args: unload_calls.append(args) or {"ok": True},
+    )
+
+    kwargs = _refine_kwargs(["only prompt"])
+    kwargs.update({
+        "provider": "vLLM",
+        "custom_server_url": "http://127.0.0.1:8000/v1",
+        "custom_model": "qwen3",
+    })
+    with pytest.raises(RuntimeError) as raised:
+        node.refine(**kwargs)
+
+    assert raised.value is original_error
+    assert unload_calls == [("vLLM", "http://127.0.0.1:8000/v1", "qwen3")]
+
+
+def test_local_llm_terminal_provider_cleanup_is_not_duplicated(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    unload_calls = []
+    original_error = RuntimeError("terminal stream failed after provider cleanup")
+
+    monkeypatch.setattr(module, "_send_progress", lambda _payload: None)
+    monkeypatch.setattr(module, "_unload_other_warm_local_llms", lambda **_kwargs: {})
+    monkeypatch.setattr(module, "_prepare_comfy_vram_before_llm", lambda **_kwargs: {})
+
+    def fail_after_provider_cleanup(**kwargs):
+        kwargs["cleanup_state"]["provider_cleanup_attempted"] = True
+        raise original_error
+
+    monkeypatch.setattr(node, "_run_single", fail_after_provider_cleanup)
+    monkeypatch.setattr(
+        module,
+        "unload_local_llm_model",
+        lambda *args: unload_calls.append(args) or {"ok": True},
+    )
+
+    kwargs = _refine_kwargs(["only prompt"])
+    kwargs.update({"provider": "LM Studio", "lm_studio_model": "google/gemma"})
+    with pytest.raises(RuntimeError) as raised:
+        node.refine(**kwargs)
+
+    assert raised.value is original_error
+    assert unload_calls == []
+
+
+def test_local_llm_lm_studio_terminal_stream_failure_runs_one_provider_cleanup(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    unload_calls = []
+    original_error = RuntimeError("Local LLM generation stopped.")
+
+    def fail_stream(*_args, **_kwargs):
+        yield "chat.start", {"type": "chat.start"}
+        raise original_error
+
+    monkeypatch.setattr(module, "_http_stream_sse", fail_stream)
+    monkeypatch.setattr(
+        node,
+        "_lm_unload_best_effort",
+        lambda native_base, model: unload_calls.append((native_base, model)),
+    )
+
+    with pytest.raises(RuntimeError) as raised:
+        node._run_lm_studio(
+            server_url="http://127.0.0.1:1234/v1",
+            model="google/gemma",
+            system_prompt="",
+            prompt="hello",
+            thinking=True,
+            seed=7,
+            model_memory="Unload after run",
+            keep_minutes=5,
+            image_attachments=[],
+            is_last=True,
+            node_id="cleanup-node",
+            index=1,
+            total=1,
+        )
+
+    assert raised.value is original_error
+    assert unload_calls == [("http://127.0.0.1:1234", "google/gemma")]
+
+
+def test_local_llm_ollama_terminal_failure_uses_explicit_cleanup_once(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    unload_calls = []
+    original_error = RuntimeError("Ollama stream stopped before completion")
+
+    monkeypatch.setattr(module, "_send_progress", lambda _payload: None)
+    monkeypatch.setattr(module, "_unload_other_warm_local_llms", lambda **_kwargs: {})
+    monkeypatch.setattr(module, "_prepare_comfy_vram_before_llm", lambda **_kwargs: {})
+    monkeypatch.setattr(node, "_run_single", lambda **_kwargs: (_ for _ in ()).throw(original_error))
+    monkeypatch.setattr(
+        module,
+        "unload_local_llm_model",
+        lambda *args: unload_calls.append(args) or {"ok": True},
+    )
+
+    with pytest.raises(RuntimeError) as raised:
+        node.refine(**_refine_kwargs(["only prompt"]))
+
+    assert raised.value is original_error
+    assert unload_calls == [("Ollama", "http://127.0.0.1:11434", "qwen3")]
+
+
+def test_local_llm_ollama_completed_terminal_request_does_not_unload_twice_on_postprocess_error(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    unload_calls = []
+
+    monkeypatch.setattr(module, "_send_progress", lambda _payload: None)
+    monkeypatch.setattr(module, "_unload_other_warm_local_llms", lambda **_kwargs: {})
+    monkeypatch.setattr(module, "_prepare_comfy_vram_before_llm", lambda **_kwargs: {})
+    def completed_provider_request(**kwargs):
+        kwargs["cleanup_state"]["provider_cleanup_attempted"] = True
+        return "answer", "", {}
+
+    monkeypatch.setattr(node, "_run_single", completed_provider_request)
+    monkeypatch.setattr(
+        module,
+        "unload_local_llm_model",
+        lambda *args: unload_calls.append(args) or {"ok": True},
+    )
+
+    kwargs = _refine_kwargs(["only prompt"])
+    kwargs["thinking"] = True
+    with pytest.raises(RuntimeError, match="no Thinking/reasoning content"):
+        node.refine(**kwargs)
+
+    # The completed final Ollama request already used keep_alive=0. The
+    # post-processing error must not trigger a second explicit unload call.
+    assert unload_calls == []
+
+
+@pytest.mark.parametrize(
+    "review",
+    [
+        "NOT OK",
+        "not approved",
+        "cannot approve",
+        "not a PASS",
+        '{"verdict":"NOT OK","reason":"subject is missing"}',
+        '{"status":"not approved","reason":"quality is too low"}',
+    ],
+)
+def test_ai_review_gate_rejects_negated_approval_phrases(review):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    gate = package.DenoAIReviewGate()
+    image = object()
+
+    result = gate.gate(review=review, image=image)
+
+    assert result["ui"]["deno_llm_gate"][0]["passed"] is False
+    assert result["ui"]["deno_llm_gate"][0]["verdict"] == "FAIL"
+    assert isinstance(result["result"][0], module.ExecutionBlocker)
+
+
+def test_ai_review_gate_keeps_explicit_positive_and_manual_approval_paths():
+    package = load_package()
+    gate = package.DenoAIReviewGate()
+    image = object()
+
+    for review in ("OK", "PASS", "APPROVE", "APPROVED", "not only OK but excellent"):
+        result = gate.gate(review=review, image=image)
+        assert result["ui"]["deno_llm_gate"][0]["passed"] is True
+        assert result["result"][0] is image
+
+    manual_pass = gate.gate(review="NOT OK", review_mode="Pass", image=image)
+    approve_once = gate.gate(review="cannot approve", approve_once=True, image=image)
+    assert manual_pass["ui"]["deno_llm_gate"][0]["source"] == "Manual pass"
+    assert manual_pass["result"][0] is image
+    assert approve_once["ui"]["deno_llm_gate"][0]["source"] == "Approve once"
+    assert approve_once["result"][0] is image
+
+
+def test_ai_reviewer_snapshot_paths_are_workflow_scoped_and_legacy_state_still_loads(tmp_path):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    sys.modules["folder_paths"].get_temp_directory = lambda: str(tmp_path)
+    gate_cls = package.NODE_CLASS_MAPPINGS["DenoAIReviewGate"]
+    gate = package.DenoAIReviewGate()
+    image = np.zeros((1, 4, 5, 3), dtype=np.float32)
+    image[0, 1, 2, 0] = 0.75
+    workflow_a = {"workflow": {"id": "11111111-1111-4111-8111-111111111111"}}
+    workflow_b = {"workflow": {"id": "22222222-2222-4222-8222-222222222222"}}
+
+    assert gate_cls.INPUT_TYPES()["hidden"] == {
+        "unique_id": "UNIQUE_ID",
+        "extra_pnginfo": "EXTRA_PNGINFO",
+    }
+
+    preview_a = module._stable_reviewer_preview_path("42", workflow_a)
+    preview_a_again = module._stable_reviewer_preview_path("42", workflow_a)
+    preview_b = module._stable_reviewer_preview_path("42", workflow_b)
+    snapshot_a = module._stable_reviewer_snapshot_path("42", workflow_a)
+    snapshot_b = module._stable_reviewer_snapshot_path("42", workflow_b)
+    legacy_snapshot = module._stable_reviewer_snapshot_path("42")
+
+    assert preview_a == preview_a_again
+    assert preview_a[1] != preview_b[1]
+    assert snapshot_a[1] != snapshot_b[1]
+    assert legacy_snapshot[1] == "deno_llm_reviewer_42.npy"
+
+    failed_a = gate.gate(review="FAIL", image=image, unique_id="42", extra_pnginfo=workflow_a)
+    failed_b = gate.gate(review="FAIL", image=image, unique_id="42", extra_pnginfo=workflow_b)
+    info_a = failed_a["ui"]["deno_llm_gate"][0]
+    info_b = failed_b["ui"]["deno_llm_gate"][0]
+    assert info_a["preview_image"]["filename"] != info_b["preview_image"]["filename"]
+    assert info_a["snapshot_image"]["filename"] != info_b["snapshot_image"]["filename"]
+
+    legacy_meta = module._save_reviewer_snapshot_image(image, "42")
+    assert legacy_meta["filename"] == "deno_llm_reviewer_42.npy"
+    approved = gate.gate(
+        review="Approved once.",
+        approve_once=True,
+        image=None,
+        reviewer_state=json.dumps({"snapshot_image": legacy_meta}),
+        unique_id="42",
+        extra_pnginfo=workflow_b,
+    )
+    restored = np.asarray(approved["result"][0])
+    assert approved["ui"]["deno_llm_gate"][0]["passed"] is True
+    assert restored.shape == image.shape
+    assert np.isclose(restored[0, 1, 2, 0], 0.75)
+
+
+def test_local_llm_frontend_async_actions_are_latest_wins():
+    node = shutil.which("node")
+    assert node, "node executable is required for the Local LLM async-action harness"
+
+    result = subprocess.run(
+        [node, str(REPO_ROOT / "tests" / "js" / "local_llm_async_action_harness.mjs")],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, f"node harness failed:\n{result.stdout}\n{result.stderr}"

--- a/tests/test_ltx_tiled_nodes_predictor.py
+++ b/tests/test_ltx_tiled_nodes_predictor.py
@@ -1044,6 +1044,209 @@ def test_av_sampler_freezes_audio_output_and_denoised_output(monkeypatch, fake_c
     assert torch.allclose(denoised_audio, audio)
 
 
+def test_av_sampler_preserves_retired_video_only_one_tile_execution(monkeypatch):
+    _patch_av_sampler_runtime(monkeypatch)
+    monkeypatch.setattr(
+        "deno_ltx_tiled_nodes._comfy_utils",
+        lambda: types.SimpleNamespace(PROGRESS_BAR_ENABLED=False),
+    )
+    video = torch.arange(1 * 2 * 3 * 4 * 4, dtype=torch.float32).reshape(
+        (1, 2, 3, 4, 4)
+    )
+    calls = []
+
+    class LegacyNoise:
+        seed = 321
+
+        def generate_noise(self, latent):
+            assert latent["samples"] is video
+            return torch.zeros_like(latent["samples"])
+
+    class LegacyGuider:
+        model_options = {}
+        model_patcher = types.SimpleNamespace(
+            model=types.SimpleNamespace(process_latent_out=lambda value: value)
+        )
+
+        def sample(
+            self,
+            noise,
+            source,
+            sampler,
+            sigmas,
+            *,
+            denoise_mask=None,
+            callback=None,
+            disable_pbar=True,
+            seed=None,
+        ):
+            calls.append(
+                {
+                    "noise": noise,
+                    "source": source,
+                    "sampler": sampler,
+                    "sigmas": sigmas,
+                    "denoise_mask": denoise_mask,
+                    "disable_pbar": disable_pbar,
+                    "seed": seed,
+                }
+            )
+            callback.x0_output["x0"] = source + 2.0
+            return source + 1.0
+
+    sampler_token = object()
+    sigmas = torch.tensor([1.0, 0.0])
+    output, denoised = DenoLTXAVStepFusedTiledSampler().sample(
+        LegacyNoise(),
+        LegacyGuider(),
+        sampler_token,
+        sigmas,
+        {
+            "samples": video,
+            "noise_mask": torch.ones_like(video),
+            "workflow_tag": "legacy-preserved",
+            "downscale_ratio_spacial": 8,
+            "downscale_ratio_temporal": 2,
+        },
+        horizontal_tiles=1,
+        vertical_tiles=1,
+        overlap=1,
+        audio_mode="freeze",
+        blend_mode="hann",
+        aggressive_memory_cleanup=False,
+        debug=False,
+        _deno_legacy_video_compat=True,
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["source"] is video
+    assert calls[0]["sampler"] is sampler_token
+    assert calls[0]["sigmas"] is sigmas
+    assert calls[0]["seed"] == 321
+    assert torch.equal(output["samples"], video + 1.0)
+    assert torch.equal(denoised["samples"], video + 2.0)
+    assert output["workflow_tag"] == "legacy-preserved"
+    assert denoised["workflow_tag"] == "legacy-preserved"
+    assert "deno_ltx_step_fused_tiling" not in output
+    assert "deno_ltx_step_fused_tiling" not in denoised
+    for latent in (output, denoised):
+        assert "downscale_ratio_spacial" not in latent
+        assert "downscale_ratio_temporal" not in latent
+
+
+def test_current_av_sampler_stays_strict_for_video_only_latent_without_migration_marker(monkeypatch):
+    _patch_av_sampler_runtime(monkeypatch)
+    monkeypatch.setattr(
+        "deno_ltx_tiled_nodes._reject_unsupported_guider",
+        lambda _guider: None,
+    )
+    video = torch.zeros((1, 2, 3, 4, 4))
+
+    with pytest.raises(TypeError, match="expects an LTX AV nested latent"):
+        DenoLTXAVStepFusedTiledSampler().sample(
+            _FakeNoise(),
+            _FakeSamplerGuider(x0_video=video, x0_audio=torch.zeros((1, 1, 2, 2))),
+            object(),
+            torch.tensor([1.0, 0.0]),
+            {"samples": video},
+            horizontal_tiles=1,
+            vertical_tiles=1,
+            overlap=1,
+            audio_mode="freeze",
+        )
+
+
+def test_legacy_video_migration_marker_runs_v0762_default_one_by_two_tiles(monkeypatch):
+    _patch_av_sampler_runtime(monkeypatch)
+    monkeypatch.setattr(
+        "deno_ltx_tiled_nodes._comfy_utils",
+        lambda: types.SimpleNamespace(PROGRESS_BAR_ENABLED=False),
+    )
+    video = torch.arange(1 * 2 * 3 * 32 * 16, dtype=torch.float32).reshape(
+        (1, 2, 3, 32, 16)
+    )
+    previous_calls = []
+
+    def previous_calculator(args):
+        previous_calls.append(args)
+        return [args["input"] + 0.25]
+
+    class LegacyNoise:
+        seed = 987
+
+        def generate_noise(self, latent):
+            assert latent["samples"] is video
+            return torch.zeros_like(video)
+
+    class LegacyGuider:
+        model_options = {"sampler_calc_cond_batch_function": previous_calculator}
+        model_patcher = types.SimpleNamespace(
+            model=types.SimpleNamespace(process_latent_out=lambda value: value)
+        )
+
+        def sample(
+            self,
+            noise,
+            source,
+            sampler,
+            sigmas,
+            *,
+            denoise_mask=None,
+            callback=None,
+            disable_pbar=True,
+            seed=None,
+        ):
+            assert torch.equal(noise, torch.zeros_like(video))
+            assert source is video
+            assert seed == 987
+            hook = self.model_options["sampler_calc_cond_batch_function"]
+            predictions = hook(
+                {
+                    "input": source,
+                    "sigma": sigmas[:1],
+                    "model": object(),
+                    "conds": [[], []],
+                    "model_options": self.model_options,
+                }
+            )
+            assert len(predictions) == 1
+            assert tuple(predictions[0].shape) == tuple(source.shape)
+            callback.x0_output["x0"] = source + 2.0
+            return source + 1.0
+
+    output, denoised = DenoLTXAVStepFusedTiledSampler().sample(
+        LegacyNoise(),
+        LegacyGuider(),
+        object(),
+        torch.tensor([1.0, 0.0]),
+        {"samples": video, "workflow_tag": "legacy-1x2"},
+        horizontal_tiles=1,
+        vertical_tiles=2,
+        overlap=8,
+        audio_mode="freeze",
+        blend_mode="hann",
+        aggressive_memory_cleanup=False,
+        debug=False,
+        _deno_legacy_video_compat=True,
+    )
+
+    assert len(previous_calls) == 2
+    assert all(tuple(call["input"].shape[-2:]) == (20, 16) for call in previous_calls)
+    assert torch.equal(output["samples"], video + 1.0)
+    assert torch.equal(denoised["samples"], video + 2.0)
+    assert output["workflow_tag"] == "legacy-1x2"
+    assert denoised["workflow_tag"] == "legacy-1x2"
+    expected_meta = {
+        "horizontal_tiles": 1,
+        "vertical_tiles": 2,
+        "overlap": 8,
+        "blend_mode": "hann",
+        "prediction_calls": 1,
+    }
+    assert output["deno_ltx_step_fused_tiling"] == expected_meta
+    assert denoised["deno_ltx_step_fused_tiling"] == expected_meta
+
+
 def test_av_sampler_rejects_missing_callback_x0(monkeypatch, fake_comfy_latent_utils):
     _patch_av_sampler_runtime(monkeypatch)
     video = torch.zeros((1, 2, 3, 6, 4))

--- a/tests/test_ltx_tiled_nodes_static.py
+++ b/tests/test_ltx_tiled_nodes_static.py
@@ -7,13 +7,19 @@ SOURCE = REPO_ROOT / "deno_ltx_tiled_nodes.py"
 
 def test_step_fused_sampler_uses_comfyui_cond_batch_hook():
     source = SOURCE.read_text(encoding="utf-8")
+    current_start = source.index("class DenoLTXAVStepFusedTiledSampler:")
+    current_end = source.index("\nNODE_CLASS_MAPPINGS", current_start)
+    current_sampler_source = source[current_start:current_end]
 
     assert "sampler_calc_cond_batch_function" in source
     assert "_comfy_samplers().calc_cond_batch" in source
     assert "predictor.call_count == 0" in source
-    assert "falling back to output" not in source
-    assert "denoised = output" not in source
+    assert "falling back to output" not in current_sampler_source
+    assert "denoised = output" not in current_sampler_source
+    assert "_require_callback_x0(" in current_sampler_source
     assert "Strict denoised_output mode" in source
+    assert "if _deno_legacy_video_compat is True:" in current_sampler_source
+    assert "if not _is_nested(latent_samples):" not in current_sampler_source
 
 
 def test_av_step_fused_sampler_reports_packed_av_outputs():

--- a/tests/test_public_workflow_migration.py
+++ b/tests/test_public_workflow_migration.py
@@ -88,13 +88,19 @@ def _optional_module_for_class():
     return mapping
 
 
-def _node_replacements():
+def _node_replacement_specs():
     for node in ast.walk(_init_tree()):
         if isinstance(node, ast.Assign):
             for target in node.targets:
                 if isinstance(target, ast.Name) and target.id == "DENO_NODE_REPLACEMENTS":
-                    replacements = ast.literal_eval(node.value)
-                    return {r["old_node_id"]: r["new_node_id"] for r in replacements}
+                    return tuple(ast.literal_eval(node.value))
+    return ()
+
+
+def _node_replacements():
+    replacements = _node_replacement_specs()
+    if replacements:
+        return {r["old_node_id"]: r["new_node_id"] for r in replacements}
     return {}
 
 
@@ -772,6 +778,100 @@ def test_fixture_deno_node_types_are_registered(fixture):
             f"{fixture.name}: DENO node '{node_type}' is neither registered in "
             f"NODE_CLASS_MAPPINGS nor in DENO_NODE_REPLACEMENTS"
         )
+
+
+def test_legacy_ltx_step_fused_sampler_replacement_contract_is_complete():
+    specs = {
+        spec["old_node_id"]: spec for spec in _node_replacement_specs()
+    }
+    replacement = specs["DenoLTXStepFusedTiledSampler"]
+
+    assert replacement["new_node_id"] == "DenoLTXAVStepFusedTiledSampler"
+    assert replacement["old_widget_ids"] == [
+        "horizontal_tiles",
+        "vertical_tiles",
+        "overlap",
+        "blend_mode",
+        "aggressive_memory_cleanup",
+        "debug",
+    ]
+    assert replacement["input_mapping"] == [
+        {"new_id": "noise", "old_id": "noise"},
+        {"new_id": "guider", "old_id": "guider"},
+        {"new_id": "sampler", "old_id": "sampler"},
+        {"new_id": "sigmas", "old_id": "sigmas"},
+        {"new_id": "latent_image", "old_id": "latent_image"},
+        {"new_id": "horizontal_tiles", "old_id": "horizontal_tiles"},
+        {"new_id": "vertical_tiles", "old_id": "vertical_tiles"},
+        {"new_id": "overlap", "old_id": "overlap"},
+        {"new_id": "audio_mode", "set_value": "freeze"},
+        {"new_id": "blend_mode", "old_id": "blend_mode"},
+        {
+            "new_id": "aggressive_memory_cleanup",
+            "old_id": "aggressive_memory_cleanup",
+        },
+        {"new_id": "debug", "old_id": "debug"},
+        {"new_id": "_deno_legacy_video_compat", "set_value": True},
+    ]
+    assert replacement["output_mapping"] == [
+        {"old_idx": 0, "new_idx": 0},
+        {"old_idx": 1, "new_idx": 1},
+    ]
+    assert "DenoLTXStepFusedTiledSampler" not in REGISTERED_IDS
+
+
+def test_legacy_ltx_step_fused_sampler_fixture_locks_saved_widget_order():
+    fixture = FIXTURE_DIR / "legacy_ltx_step_fused_sampler_v0762.json"
+    graph = _load(fixture)
+    nodes = [
+        node
+        for node in graph.get("nodes", [])
+        if node.get("type") == "DenoLTXStepFusedTiledSampler"
+    ]
+    assert len(nodes) == 1
+    assert nodes[0]["widgets_values"] == [1, 2, 8, "hann", False, False]
+    assert [slot["name"] for slot in nodes[0]["outputs"]] == [
+        "output",
+        "denoised_output",
+    ]
+    assert [slot["link"] for slot in nodes[0]["inputs"][:5]] == [1, 2, 3, 4, 5]
+    assert nodes[0]["inputs"][8]["name"] == "blend_mode"
+    assert nodes[0]["inputs"][8]["link"] == 6
+    assert nodes[0]["outputs"][0]["links"] == [7]
+    assert nodes[0]["outputs"][1]["links"] == [8]
+    assert graph["links"] == [
+        [1, 10, 0, 1, 0, "NOISE"],
+        [2, 11, 0, 1, 1, "GUIDER"],
+        [3, 12, 0, 1, 2, "SAMPLER"],
+        [4, 13, 0, 1, 3, "SIGMAS"],
+        [5, 14, 0, 1, 4, "LATENT"],
+        [6, 15, 0, 1, 8, "COMBO"],
+        [7, 1, 0, 20, 0, "LATENT"],
+        [8, 1, 1, 21, 0, "LATENT"],
+    ]
+
+
+def test_legacy_ltx_step_fused_sampler_frontend_replacement_preserves_values_and_links():
+    node_bin = shutil.which("node")
+    if not node_bin:
+        pytest.skip("node is required for the frontend replacement harness")
+
+    replacement = next(
+        spec
+        for spec in _node_replacement_specs()
+        if spec["old_node_id"] == "DenoLTXStepFusedTiledSampler"
+    )
+    fixture = FIXTURE_DIR / "legacy_ltx_step_fused_sampler_v0762.json"
+    harness = REPO_ROOT / "tests" / "js" / "ltx_legacy_replacement_harness.mjs"
+    result = subprocess.run(
+        [node_bin, str(harness), json.dumps(replacement), str(fixture)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"node replacement harness failed:\n{result.stdout}\n{result.stderr}"
+    )
+    assert "ltx_legacy_replacement_harness: ok" in result.stdout
 
 
 @pytest.mark.parametrize("fixture", FIXTURES, ids=lambda p: p.name)

--- a/tests/test_translate_engine.py
+++ b/tests/test_translate_engine.py
@@ -22,6 +22,29 @@ def _director_result(packet):
     return packet["result"] if isinstance(packet, dict) else packet
 
 
+def test_ideogram_save_path_containment_uses_components_and_resolves_links(tmp_path):
+    base = tmp_path / "input"
+    inside = base / "nested" / "image.png"
+    sibling = tmp_path / "input-escape" / "image.png"
+    inside.parent.mkdir(parents=True)
+    sibling.parent.mkdir(parents=True)
+    inside.write_bytes(b"inside")
+    sibling.write_bytes(b"outside")
+
+    assert deno_ideogram_director._path_is_within_base(base, inside) is True
+    assert deno_ideogram_director._path_is_within_base(base, sibling) is False
+    assert deno_ideogram_director._path_is_within_base(
+        base, base / ".." / "input-escape" / "image.png"
+    ) is False
+
+    link = base / "outside-link.png"
+    try:
+        link.symlink_to(sibling)
+    except (OSError, NotImplementedError):
+        return
+    assert deno_ideogram_director._path_is_within_base(base, link) is False
+
+
 def test_language_display_contract():
     assert len(engine.LANGS) == 106
     assert engine.code_for_display("자동 감지") == "auto"

--- a/web/js/deno_advanced_image_source_loader.js
+++ b/web/js/deno_advanced_image_source_loader.js
@@ -763,9 +763,9 @@ function setupAdvancedImageSourceLoader(node) {
     };
 
     clearBtn.onclick = () => setPaths([]);
-    inputFolderBtn.onclick = () => showInputFolderBrowser(setPaths, getPaths);
+    inputFolderBtn.onclick = () => showInputFolderBrowser(node, setPaths, getPaths);
     externalFolderBtn.onclick = () => showExternalFolderBrowser(node, setPaths, getPaths, folderUploadInput, uploadFiles);
-    urlPathBtn.onclick = () => showSourceTextDialog(setPaths, getPaths);
+    urlPathBtn.onclick = () => showSourceTextDialog(node, setPaths, getPaths);
 
     container.ondragover = (event) => {
         if (isReordering) {
@@ -797,6 +797,8 @@ function setupAdvancedImageSourceLoader(node) {
     node.__denoAdvancedPanCleanup = installMiddleMouseCanvasPan(container);
     const originalOnRemoved = node.onRemoved;
     node.onRemoved = function () {
+        this.__denoCloseAdvancedFolderBrowser?.();
+        this.__denoCloseAdvancedFolderBrowser = null;
         this.__denoAdvancedPanCleanup?.();
         this.__denoAdvancedPanCleanup = null;
         return originalOnRemoved?.apply(this, arguments);
@@ -911,8 +913,9 @@ function installMiddleMouseCanvasPan(root) {
     };
 }
 
-function showInputFolderBrowser(setPaths, getPaths) {
+function showInputFolderBrowser(node, setPaths, getPaths) {
     showBrowserModal({
+        ownerNode: node,
         title: "Add images from ComfyUI input folder",
         rootControls: null,
         initialStatus: "Loading input folder list...",
@@ -941,7 +944,7 @@ function showExternalFolderBrowser(node, setPaths, getPaths, folderUploadInput, 
     let refresh = null;
     loadBtn.onclick = () => refresh?.("");
     uploadFolderBtn.onclick = () => folderUploadInput.click();
-    folderUploadInput.onchange = async (event) => {
+    const onFolderUpload = async (event) => {
         const files = Array.from(event.target.files || []);
         const firstPath = String(files[0]?.webkitRelativePath || "");
         const rootName = sanitizePathPart(firstPath.split("/")[0] || "selected-folder");
@@ -955,24 +958,33 @@ function showExternalFolderBrowser(node, setPaths, getPaths, folderUploadInput, 
         });
         folderUploadInput.value = "";
     };
+    folderUploadInput.onchange = onFolderUpload;
 
     refresh = showBrowserModal({
+        ownerNode: node,
         title: "Add images from an external folder",
         rootControls: rootRow,
         initialStatus: "Paste a folder path and click Load Path, or use Upload Folder... to import a folder.",
-        fetchEntries: async (folderPath) => {
+        fetchEntries: async (folderPath, signal) => {
             const rootPath = String(rootInput.value || "").trim();
-            return fetchExternalFolderImagesAndRemember(node, rootPath, folderPath);
+            return fetchExternalFolderImagesAndRemember(node, rootPath, folderPath, signal);
         },
         getPreviewUrl: (entry) => externalImagePreviewUrl(entry.path),
         getSourceValue: (entry) => entry.path,
         setPaths,
         getPaths,
         waitForManualLoad: true,
+        onClose: () => {
+            if (folderUploadInput.onchange === onFolderUpload) {
+                folderUploadInput.onchange = null;
+            }
+        },
     });
 }
 
-function showSourceTextDialog(setPaths, getPaths) {
+function showSourceTextDialog(node, setPaths, getPaths) {
+    node?.__denoCloseAdvancedFolderBrowser?.();
+    let closed = false;
     const overlay = createOverlay();
     const modal = createModal("Add URLs or file paths");
 
@@ -999,11 +1011,27 @@ function showSourceTextDialog(setPaths, getPaths) {
     const addBtn = createActionButton("Add Sources");
     footer.append(cancelBtn, addBtn);
 
-    cancelBtn.onclick = () => overlay.remove();
+    const close = () => {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        overlay.remove();
+        if (node?.__denoCloseAdvancedFolderBrowser === close) {
+            node.__denoCloseAdvancedFolderBrowser = null;
+        }
+    };
+    if (node) {
+        node.__denoCloseAdvancedFolderBrowser = close;
+    }
+    cancelBtn.onclick = close;
     addBtn.onclick = () => {
+        if (closed) {
+            return;
+        }
         const added = text.value.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
         setPaths(getPaths().concat(added));
-        overlay.remove();
+        close();
     };
 
     modal.append(text, footer);
@@ -1013,6 +1041,10 @@ function showSourceTextDialog(setPaths, getPaths) {
 }
 
 function showBrowserModal(options) {
+    const ownerNode = options.ownerNode;
+    ownerNode?.__denoCloseAdvancedFolderBrowser?.();
+    const requestGate = createLatestRequestGate();
+    let closed = false;
     const overlay = createOverlay();
     const modal = createModal(options.title);
 
@@ -1055,7 +1087,22 @@ function showBrowserModal(options) {
 
     const header = modal.firstElementChild;
     const closeBtn = header?.querySelector("button");
-    closeBtn.onclick = () => overlay.remove();
+    const closeModal = () => {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        requestGate.dispose();
+        overlay.remove();
+        options.onClose?.();
+        if (ownerNode?.__denoCloseAdvancedFolderBrowser === closeModal) {
+            ownerNode.__denoCloseAdvancedFolderBrowser = null;
+        }
+    };
+    closeBtn.onclick = closeModal;
+    if (ownerNode) {
+        ownerNode.__denoCloseAdvancedFolderBrowser = closeModal;
+    }
 
     if (options.rootControls) {
         modal.append(options.rootControls);
@@ -1173,15 +1220,22 @@ function showBrowserModal(options) {
     };
 
     const loadFolder = async (folderPath = "") => {
+        const request = requestGate.start();
         status.textContent = "Loading...";
         try {
-            const payload = await options.fetchEntries(folderPath);
+            const payload = await options.fetchEntries(folderPath, request.signal);
+            if (!request.isCurrent() || closed || !overlay.isConnected) {
+                return;
+            }
             currentFolder = normalizeSlashPath(payload.path || folderPath || "");
             parentFolder = normalizeSlashPath(payload.parent || "");
             folders = payload.folders || [];
             files = payload.files || [];
             render();
         } catch (error) {
+            if (!request.isCurrent() || closed || error?.name === "AbortError") {
+                return;
+            }
             status.textContent = error.message || String(error);
             folders = [];
             files = [];
@@ -1193,7 +1247,7 @@ function showBrowserModal(options) {
     search.oninput = render;
     addBtn.onclick = () => {
         options.setPaths(options.getPaths().concat(Array.from(selected)));
-        overlay.remove();
+        closeModal();
     };
 
     if (!options.waitForManualLoad) {
@@ -1203,12 +1257,12 @@ function showBrowserModal(options) {
     return loadFolder;
 }
 
-async function fetchInputFolderImages(folderPath = "") {
+async function fetchInputFolderImages(folderPath = "", signal = undefined) {
     const path = normalizeSlashPath(folderPath);
     const endpoint = path
         ? `/deno/input-folder-images?path=${encodeURIComponent(path)}`
         : "/deno/input-folder-images";
-    const response = await api.fetchApi(endpoint, { cache: "no-store" });
+    const response = await api.fetchApi(endpoint, { cache: "no-store", signal });
     if (response.status !== 200) {
         throw new Error(`Input folder list failed (${response.status})`);
     }
@@ -1227,13 +1281,13 @@ async function fetchInputFolderImages(folderPath = "") {
     };
 }
 
-async function fetchExternalFolderImages(rootPath, folderPath = "") {
+async function fetchExternalFolderImages(rootPath, folderPath = "", signal = undefined) {
     const root = String(rootPath || "").trim();
     if (!root) {
         throw new Error("Paste a folder path first.");
     }
     const params = new URLSearchParams({ root, path: normalizeSlashPath(folderPath) });
-    const response = await api.fetchApi(`/deno/advanced/external-folder-images?${params.toString()}`, { cache: "no-store" });
+    const response = await api.fetchApi(`/deno/advanced/external-folder-images?${params.toString()}`, { cache: "no-store", signal });
     if (response.status !== 200) {
         let message = `External folder list failed (${response.status})`;
         try {
@@ -1260,9 +1314,14 @@ async function fetchExternalFolderImages(rootPath, folderPath = "") {
     };
 }
 
-async function fetchExternalFolderImagesAndRemember(node, rootPath, folderPath = "") {
+async function fetchExternalFolderImagesAndRemember(node, rootPath, folderPath = "", signal = undefined) {
     const root = String(rootPath || "").trim();
-    const payload = await fetchExternalFolderImages(root, folderPath);
+    const payload = await fetchExternalFolderImages(root, folderPath, signal);
+    if (signal?.aborted) {
+        const error = new Error("Request aborted");
+        error.name = "AbortError";
+        throw error;
+    }
     node.__denoAdvancedLastExternalRoot = root;
     return payload;
 }
@@ -1321,6 +1380,41 @@ function classifySourceLocation(path) {
         return "external";
     }
     return "input";
+}
+
+function createLatestRequestGate() {
+    let generation = 0;
+    let controller = null;
+    let disposed = false;
+
+    const invalidate = () => {
+        generation += 1;
+        controller?.abort();
+        controller = null;
+    };
+
+    return {
+        start() {
+            invalidate();
+            const requestGeneration = generation;
+            controller = new AbortController();
+            if (disposed) {
+                controller.abort();
+            }
+            const signal = controller.signal;
+            return {
+                signal,
+                isCurrent: () => !disposed && !signal.aborted && requestGeneration === generation,
+            };
+        },
+        dispose() {
+            if (disposed) {
+                return;
+            }
+            disposed = true;
+            invalidate();
+        },
+    };
 }
 
 function createOverlay() {
@@ -1450,5 +1544,6 @@ if (typeof window !== "undefined" && typeof window.__DENO_ADVANCED_IMAGE_SOURCE_
         getPreviewUrl,
         getSourceKind,
         installMiddleMouseCanvasPan,
+        createLatestRequestGate,
     });
 }

--- a/web/js/deno_bernini_prompt_guide.js
+++ b/web/js/deno_bernini_prompt_guide.js
@@ -287,6 +287,13 @@ app.registerExtension({
             });
             return result;
         };
+
+        const onRemoved = nodeType.prototype.onRemoved;
+        nodeType.prototype.onRemoved = function () {
+            this.__denoBerniniTaskInfoClose?.();
+            this.__denoBerniniTaskInfoClose = null;
+            return onRemoved?.apply(this, arguments);
+        };
     },
 });
 
@@ -861,7 +868,12 @@ function isInsideBounds(pos, bounds) {
 
 function showTaskInfoPanel(node, event) {
     ensureTaskInfoStyles();
-    document.getElementById("deno-bernini-task-info-panel")?.remove();
+    const existing = document.getElementById("deno-bernini-task-info-panel");
+    if (existing?.__denoClose) {
+        existing.__denoClose();
+    } else {
+        existing?.remove();
+    }
 
     const help = getTaskHelp(node);
     const panel = document.createElement("div");
@@ -886,11 +898,26 @@ function showTaskInfoPanel(node, event) {
         </div>
     `;
 
+    let closed = false;
+    let listenerTimer = 0;
     const close = () => {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        if (listenerTimer) {
+            clearTimeout(listenerTimer);
+            listenerTimer = 0;
+        }
         panel.remove();
         document.removeEventListener("pointerdown", closeOnOutside, true);
         document.removeEventListener("keydown", closeOnEscape, true);
+        if (node.__denoBerniniTaskInfoClose === close) {
+            node.__denoBerniniTaskInfoClose = null;
+        }
     };
+    panel.__denoClose = close;
+    node.__denoBerniniTaskInfoClose = close;
     const closeOnOutside = (pointerEvent) => {
         if (!panel.contains(pointerEvent.target)) {
             close();
@@ -921,9 +948,12 @@ function showTaskInfoPanel(node, event) {
     panel.style.left = `${x}px`;
     panel.style.top = `${y}px`;
 
-    setTimeout(() => {
-        document.addEventListener("pointerdown", closeOnOutside, true);
-        document.addEventListener("keydown", closeOnEscape, true);
+    listenerTimer = setTimeout(() => {
+        listenerTimer = 0;
+        if (!closed && panel.isConnected) {
+            document.addEventListener("pointerdown", closeOnOutside, true);
+            document.addEventListener("keydown", closeOnEscape, true);
+        }
     }, 0);
 }
 

--- a/web/js/deno_extra_nodes.js
+++ b/web/js/deno_extra_nodes.js
@@ -994,12 +994,12 @@ function setupMultiImageLoader(node, options = {}) {
         return { name, path };
     }
 
-    async function fetchInputFolderImages(inputPath = "") {
+    async function fetchInputFolderImages(inputPath = "", signal = undefined) {
         const browserPath = normalizeInputFolderPath(inputPath);
         const denoEndpoint = browserPath
             ? `/deno/input-folder-images?path=${encodeURIComponent(browserPath)}`
             : "/deno/input-folder-images";
-        const denoResponse = await api.fetchApi(denoEndpoint, { cache: "no-store" });
+        const denoResponse = await api.fetchApi(denoEndpoint, { cache: "no-store", signal });
         if (denoResponse.status === 200) {
             const payload = await denoResponse.json();
             return {
@@ -1014,7 +1014,7 @@ function setupMultiImageLoader(node, options = {}) {
             throw new Error(`Input folder list failed (${denoResponse.status})`);
         }
 
-        const response = await api.fetchApi("/object_info/LoadImage", { cache: "no-store" });
+        const response = await api.fetchApi("/object_info/LoadImage", { cache: "no-store", signal });
         if (response.status !== 200) {
             throw new Error(`Input folder list failed (${denoResponse.status}, fallback ${response.status})`);
         }
@@ -1029,6 +1029,9 @@ function setupMultiImageLoader(node, options = {}) {
     }
 
     function showInputFolderBrowser() {
+        node.__denoCloseInputFolderBrowser?.();
+        const requestGate = createLatestRequestGate();
+        let closed = false;
         const overlay = document.createElement("div");
         overlay.style.cssText = `
             position: fixed;
@@ -1167,6 +1170,7 @@ function setupMultiImageLoader(node, options = {}) {
         };
 
         const cleanupInputFolderBrowser = () => {
+            requestGate.dispose();
             window.removeEventListener("resize", scheduleVirtualRender);
             if (virtualRenderFrame) {
                 cancelAnimationFrame(virtualRenderFrame);
@@ -1175,9 +1179,17 @@ function setupMultiImageLoader(node, options = {}) {
         };
 
         const closeInputFolderBrowser = () => {
+            if (closed) {
+                return;
+            }
+            closed = true;
             cleanupInputFolderBrowser();
             overlay.remove();
+            if (node.__denoCloseInputFolderBrowser === closeInputFolderBrowser) {
+                node.__denoCloseInputFolderBrowser = null;
+            }
         };
+        node.__denoCloseInputFolderBrowser = closeInputFolderBrowser;
 
         const refreshSelected = () => {
             selectedLabel.textContent = `${selected.size} selected`;
@@ -1389,10 +1401,17 @@ function setupMultiImageLoader(node, options = {}) {
 
         const loadInputFolder = (path = "") => {
             const nextPath = normalizeInputFolderPath(path);
+            const request = requestGate.start();
             status.textContent = "Loading input folder list...";
             list.replaceChildren();
-            return fetchInputFolderImages(nextPath)
+            return fetchInputFolderImages(nextPath, request.signal)
                 .then((payload) => {
+                    if (!request.isCurrent() || closed || !container.isConnected) {
+                        if (!container.isConnected) {
+                            closeInputFolderBrowser();
+                        }
+                        return;
+                    }
                     currentPath = normalizeInputFolderPath(payload.path ?? nextPath);
                     currentParent = normalizeInputFolderPath(payload.parent ?? "");
                     allFolders = payload.folders ?? [];
@@ -1403,6 +1422,9 @@ function setupMultiImageLoader(node, options = {}) {
                     search.focus();
                 })
                 .catch((error) => {
+                    if (!request.isCurrent() || closed || error?.name === "AbortError") {
+                        return;
+                    }
                     status.textContent = `Failed to read input folder list: ${error.message || error}`;
                     allFolders = [];
                     allFiles = [];
@@ -1477,6 +1499,8 @@ function setupMultiImageLoader(node, options = {}) {
     document.addEventListener("paste", pasteHandler, { capture: true });
     const originalRemoved = node.onRemoved;
     node.onRemoved = function () {
+        this.__denoCloseInputFolderBrowser?.();
+        this.__denoCloseInputFolderBrowser = null;
         document.removeEventListener("paste", pasteHandler, { capture: true });
         originalRemoved?.apply(this, arguments);
     };
@@ -1492,6 +1516,41 @@ function setupMultiImageLoader(node, options = {}) {
     node._denoUpdateLoaderVisibility?.();
     render();
     refreshOutputSizeHint();
+}
+
+function createLatestRequestGate() {
+    let generation = 0;
+    let controller = null;
+    let disposed = false;
+
+    const invalidate = () => {
+        generation += 1;
+        controller?.abort();
+        controller = null;
+    };
+
+    return {
+        start() {
+            invalidate();
+            const requestGeneration = generation;
+            controller = new AbortController();
+            if (disposed) {
+                controller.abort();
+            }
+            const signal = controller.signal;
+            return {
+                signal,
+                isCurrent: () => !disposed && !signal.aborted && requestGeneration === generation,
+            };
+        },
+        dispose() {
+            if (disposed) {
+                return;
+            }
+            disposed = true;
+            invalidate();
+        },
+    };
 }
 
 async function calculateLoaderOutputSize(node, paths) {
@@ -4048,5 +4107,6 @@ if (typeof window !== "undefined" && typeof window.__DENO_EXTRA_NODES_TEST_HOOK_
         getInputLinkIds,
         notifyConnectedSequencers,
         setupSequencer,
+        createLatestRequestGate,
     });
 }

--- a/web/js/deno_floating_tools.js
+++ b/web/js/deno_floating_tools.js
@@ -1441,6 +1441,12 @@ function readCachedUpdateState() {
     const cached = readStoredJson(UPDATE_CACHE_KEY, null);
     if (!cached || typeof cached !== "object") return null;
     if (!Number.isFinite(Number(cached.checkedAt)) && getLatestMetadataTime(cached) === null) return null;
+    if (
+        ["latest", "updates"].includes(cached.status)
+        && !hasCompleteLatestVersions(latestVersionsFromState(cached))
+    ) {
+        return null;
+    }
     return cached;
 }
 
@@ -1451,7 +1457,8 @@ function getLatestMetadataTime(state) {
 
 function isLatestMetadataFresh(state) {
     const latestCheckedAt = getLatestMetadataTime(state);
-    return Boolean(latestCheckedAt !== null && Date.now() - latestCheckedAt < UPDATE_CACHE_TTL_MS);
+    const age = latestCheckedAt === null ? Number.POSITIVE_INFINITY : Date.now() - latestCheckedAt;
+    return Boolean(age >= 0 && age < UPDATE_CACHE_TTL_MS);
 }
 
 function latestVersionsFromState(state) {
@@ -1502,11 +1509,15 @@ async function fetchLatestUpdateVersions() {
         fetchPypiLatest("comfyui-workflow-templates"),
         fetchPypiLatest("comfyui-frontend-package"),
     ]);
-    return {
+    const latestVersions = {
         comfyui: comfyLatest,
         templates: templatesLatest,
         frontend: frontendLatest,
     };
+    if (!hasCompleteLatestVersions(latestVersions)) {
+        throw new Error("Latest version metadata is incomplete.");
+    }
+    return latestVersions;
 }
 
 function buildUpdateItems(system, latestVersions) {
@@ -1537,6 +1548,9 @@ function buildUpdateItems(system, latestVersions) {
 }
 
 function buildUpdateState(system, latestVersions, latestCheckedAt) {
+    if (!hasCompleteLatestVersions(latestVersions)) {
+        throw new Error("Latest version metadata is incomplete.");
+    }
     const items = buildUpdateItems(system, latestVersions);
     const hasUpdates = items.some((item) => item.updateAvailable);
     return {

--- a/web/js/deno_image_compare.js
+++ b/web/js/deno_image_compare.js
@@ -28,7 +28,7 @@ const COLORS = {
 };
 
 function imageDataToUrl(data) {
-    return api.apiURL(`/view?filename=${encodeURIComponent(data.filename)}&type=${data.type}&subfolder=${data.subfolder}${app.getPreviewFormatParam()}${app.getRandParam()}`);
+    return api.apiURL(`/view?filename=${encodeURIComponent(data.filename)}&type=${encodeURIComponent(data.type || "output")}&subfolder=${encodeURIComponent(data.subfolder || "")}${app.getPreviewFormatParam()}${app.getRandParam()}`);
 }
 
 app.registerExtension({

--- a/web/js/deno_local_llm_refiner.js
+++ b/web/js/deno_local_llm_refiner.js
@@ -157,10 +157,12 @@ let reviewerTooltipOwner = null;
 let reviewerTooltipOwnerFrame = 0;
 const progressListenerApis = new WeakSet();
 const localLLMQueuePromptApis = new WeakSet();
+const localLLMAppQueuePromptApps = new WeakSet();
 let progressListenerRetryScheduled = false;
 const localLLMStateByNode = new WeakMap();
 const localLLMDialogTokenByNode = new WeakMap();
 const localLLMOwnedUiByNode = new WeakMap();
+const localLLMAsyncActionByNode = new WeakMap();
 let localLLMDialogTokenCounter = 0;
 const localLLMGraphByPromptBundle = new WeakMap();
 const localLLMPromptGraphById = new Map();
@@ -436,6 +438,81 @@ function closeLocalLLMOwnedUi(node) {
     removeReviewerTooltipForNode(node);
 }
 
+function localLLMAsyncActionCanAbort(action) {
+    return String(action || "") === "refresh";
+}
+
+function abortLocalLLMAsyncAction(actionState) {
+    if (!actionState?.controller || !localLLMAsyncActionCanAbort(actionState.action)) {
+        return false;
+    }
+    try {
+        actionState.controller.abort();
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function invalidateLocalLLMAsyncAction(node, reason = "invalidated") {
+    const key = localLLMNodeStateKey(node);
+    if (!key) {
+        return 0;
+    }
+    const previous = localLLMAsyncActionByNode.get(key);
+    abortLocalLLMAsyncAction(previous);
+    const generation = Math.max(0, Number(previous?.generation) || 0) + 1;
+    localLLMAsyncActionByNode.set(key, {
+        generation,
+        action: "",
+        reason: String(reason || "invalidated"),
+        controller: null,
+    });
+    return generation;
+}
+
+function beginLocalLLMAsyncAction(node, action) {
+    const key = localLLMNodeStateKey(node);
+    if (!key) {
+        return null;
+    }
+    const previous = localLLMAsyncActionByNode.get(key);
+    abortLocalLLMAsyncAction(previous);
+    const token = {
+        generation: Math.max(0, Number(previous?.generation) || 0) + 1,
+        action: String(action || "action"),
+        controller: typeof AbortController === "function" ? new AbortController() : null,
+    };
+    localLLMAsyncActionByNode.set(key, token);
+    return token;
+}
+
+function isLocalLLMAsyncActionCurrent(node, token) {
+    const key = localLLMNodeStateKey(node);
+    return Boolean(key && token && localLLMAsyncActionByNode.get(key) === token);
+}
+
+function finishLocalLLMAsyncAction(node, token) {
+    const key = localLLMNodeStateKey(node);
+    if (!key || !token || localLLMAsyncActionByNode.get(key) !== token) {
+        return false;
+    }
+    localLLMAsyncActionByNode.set(key, {
+        generation: token.generation,
+        action: "",
+        reason: "finished",
+        controller: null,
+    });
+    return true;
+}
+
+function localLLMAsyncFetchOptions(token, options) {
+    if (!token?.controller?.signal) {
+        return options;
+    }
+    return { ...options, signal: token.controller.signal };
+}
+
 function installLocalLLMNodeCleanup(node) {
     if (!node || node.__denoLocalLLMNodeCleanupInstalled) {
         return;
@@ -443,6 +520,7 @@ function installLocalLLMNodeCleanup(node) {
     node.__denoLocalLLMNodeCleanupInstalled = true;
     const previousOnRemoved = node.onRemoved;
     node.onRemoved = function (...args) {
+        invalidateLocalLLMAsyncAction(this, "node removed");
         closeLocalLLMOwnedUi(this);
         return previousOnRemoved?.apply(this, args);
     };
@@ -537,6 +615,34 @@ function localLLMNodeForExecutionDetail(detail) {
     }
     pruneLocalLLMPromptGraphs();
     return localLLMNodeInGraph(localLLMPromptGraphById.get(promptId), detail?.node_id);
+}
+
+function invalidateLocalLLMAsyncActionsForExecutionDetail(detail, reason = "execution") {
+    const promptId = String(detail?.prompt_id || "").trim();
+    if (!promptId) {
+        return 0;
+    }
+    pruneLocalLLMPromptGraphs();
+    const graph = localLLMPromptGraphById.get(promptId);
+    if (!graph) {
+        return 0;
+    }
+    const nodeId = detail?.node_id ?? detail?.node;
+    const nodes = nodeId === null || nodeId === undefined || String(nodeId).trim() === ""
+        ? localLLMGraphNodes(graph).filter((node) => node?.type === NODE_NAME)
+        : [localLLMNodeInGraph(graph, nodeId)].filter(Boolean);
+    for (const node of nodes) {
+        invalidateLocalLLMAsyncAction(node, reason);
+    }
+    return nodes.length;
+}
+
+function invalidateLocalLLMAsyncActionsForGraph(graph, reason = "queue submitted") {
+    const nodes = localLLMGraphNodes(graph).filter((node) => node?.type === NODE_NAME);
+    for (const node of nodes) {
+        invalidateLocalLLMAsyncAction(node, reason);
+    }
+    return nodes.length;
 }
 
 function localLLMNodeDialogToken(node) {
@@ -992,6 +1098,7 @@ app.registerExtension({
     },
     setup() {
         installProgressListener();
+        installLocalLLMAppQueuePromptHook(app);
         installLocalLLMApiQueuePromptHook(api);
         installReviewerGraphToPromptHook();
         installGraphScan();
@@ -1316,6 +1423,9 @@ function installLocalLLMApiQueuePromptHook(targetApi = api) {
     targetApi.queuePrompt = async function (...args) {
         const promptBundle = args?.[1];
         const submittedGraph = localLLMGraphByPromptBundle.get(promptBundle) || null;
+        if (submittedGraph) {
+            invalidateLocalLLMAsyncActionsForGraph(submittedGraph, "queue API submitted");
+        }
         const result = await originalQueuePrompt.apply(this, args);
         if (submittedGraph && result?.prompt_id) {
             rememberLocalLLMPromptGraph(result.prompt_id, submittedGraph);
@@ -1323,6 +1433,30 @@ function installLocalLLMApiQueuePromptHook(targetApi = api) {
         return result;
     };
     localLLMQueuePromptApis.add(targetApi);
+    return true;
+}
+
+function installLocalLLMAppQueuePromptHook(targetApp = app) {
+    if (!targetApp || (typeof targetApp !== "object" && typeof targetApp !== "function")) {
+        return false;
+    }
+    if (localLLMAppQueuePromptApps.has(targetApp)) {
+        return true;
+    }
+    const originalQueuePrompt = targetApp.queuePrompt;
+    if (typeof originalQueuePrompt !== "function") {
+        return false;
+    }
+    targetApp.queuePrompt = function (...args) {
+        const submittedGraph = this?.rootGraph || targetApp.rootGraph || safeAppGraph();
+        // app.queuePrompt is the earliest queue boundary. Invalidate read-only
+        // Refresh work before graphToPrompt serializes provider/model widgets.
+        // Stop and Unload requests keep running; only their stale UI ownership
+        // token changes.
+        invalidateLocalLLMAsyncActionsForGraph(submittedGraph, "queue submitted");
+        return originalQueuePrompt.apply(this, args);
+    };
+    localLLMAppQueuePromptApps.add(targetApp);
     return true;
 }
 
@@ -1964,7 +2098,10 @@ if (typeof globalThis !== "undefined" && typeof globalThis.__DENO_LOCAL_LLM_REVI
         applyReviewerSubmitModes,
         applyLocalLLMAfterGenerateSeedModes,
         advanceLocalLLMSeedAfterQueued,
+        beginLocalLLMAsyncAction,
+        finishLocalLLMAsyncAction,
         isLocalLLMOwnExecutionError,
+        isLocalLLMAsyncActionCurrent,
         isShiftedCustomModelValue,
         localLLMExecutionErrorMessage,
         nextLocalLLMSeedValue,
@@ -1992,9 +2129,13 @@ if (typeof globalThis !== "undefined" && typeof globalThis.__DENO_LOCAL_LLM_REVI
         collectReviewerSelectableSeedCandidates,
         closeLocalLLMOwnedUi,
         incrementReviewerRetrySeed,
+        installLocalLLMAppQueuePromptHook,
         installLocalLLMApiQueuePromptHook,
         installLocalLLMNodeCleanup,
         installLocalLLMQueueCallbacks,
+        invalidateLocalLLMAsyncAction,
+        invalidateLocalLLMAsyncActionsForGraph,
+        invalidateLocalLLMAsyncActionsForExecutionDetail,
         localLLMNodeForExecutionDetail,
         maybeAutoRetryReviewer,
         previewTextDialogBody,
@@ -2019,6 +2160,11 @@ if (typeof globalThis !== "undefined" && typeof globalThis.__DENO_LOCAL_LLM_REVI
         setReviewerAutoRetryEnabled,
         setReviewerSeedTarget,
         splitPreviewLinesForWidth,
+        refreshModels,
+        stopLocalModel,
+        unloadLocalModel,
+        wrapModelCallback,
+        wrapProviderCallback,
     });
 }
 
@@ -2045,8 +2191,12 @@ function installProgressListener() {
                 if (!node) {
                     return;
                 }
+                invalidateLocalLLMAsyncAction(node, "execution progress");
                 setLocalLLMNodeState(node, localLLMProgressStatePatch(node, detail));
                 markGraphDirty(node);
+            });
+            eventApi.addEventListener("execution_start", ({ detail }) => {
+                invalidateLocalLLMAsyncActionsForExecutionDetail(detail, "execution started");
             });
             eventApi.addEventListener("execution_error", ({ detail }) => {
                 if (!isLocalLLMOwnExecutionError(detail)) {
@@ -2056,6 +2206,7 @@ function installProgressListener() {
                 if (!node) {
                     return;
                 }
+                invalidateLocalLLMAsyncAction(node, "execution error");
                 setLocalLLMNodeState(node, {
                     status: "error",
                     answer: "",
@@ -2066,6 +2217,9 @@ function installProgressListener() {
             });
             for (const eventName of ["execution_success", "execution_error", "execution_interrupted"]) {
                 eventApi.addEventListener(eventName, ({ detail }) => {
+                    if (eventName === "execution_interrupted") {
+                        invalidateLocalLLMAsyncActionsForExecutionDetail(detail, "execution interrupted");
+                    }
                     forgetLocalLLMPromptGraph(detail?.prompt_id);
                 });
             }
@@ -2640,6 +2794,7 @@ function setupNode(node) {
         setActiveProviderModelVisibility(node);
         wrapProviderCallback(node);
         wrapModelCallback(node);
+        wrapServerCallback(node);
         wrapModelMemoryCallback(node);
         addRefreshButton(node);
         addStopButton(node);
@@ -5077,6 +5232,7 @@ function wrapModelCallback(node) {
         }
         const original = modelWidget.callback;
         modelWidget.callback = function () {
+            invalidateLocalLLMAsyncAction(node, "model changed");
             const result = original?.apply(this, arguments);
             repairModelWidgetValue(modelWidget);
             if (name !== "custom_model") {
@@ -5099,6 +5255,24 @@ function wrapModelCallback(node) {
     }
 }
 
+function wrapServerCallback(node) {
+    const serverWidget = getWidget(node, "custom_server_url");
+    if (!serverWidget || serverWidget.__denoLocalLLMServerWrapped) {
+        return;
+    }
+    const original = serverWidget.callback;
+    serverWidget.callback = function () {
+        invalidateLocalLLMAsyncAction(node, "server changed");
+        const result = original?.apply(this, arguments);
+        const provider = currentProvider(node);
+        if (OPENAI_COMPATIBLE_PROVIDERS.has(provider)) {
+            rememberOpenAIProviderServerUrl(node, provider, serverWidget.value);
+        }
+        return result;
+    };
+    serverWidget.__denoLocalLLMServerWrapped = true;
+}
+
 function wrapProviderCallback(node) {
     const providerWidget = getWidget(node, "provider");
     if (!providerWidget || providerWidget.__denoLocalLLMWrapped) {
@@ -5106,6 +5280,7 @@ function wrapProviderCallback(node) {
     }
     const original = providerWidget.callback;
     providerWidget.callback = function () {
+        invalidateLocalLLMAsyncAction(node, "provider changed");
         const result = original?.apply(this, arguments);
         const provider = currentProvider(node);
         setActiveProviderModelVisibility(node);
@@ -5331,6 +5506,10 @@ function isLocalLLMBusyState(node) {
 }
 
 async function stopLocalModel(node) {
+    const action = beginLocalLLMAsyncAction(node, "stop");
+    if (!action) {
+        return;
+    }
     const provider = currentProvider(node);
     const serverUrl = defaultServerForProvider(provider, node);
     const modelWidget = activeModelWidget(node);
@@ -5350,16 +5529,23 @@ async function stopLocalModel(node) {
             status: "stop skipped",
             thinking: "Refresh Models and select an installed local LLM model before stopping.",
         });
+        finishLocalLLMAsyncAction(node, action);
         refreshNode(node);
         return;
     }
     try {
-        const response = await fetch("/deno/local_llm/stop", {
+        const response = await fetch("/deno/local_llm/stop", localLLMAsyncFetchOptions(action, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ provider, server_url: serverUrl, model }),
-        });
+        }));
+        if (!isLocalLLMAsyncActionCurrent(node, action)) {
+            return;
+        }
         const payload = await response.json();
+        if (!isLocalLLMAsyncActionCurrent(node, action)) {
+            return;
+        }
         if (!response.ok && !payload?.message) {
             throw new Error(payload?.error || `HTTP ${response.status}`);
         }
@@ -5371,6 +5557,9 @@ async function stopLocalModel(node) {
             thinking: String(payload.message || payload.error || "Stop request finished."),
         });
     } catch (error) {
+        if (!isLocalLLMAsyncActionCurrent(node, action)) {
+            return;
+        }
         setLocalLLMNodeState(node, {
             status: "stop failed",
             provider,
@@ -5378,8 +5567,11 @@ async function stopLocalModel(node) {
             answer: "",
             thinking: String(error?.message || error),
         });
+    } finally {
+        if (finishLocalLLMAsyncAction(node, action)) {
+            refreshNode(node);
+        }
     }
-    refreshNode(node);
 }
 
 function isManualUnloadUnavailableMessage(message) {
@@ -5395,6 +5587,11 @@ async function unloadLocalModel(node) {
     const model = String(modelWidget?.value || "").trim();
     const invalidModel = !model || isUnavailableModelWidgetValue(model);
     if (isLocalLLMBusyState(node)) {
+        const key = localLLMNodeStateKey(node);
+        const pendingAction = key ? localLLMAsyncActionByNode.get(key) : null;
+        if (pendingAction?.action !== "unload") {
+            invalidateLocalLLMAsyncAction(node, "unload blocked");
+        }
         setLocalLLMNodeState(node, {
             status: "unload blocked",
             provider,
@@ -5403,6 +5600,10 @@ async function unloadLocalModel(node) {
             thinking: "The local LLM is still generating. Press Stop LLM first, then unload after it has stopped.",
         });
         refreshNode(node);
+        return;
+    }
+    const action = beginLocalLLMAsyncAction(node, "unload");
+    if (!action) {
         return;
     }
     setLocalLLMNodeState(node, {
@@ -5418,16 +5619,23 @@ async function unloadLocalModel(node) {
             status: "unload skipped",
             thinking: "Refresh Models and select an installed local LLM model before unloading.",
         });
+        finishLocalLLMAsyncAction(node, action);
         refreshNode(node);
         return;
     }
     try {
-        const response = await fetch("/deno/local_llm/unload", {
+        const response = await fetch("/deno/local_llm/unload", localLLMAsyncFetchOptions(action, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ provider, server_url: serverUrl, model }),
-        });
+        }));
+        if (!isLocalLLMAsyncActionCurrent(node, action)) {
+            return;
+        }
         const payload = await response.json();
+        if (!isLocalLLMAsyncActionCurrent(node, action)) {
+            return;
+        }
         const payloadMessage = String(payload?.message || payload?.error || "");
         if (!response.ok && !payloadMessage) {
             throw new Error(payload?.error || `HTTP ${response.status}`);
@@ -5441,6 +5649,9 @@ async function unloadLocalModel(node) {
             thinking: payloadMessage || "Unload request finished.",
         });
     } catch (error) {
+        if (!isLocalLLMAsyncActionCurrent(node, action)) {
+            return;
+        }
         setLocalLLMNodeState(node, {
             status: "LLM unload failed",
             provider,
@@ -5448,11 +5659,18 @@ async function unloadLocalModel(node) {
             answer: "",
             thinking: String(error?.message || error),
         });
+    } finally {
+        if (finishLocalLLMAsyncAction(node, action)) {
+            refreshNode(node);
+        }
     }
-    refreshNode(node);
 }
 
 async function refreshModels(node) {
+    const action = beginLocalLLMAsyncAction(node, "refresh");
+    if (!action) {
+        return;
+    }
     const provider = currentProvider(node);
     const serverUrl = defaultServerForProvider(provider, node);
     const modelWidget = activeModelWidget(node);
@@ -5464,12 +5682,18 @@ async function refreshModels(node) {
     });
     refreshNode(node);
     try {
-        const response = await fetch("/deno/local_llm/models", {
+        const response = await fetch("/deno/local_llm/models", localLLMAsyncFetchOptions(action, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ provider, server_url: serverUrl }),
-        });
+        }));
+        if (!isLocalLLMAsyncActionCurrent(node, action)) {
+            return;
+        }
         const payload = await response.json();
+        if (!isLocalLLMAsyncActionCurrent(node, action)) {
+            return;
+        }
         if (!response.ok || payload.error) {
             throw new Error(payload.error || `HTTP ${response.status}`);
         }
@@ -5499,6 +5723,9 @@ async function refreshModels(node) {
                 : "No models were returned by the local server.",
         });
     } catch (error) {
+        if (!isLocalLLMAsyncActionCurrent(node, action)) {
+            return;
+        }
         updateModelChoices(node, provider, []);
         if (!OPENAI_COMPATIBLE_PROVIDERS.has(provider) && modelWidget && hasUsableSavedModelValue(savedModel)) {
             modelWidget.value = missingSavedModelDisplayValue(savedModel);
@@ -5512,8 +5739,11 @@ async function refreshModels(node) {
                 ? `Saved ${provider} model "${savedModel}" could not be verified on this PC. ${String(error?.message || error)}`
                 : String(error?.message || error),
         });
+    } finally {
+        if (finishLocalLLMAsyncAction(node, action)) {
+            refreshNode(node);
+        }
     }
-    refreshNode(node);
 }
 
 function normalizeModelChoices(models) {

--- a/web/js/deno_ltx_model_downloader.js
+++ b/web/js/deno_ltx_model_downloader.js
@@ -84,6 +84,7 @@ app.registerExtension({
         const onNodeCreated = nodeType.prototype.onNodeCreated;
         nodeType.prototype.onNodeCreated = function () {
             const result = onNodeCreated?.apply(this, arguments);
+            this.__denoLtxSetupDisposed = false;
             setupNode(this);
             return result;
         };
@@ -91,14 +92,27 @@ app.registerExtension({
         const onConfigure = nodeType.prototype.onConfigure;
         nodeType.prototype.onConfigure = function () {
             const result = onConfigure?.apply(this, arguments);
-            queueMicrotask(() => setupNode(this));
+            queueMicrotask(() => {
+                if (!this.__denoLtxSetupDisposed) {
+                    setupNode(this);
+                }
+            });
             return result;
+        };
+
+        const onRemoved = nodeType.prototype.onRemoved;
+        nodeType.prototype.onRemoved = function () {
+            this.__denoLtxSetupUi?.dispose?.();
+            this.__denoLtxSetupUi = null;
+            this.__denoLtxSetupReady = false;
+            this.__denoLtxSetupDisposed = true;
+            return onRemoved?.apply(this, arguments);
         };
     },
 });
 
 function setupNode(node) {
-    if (!node || node.type !== NODE_NAME) {
+    if (!node || node.type !== NODE_NAME || node.__denoLtxSetupDisposed) {
         return;
     }
     if (node.__denoLtxSetupReady) {
@@ -141,7 +155,44 @@ function hideWidget(widget) {
     widget.computeSize = () => [0, -4];
 }
 
+function createLatestRequestGate() {
+    let generation = 0;
+    let controller = null;
+    let disposed = false;
+
+    const invalidate = () => {
+        generation += 1;
+        controller?.abort();
+        controller = null;
+    };
+
+    return {
+        start() {
+            invalidate();
+            const requestGeneration = generation;
+            controller = new AbortController();
+            if (disposed) {
+                controller.abort();
+            }
+            const signal = controller.signal;
+            return {
+                signal,
+                isCurrent: () => !disposed && !signal.aborted && requestGeneration === generation,
+            };
+        },
+        dispose() {
+            if (disposed) {
+                return;
+            }
+            disposed = true;
+            invalidate();
+        },
+    };
+}
+
 function buildUi(node, rootWidget, presetsWidget) {
+    let disposed = false;
+    const requestGate = createLatestRequestGate();
     const root = document.createElement("div");
     root.style.cssText = `
         width:100%;
@@ -393,6 +444,9 @@ function buildUi(node, rootWidget, presetsWidget) {
     }
 
     function setStatus(text, danger = false) {
+        if (disposed) {
+            return;
+        }
         status.textContent = text;
         status.style.color = danger ? "#ffb0b0" : "#94f7af";
     }
@@ -414,8 +468,9 @@ function buildUi(node, rootWidget, presetsWidget) {
         return payload;
     }
 
-    async function postJson(path, body) {
+    async function postJson(path, body, options = {}) {
         return apiJson(path, {
+            ...options,
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(body),
@@ -595,6 +650,9 @@ function buildUi(node, rootWidget, presetsWidget) {
     }
 
     function reloadFromWidgets() {
+        if (disposed) {
+            return;
+        }
         state.presetsState = readPresetsState(presetsWidget);
         state.editorPresetId = currentPackage(state.presetsState).id;
         resetRootToAuto();
@@ -605,6 +663,10 @@ function buildUi(node, rootWidget, presetsWidget) {
     }
 
     async function refreshInfo() {
+        if (disposed) {
+            return;
+        }
+        const request = requestGate.start();
         const sequence = ++state.refreshSequence;
         try {
             renderPresetButton();
@@ -615,8 +677,8 @@ function buildUi(node, rootWidget, presetsWidget) {
                 model_root: rootWidget?.value || "",
                 presets_state: state.presetsState,
                 package: active,
-            });
-            if (sequence !== state.refreshSequence) {
+            }, { signal: request.signal });
+            if (!request.isCurrent() || sequence !== state.refreshSequence) {
                 return;
             }
             renderRoots(payload);
@@ -626,7 +688,7 @@ function buildUi(node, rootWidget, presetsWidget) {
             setProgress(existing, total);
             setStatus(existing === total ? "All files found. Press R if model lists need refresh." : "Open missing links, then move files to the shown paths.");
         } catch (error) {
-            if (sequence !== state.refreshSequence) {
+            if (!request.isCurrent() || sequence !== state.refreshSequence || error?.name === "AbortError") {
                 return;
             }
             setStatus(error.message || String(error), true);
@@ -692,9 +754,11 @@ function buildUi(node, rootWidget, presetsWidget) {
         presetMenu.style.display = presetMenu.style.display === "none" ? "block" : "none";
     });
     addPresetButton.addEventListener("click", openNewPresetEditor);
-    document.addEventListener("click", () => {
+    const onDocumentClick = () => {
         presetMenu.style.display = "none";
-    });
+        closeModelPathMenus();
+    };
+    document.addEventListener("click", onDocumentClick);
     editButton.addEventListener("click", () => {
         state.editorPresetId = currentPackage(state.presetsState).id;
         setEditingMode(!state.editing);
@@ -703,10 +767,23 @@ function buildUi(node, rootWidget, presetsWidget) {
     renderPresetButton();
     editor.load(currentPackage(state.presetsState));
     setEditingMode(false);
-    return { root, refreshInfo, computeSize, applyNodeSize, reloadFromWidgets };
+    function dispose() {
+        if (disposed) {
+            return;
+        }
+        disposed = true;
+        state.refreshSequence += 1;
+        requestGate.dispose();
+        document.removeEventListener("click", onDocumentClick);
+        editor.dispose?.();
+    }
+
+    return { root, refreshInfo, computeSize, applyNodeSize, reloadFromWidgets, dispose };
 }
 
 function buildEditor(readPackage, getModelSubdirs, resolveCivitaiUrl, onSave, onLayoutChange) {
+    let disposed = false;
+    let layoutFrame = 0;
     const root = document.createElement("div");
     root.style.cssText = `
         display:flex;
@@ -732,7 +809,17 @@ function buildEditor(readPackage, getModelSubdirs, resolveCivitaiUrl, onSave, on
 
     const rows = document.createElement("div");
     rows.style.cssText = "display:flex; flex-direction:column; gap:9px;";
-    const scheduleLayout = () => requestAnimationFrame(() => onLayoutChange?.(rows.children.length));
+    const scheduleLayout = () => {
+        if (disposed || layoutFrame) {
+            return;
+        }
+        layoutFrame = requestAnimationFrame(() => {
+            layoutFrame = 0;
+            if (!disposed) {
+                onLayoutChange?.(rows.children.length);
+            }
+        });
+    };
     root.addEventListener("deno-layout-change", scheduleLayout);
     const observer = new MutationObserver(scheduleLayout);
     observer.observe(rows, { childList: true });
@@ -747,9 +834,19 @@ function buildEditor(readPackage, getModelSubdirs, resolveCivitaiUrl, onSave, on
 
     root.append(guide, sectionTitle, titleInput.root, fileSectionTitle, rows, actions);
 
+    function disposeRows() {
+        for (const row of [...rows.children]) {
+            row.__denoDispose?.();
+        }
+    }
+
     function load(packageValue = readPackage()) {
+        if (disposed) {
+            return;
+        }
         const packageData = normalizePackage(packageValue);
         titleInput.input.value = packageData.title;
+        disposeRows();
         rows.replaceChildren();
         const files = packageData.files.length ? packageData.files : [{ url: "", target_subdir: "checkpoints", filename: "", size: 0 }];
         for (const file of files) {
@@ -774,6 +871,9 @@ function buildEditor(readPackage, getModelSubdirs, resolveCivitaiUrl, onSave, on
     }
 
     addButton.addEventListener("click", () => {
+        if (disposed) {
+            return;
+        }
         rows.append(createFileEditorRow({ url: "", target_subdir: "checkpoints", filename: "", size: 0 }, rows.children.length + 1, getModelSubdirs(), resolveCivitaiUrl));
         renumberRows(rows);
         scheduleLayout();
@@ -781,7 +881,20 @@ function buildEditor(readPackage, getModelSubdirs, resolveCivitaiUrl, onSave, on
     saveButton.addEventListener("click", () => onSave(collect()));
 
     load();
-    return { root, load };
+    function dispose() {
+        if (disposed) {
+            return;
+        }
+        disposed = true;
+        root.removeEventListener("deno-layout-change", scheduleLayout);
+        observer.disconnect();
+        if (layoutFrame) {
+            cancelAnimationFrame(layoutFrame);
+            layoutFrame = 0;
+        }
+        disposeRows();
+    }
+    return { root, load, dispose };
 }
 
 function buildExampleGuide(onUseExample) {
@@ -835,6 +948,8 @@ function buildExampleGuide(onUseExample) {
 }
 
 function createFileEditorRow(file, index, modelSubdirs = [], resolveCivitaiUrl = null) {
+    let disposed = false;
+    const resetTimers = new Set();
     const row = document.createElement("div");
     row.style.cssText = `
         display:flex;
@@ -855,6 +970,7 @@ function createFileEditorRow(file, index, modelSubdirs = [], resolveCivitaiUrl =
     const remove = createMiniButton("Remove");
     remove.onclick = () => {
         const parent = row.parentElement;
+        row.__denoDispose?.();
         row.remove();
         if (parent) {
             renumberRows(parent);
@@ -907,19 +1023,31 @@ function createFileEditorRow(file, index, modelSubdirs = [], resolveCivitaiUrl =
     const civitaiButton = createMiniButton("Civitai");
     civitaiButton.title = "Convert a Civitai page or download URL into a direct browser download link.";
     civitaiButton.onclick = async () => {
+        if (disposed) {
+            return;
+        }
         if (!resolveCivitaiUrl) {
             return;
         }
         const rawUrl = url.input.value.trim();
         if (!rawUrl) {
             civitaiButton.textContent = "No URL";
-            setTimeout(() => { civitaiButton.textContent = "Civitai"; }, 900);
+            const timer = setTimeout(() => {
+                resetTimers.delete(timer);
+                if (!disposed) {
+                    civitaiButton.textContent = "Civitai";
+                }
+            }, 900);
+            resetTimers.add(timer);
             return;
         }
         civitaiButton.disabled = true;
         civitaiButton.textContent = "...";
         try {
             const result = await resolveCivitaiUrl(rawUrl);
+            if (disposed || !row.isConnected) {
+                return;
+            }
             if (result.download_url) {
                 url.input.value = result.download_url;
             }
@@ -935,19 +1063,39 @@ function createFileEditorRow(file, index, modelSubdirs = [], resolveCivitaiUrl =
             }
             civitaiButton.textContent = result.filename ? "Done" : "Link";
         } catch (error) {
+            if (disposed) {
+                return;
+            }
             console.warn("[DENO] Civitai link conversion failed:", error);
             civitaiButton.textContent = "Fail";
         } finally {
-            setTimeout(() => {
-                civitaiButton.disabled = false;
-                civitaiButton.textContent = "Civitai";
-            }, 900);
+            if (!disposed) {
+                const timer = setTimeout(() => {
+                    resetTimers.delete(timer);
+                    if (!disposed) {
+                        civitaiButton.disabled = false;
+                        civitaiButton.textContent = "Civitai";
+                    }
+                }, 900);
+                resetTimers.add(timer);
+            }
         }
     };
     urlRow.append(url.root, civitaiButton);
 
     pathGrid.append(targetSubdir.root, filename.root);
     row.append(header, urlRow, pathGrid, sizeInput);
+    row.__denoDispose = () => {
+        if (disposed) {
+            return;
+        }
+        disposed = true;
+        for (const timer of resetTimers) {
+            clearTimeout(timer);
+        }
+        resetTimers.clear();
+        civitaiButton.disabled = false;
+    };
     return row;
 }
 
@@ -1059,10 +1207,6 @@ function createModelPathField(value, modelSubdirs = []) {
     customInput.addEventListener("input", () => {
         valueInput.value = "";
     });
-    document.addEventListener("click", () => {
-        menu.style.display = "none";
-    });
-
     root.append(label, button, menu, valueInput, customInput);
     return { root, input: valueInput };
 }
@@ -1491,4 +1635,10 @@ async function copyText(text) {
     textarea.select();
     document.execCommand("copy");
     textarea.remove();
+}
+
+if (typeof window !== "undefined" && typeof window.__DENO_LTX_MODEL_DOWNLOADER_TEST_HOOK__ === "function") {
+    window.__DENO_LTX_MODEL_DOWNLOADER_TEST_HOOK__({
+        createLatestRequestGate,
+    });
 }

--- a/web/js/deno_ltx_multi_lora.js
+++ b/web/js/deno_ltx_multi_lora.js
@@ -46,6 +46,7 @@ app.registerExtension({
         const onNodeCreated = nodeType.prototype.onNodeCreated;
         nodeType.prototype.onNodeCreated = function () {
             const result = onNodeCreated?.apply(this, arguments);
+            this.__denoLtxMultiLoraRemoved = false;
             setupNode(this);
             return result;
         };
@@ -53,7 +54,11 @@ app.registerExtension({
         const onConfigure = nodeType.prototype.onConfigure;
         nodeType.prototype.onConfigure = function () {
             const result = onConfigure?.apply(this, arguments);
+            this.__denoLtxMultiLoraRemoved = false;
             queueMicrotask(() => {
+                if (this.__denoLtxMultiLoraRemoved) {
+                    return;
+                }
                 setupNode(this);
                 if (this.__denoLtxMultiLoraConfiguredWidgetValues) {
                     applyLtxMultiLoraSerializedValuesToWidgets(this, this.__denoLtxMultiLoraConfiguredWidgetValues);
@@ -64,6 +69,15 @@ app.registerExtension({
                 }
             });
             return result;
+        };
+
+        const onRemoved = nodeType.prototype.onRemoved;
+        nodeType.prototype.onRemoved = function () {
+            this.__denoLtxMultiLoraRemoved = true;
+            this.__denoLtxMultiLoraChooserGeneration =
+                Number(this.__denoLtxMultiLoraChooserGeneration || 0) + 1;
+            closeOwnedLtxMultiLoraUi(this);
+            return onRemoved?.apply(this, arguments);
         };
     },
 });
@@ -728,21 +742,34 @@ class DenoAddLoraWidget extends DenoBaseWidget {
 }
 
 async function showLoraChooser(event, node, index) {
+    const generation = Number(node.__denoLtxMultiLoraChooserGeneration || 0) + 1;
+    node.__denoLtxMultiLoraChooserGeneration = generation;
     const values = await loraOptions(node);
-    new LiteGraph.ContextMenu(values.map((value) => displayLora(value)), {
+    if (node.__denoLtxMultiLoraRemoved || generation !== node.__denoLtxMultiLoraChooserGeneration) {
+        return;
+    }
+    closeOwnedLtxMultiLoraContextMenu(node);
+    const menu = new LiteGraph.ContextMenu(values.map((value) => displayLora(value)), {
         event,
         title: "Choose a LoRA",
         className: "dark",
         scale: Math.max(1, app.canvas?.ds?.scale ?? 1),
         callback: (value) => {
+            if (node.__denoLtxMultiLoraRemoved || generation !== node.__denoLtxMultiLoraChooserGeneration) {
+                return;
+            }
             const selected = String(value?.content ?? value?.value ?? value);
             setValue(node, `lora_${index}`, selected === "None" ? NONE_VALUE : selected);
             redraw(node);
         },
     });
+    node.__denoLtxMultiLoraContextMenu = menu;
 }
 
 function showRemoveLoraMenu(event, node, index) {
+    if (node.__denoLtxMultiLoraRemoved) {
+        return;
+    }
     const count = activeCount(node);
     const enabled = getValue(node, `enabled_${index}`, true);
     const menuItems = [
@@ -767,7 +794,8 @@ function showRemoveLoraMenu(event, node, index) {
         },
     ];
 
-    new LiteGraph.ContextMenu(menuItems, {
+    closeOwnedLtxMultiLoraContextMenu(node);
+    node.__denoLtxMultiLoraContextMenu = new LiteGraph.ContextMenu(menuItems, {
         event,
         title: `LoRA Slot ${index}`,
         className: "dark",
@@ -1288,7 +1316,11 @@ function drawIconButton(ctx, x, y, kind, active) {
 }
 
 function openLoraInfoEditor(node, index) {
+    if (node.__denoLtxMultiLoraRemoved) {
+        return;
+    }
     ensureLoraInfoStyles();
+    node.__denoLtxMultiLoraInfoClose?.();
     const overlay = document.createElement("div");
     overlay.className = "deno-ltx-lora-info-overlay";
     const loraName = displayLora(getValue(node, `lora_${index}`, NONE_VALUE));
@@ -1322,7 +1354,18 @@ function openLoraInfoEditor(node, index) {
     triggerInput.value = String(getValue(node, `trigger_${index}`, "") || "");
     descriptionInput.value = String(getValue(node, `description_${index}`, "") || "");
 
-    const close = () => overlay.remove();
+    let closed = false;
+    const close = () => {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        overlay.remove();
+        if (node.__denoLtxMultiLoraInfoClose === close) {
+            node.__denoLtxMultiLoraInfoClose = null;
+        }
+    };
+    node.__denoLtxMultiLoraInfoClose = close;
     const save = () => {
         setValue(node, `trigger_${index}`, triggerInput.value.trim());
         setValue(node, `description_${index}`, descriptionInput.value.trim());
@@ -1358,7 +1401,26 @@ function openLoraInfoEditor(node, index) {
     });
 
     document.body.appendChild(overlay);
-    queueMicrotask(() => triggerInput.focus());
+    queueMicrotask(() => {
+        if (!closed && overlay.isConnected) {
+            triggerInput.focus();
+        }
+    });
+}
+
+function closeOwnedLtxMultiLoraContextMenu(node) {
+    const menu = node?.__denoLtxMultiLoraContextMenu;
+    node.__denoLtxMultiLoraContextMenu = null;
+    try { menu?.close?.(); } catch (_error) {}
+    try { menu?.root?.remove?.(); } catch (_error) {}
+}
+
+function closeOwnedLtxMultiLoraUi(node) {
+    closeOwnedLtxMultiLoraContextMenu(node);
+    node?.__denoLtxMultiLoraInfoClose?.();
+    if (node) {
+        node.__denoLtxMultiLoraInfoClose = null;
+    }
 }
 
 function copyText(text) {

--- a/web/js/deno_ltx_tiled_sampler_compat.js
+++ b/web/js/deno_ltx_tiled_sampler_compat.js
@@ -1,0 +1,76 @@
+import { app } from "../../scripts/app.js";
+
+const NODE_NAME = "DenoLTXAVStepFusedTiledSampler";
+const LEGACY_COMPAT_WIDGET = "_deno_legacy_video_compat";
+
+function ensureLegacyCompatibilityMarker(node) {
+    if (!node || node.type !== NODE_NAME) {
+        return null;
+    }
+
+    let widget = (node.widgets || []).find((candidate) => candidate?.name === LEGACY_COMPAT_WIDGET);
+    if (!widget && typeof node.addWidget === "function") {
+        widget = node.addWidget(
+            "toggle",
+            LEGACY_COMPAT_WIDGET,
+            false,
+            (value) => {
+                widget.value = value === true;
+            },
+            { serialize: true },
+        );
+    }
+    if (!widget) {
+        return null;
+    }
+
+    widget.value = widget.value === true;
+    widget.hidden = true;
+    widget.type = "hidden";
+    widget.options = { ...(widget.options || {}), serialize: true };
+    widget.computeSize = () => [0, -4];
+    widget.serializeValue = () => widget.value === true;
+    if (widget.element) {
+        widget.element.style.display = "none";
+    }
+    return widget;
+}
+
+app.registerExtension({
+    name: "Deno.LTX.TiledSamplerSavedWorkflowCompatibility",
+
+    beforeRegisterNodeDef(nodeType, nodeData) {
+        if (nodeData?.name !== NODE_NAME) {
+            return;
+        }
+
+        const previousOnNodeCreated = nodeType.prototype.onNodeCreated;
+        nodeType.prototype.onNodeCreated = function (...args) {
+            const result = previousOnNodeCreated?.apply(this, args);
+            ensureLegacyCompatibilityMarker(this);
+            return result;
+        };
+
+        const previousOnConfigure = nodeType.prototype.onConfigure;
+        nodeType.prototype.onConfigure = function (...args) {
+            const result = previousOnConfigure?.apply(this, args);
+            ensureLegacyCompatibilityMarker(this);
+            return result;
+        };
+    },
+
+    nodeCreated(node) {
+        ensureLegacyCompatibilityMarker(node);
+    },
+});
+
+if (
+    typeof globalThis !== "undefined" &&
+    typeof globalThis.__DENO_LTX_TILED_COMPAT_TEST_HOOK__ === "function"
+) {
+    globalThis.__DENO_LTX_TILED_COMPAT_TEST_HOOK__({
+        ensureLegacyCompatibilityMarker,
+        LEGACY_COMPAT_WIDGET,
+        NODE_NAME,
+    });
+}

--- a/web/js/deno_multi_lora.js
+++ b/web/js/deno_multi_lora.js
@@ -46,6 +46,7 @@ app.registerExtension({
         const onNodeCreated = nodeType.prototype.onNodeCreated;
         nodeType.prototype.onNodeCreated = function () {
             const result = onNodeCreated?.apply(this, arguments);
+            this.__denoMultiLoraRemoved = false;
             setupNode(this);
             return result;
         };
@@ -53,7 +54,11 @@ app.registerExtension({
         const onConfigure = nodeType.prototype.onConfigure;
         nodeType.prototype.onConfigure = function () {
             const result = onConfigure?.apply(this, arguments);
+            this.__denoMultiLoraRemoved = false;
             queueMicrotask(() => {
+                if (this.__denoMultiLoraRemoved) {
+                    return;
+                }
                 setupNode(this);
                 if (this.__denoMultiLoraConfiguredWidgetValues) {
                     applyMultiLoraSerializedValuesToWidgets(this, this.__denoMultiLoraConfiguredWidgetValues);
@@ -64,6 +69,15 @@ app.registerExtension({
                 }
             });
             return result;
+        };
+
+        const onRemoved = nodeType.prototype.onRemoved;
+        nodeType.prototype.onRemoved = function () {
+            this.__denoMultiLoraRemoved = true;
+            this.__denoMultiLoraChooserGeneration =
+                Number(this.__denoMultiLoraChooserGeneration || 0) + 1;
+            closeOwnedMultiLoraUi(this);
+            return onRemoved?.apply(this, arguments);
         };
     },
 });
@@ -706,21 +720,34 @@ class DenoAddLoraWidget extends DenoBaseWidget {
 }
 
 async function showLoraChooser(event, node, index) {
+    const generation = Number(node.__denoMultiLoraChooserGeneration || 0) + 1;
+    node.__denoMultiLoraChooserGeneration = generation;
     const values = await loraOptions(node);
-    new LiteGraph.ContextMenu(values.map((value) => displayLora(value)), {
+    if (node.__denoMultiLoraRemoved || generation !== node.__denoMultiLoraChooserGeneration) {
+        return;
+    }
+    closeOwnedMultiLoraContextMenu(node);
+    const menu = new LiteGraph.ContextMenu(values.map((value) => displayLora(value)), {
         event,
         title: "Choose a LoRA",
         className: "dark",
         scale: Math.max(1, app.canvas?.ds?.scale ?? 1),
         callback: (value) => {
+            if (node.__denoMultiLoraRemoved || generation !== node.__denoMultiLoraChooserGeneration) {
+                return;
+            }
             const selected = String(value?.content ?? value?.value ?? value);
             setValue(node, `lora_${index}`, selected === "None" ? NONE_VALUE : selected);
             redraw(node);
         },
     });
+    node.__denoMultiLoraContextMenu = menu;
 }
 
 function showRemoveLoraMenu(event, node, index) {
+    if (node.__denoMultiLoraRemoved) {
+        return;
+    }
     const count = activeCount(node);
     const enabled = getValue(node, `enabled_${index}`, true);
     const menuItems = [
@@ -745,7 +772,8 @@ function showRemoveLoraMenu(event, node, index) {
         },
     ];
 
-    new LiteGraph.ContextMenu(menuItems, {
+    closeOwnedMultiLoraContextMenu(node);
+    node.__denoMultiLoraContextMenu = new LiteGraph.ContextMenu(menuItems, {
         event,
         title: `LoRA Slot ${index}`,
         className: "dark",
@@ -1269,7 +1297,11 @@ function drawIconButton(ctx, x, y, kind, active) {
 }
 
 function openLoraInfoEditor(node, index) {
+    if (node.__denoMultiLoraRemoved) {
+        return;
+    }
     ensureLoraInfoStyles();
+    node.__denoMultiLoraInfoClose?.();
     const overlay = document.createElement("div");
     overlay.className = "deno-multi-lora-info-overlay";
     const loraName = displayLora(getValue(node, `lora_${index}`, NONE_VALUE));
@@ -1303,7 +1335,18 @@ function openLoraInfoEditor(node, index) {
     triggerInput.value = String(getValue(node, `trigger_${index}`, "") || "");
     descriptionInput.value = String(getValue(node, `description_${index}`, "") || "");
 
-    const close = () => overlay.remove();
+    let closed = false;
+    const close = () => {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        overlay.remove();
+        if (node.__denoMultiLoraInfoClose === close) {
+            node.__denoMultiLoraInfoClose = null;
+        }
+    };
+    node.__denoMultiLoraInfoClose = close;
     const save = () => {
         setValue(node, `trigger_${index}`, triggerInput.value.trim());
         setValue(node, `description_${index}`, descriptionInput.value.trim());
@@ -1339,7 +1382,26 @@ function openLoraInfoEditor(node, index) {
     });
 
     document.body.appendChild(overlay);
-    queueMicrotask(() => triggerInput.focus());
+    queueMicrotask(() => {
+        if (!closed && overlay.isConnected) {
+            triggerInput.focus();
+        }
+    });
+}
+
+function closeOwnedMultiLoraContextMenu(node) {
+    const menu = node?.__denoMultiLoraContextMenu;
+    node.__denoMultiLoraContextMenu = null;
+    try { menu?.close?.(); } catch (_error) {}
+    try { menu?.root?.remove?.(); } catch (_error) {}
+}
+
+function closeOwnedMultiLoraUi(node) {
+    closeOwnedMultiLoraContextMenu(node);
+    node?.__denoMultiLoraInfoClose?.();
+    if (node) {
+        node.__denoMultiLoraInfoClose = null;
+    }
 }
 
 function copyText(text) {

--- a/web/js/deno_node_help.js
+++ b/web/js/deno_node_help.js
@@ -16,10 +16,13 @@ const CHANGELOG_URL = "https://raw.githubusercontent.com/Deno2026/comfyui-deno-c
 const RELEASE_BASE_URL = "https://github.com/Deno2026/comfyui-deno-custom-nodes/releases/tag";
 const VERSION_CACHE_KEY = "denoCustomNodes.versionStatus.v2";
 const VERSION_CACHE_MS = 6 * 60 * 60 * 1000;
+const VERSION_FETCH_TIMEOUT_MS = 8000;
 const MAX_RELEASE_NOTES = 4;
 
 const nodeHelpDescriptions = new Map();
 const popupState = new Map();
+const nodeInstanceKeys = new WeakMap();
+let nodeInstanceKeyCounter = 0;
 let versionStatusPromise = null;
 let canvasHelpCursorTicket = 0;
 let denoVersionStatus = {
@@ -76,7 +79,16 @@ function getNodeClassName(source) {
 }
 
 function getNodeKey(node) {
-    return String(node?.id ?? node?.type ?? node?.comfyClass ?? "");
+    if (node && (typeof node === "object" || typeof node === "function")) {
+        let key = nodeInstanceKeys.get(node);
+        if (!key) {
+            nodeInstanceKeyCounter += 1;
+            key = `deno-help-node-${nodeInstanceKeyCounter}`;
+            nodeInstanceKeys.set(node, key);
+        }
+        return key;
+    }
+    return String(node ?? "");
 }
 
 function getNodeDescription(node) {
@@ -107,6 +119,10 @@ function compareVersions(left, right) {
 
 function normalizeVersion(version) {
     return String(version || "").trim().replace(/^v/i, "");
+}
+
+function isValidVersion(version) {
+    return /^[0-9]+(?:\.[0-9]+){1,3}$/.test(normalizeVersion(version));
 }
 
 function releaseUrl(version) {
@@ -151,7 +167,7 @@ function parseChangelogNotes(markdown, version) {
 
 async function fetchReleaseNotes(version) {
     try {
-        const response = await fetch(`${CHANGELOG_URL}?t=${Date.now()}`, {
+        const response = await fetchWithTimeout(`${CHANGELOG_URL}?t=${Date.now()}`, {
             method: "GET",
             headers: { "Accept": "text/plain" },
             cache: "no-store",
@@ -162,6 +178,16 @@ async function fetchReleaseNotes(version) {
         return parseChangelogNotes(await response.text(), version);
     } catch (_error) {
         return [];
+    }
+}
+
+async function fetchWithTimeout(url, options = {}, timeoutMs = VERSION_FETCH_TIMEOUT_MS) {
+    const controller = new AbortController();
+    const timer = window.setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        return await fetch(url, { ...options, signal: controller.signal });
+    } finally {
+        window.clearTimeout(timer);
     }
 }
 
@@ -176,7 +202,9 @@ function loadCachedVersionStatus(currentVersion) {
     try {
         const cached = JSON.parse(localStorage.getItem(VERSION_CACHE_KEY) || "null");
         if (!cached || cached.current_version !== currentVersion) return null;
-        if ((Date.now() - Number(cached.checked_at || 0)) > VERSION_CACHE_MS) return null;
+        const age = Date.now() - Number(cached.checked_at || 0);
+        if (!Number.isFinite(age) || age < 0 || age > VERSION_CACHE_MS) return null;
+        if (["latest", "update_available"].includes(cached.status) && !isValidVersion(cached.latest_version)) return null;
         return cached;
     } catch (_error) {
         return null;
@@ -212,7 +240,7 @@ async function refreshDenoVersionStatus() {
 
     versionStatusPromise = (async () => {
         try {
-            const response = await fetch(REGISTRY_INSTALL_URL, {
+            const response = await fetchWithTimeout(REGISTRY_INSTALL_URL, {
                 method: "GET",
                 headers: { "Accept": "application/json" },
                 cache: "no-store",
@@ -221,7 +249,10 @@ async function refreshDenoVersionStatus() {
                 throw new Error(`Comfy Registry returned HTTP ${response.status}`);
             }
             const payload = await response.json();
-            const latestVersion = latestVersionFromRegistryPayload(payload) || currentVersion;
+            const latestVersion = latestVersionFromRegistryPayload(payload);
+            if (!isValidVersion(latestVersion)) {
+                throw new Error("Comfy Registry response did not include a valid version.");
+            }
             const updateAvailable = compareVersions(latestVersion, currentVersion) > 0;
             const releaseNotes = updateAvailable ? await fetchReleaseNotes(latestVersion) : [];
             const status = {

--- a/web/js/deno_video_compare.js
+++ b/web/js/deno_video_compare.js
@@ -191,6 +191,9 @@ function getState(node) {
       panStart: null, down: null, raf: 0, dom: null,
       ar: 16 / 9, _fitting: false, _wasPlaying: false, burnLabels: false,
       manualSized: isManualSized(node), resizeTrackingArmed: false,
+      destroyed: false, detached: false, connectedOnce: false, resumeOnAttach: false,
+      beginRun: 0, beginInterval: null, beginTimeout: null,
+      transientCleanups: new Set(), audioController: null,
       // audio (Phase 2): WebAudio fed by raw planar f32 PCM
       actx: null, master: null, gA: null, gB: null,
       bufA: null, bufB: null, srcA: null, srcB: null,
@@ -229,21 +232,112 @@ app.registerExtension({
     };
     const onRemoved = nodeType.prototype.onRemoved;
     nodeType.prototype.onRemoved = function () {
-      const s = this.__dvp;
-      if (s && s.raf) { cancelAnimationFrame(s.raf); s.raf = 0; }
-      if (s) {
-        try { stopAudioSources(this); } catch (e) {}
-        if (s.actx) { try { s.actx.close(); } catch (e) {} s.actx = null; }
-        if (s.cache) s.cache.clear();
-        if (s.dom?.onFullscreenChange) {
-          document.removeEventListener("fullscreenchange", s.dom.onFullscreenChange);
-          document.removeEventListener("webkitfullscreenchange", s.dom.onFullscreenChange);
-        }
-      }
+      disposeVideoCompareNode(this);
       return onRemoved?.apply(this, arguments);
     };
   },
 });
+
+function clearPlaybackBeginTimers(state) {
+  if (state.beginInterval != null) {
+    clearInterval(state.beginInterval);
+    state.beginInterval = null;
+  }
+  if (state.beginTimeout != null) {
+    clearTimeout(state.beginTimeout);
+    state.beginTimeout = null;
+  }
+}
+
+function cancelPendingPlaybackBegin(state) {
+  state.beginRun = (state.beginRun || 0) + 1;
+  clearPlaybackBeginTimers(state);
+}
+
+function schedulePlaybackBegin(state, firstFrame, begin) {
+  cancelPendingPlaybackBegin(state);
+  const run = state.beginRun;
+  let begun = false;
+  const finish = () => {
+    if (begun || state.destroyed || run !== state.beginRun) return false;
+    if (begin() === false) return false;
+    begun = true;
+    clearPlaybackBeginTimers(state);
+    return true;
+  };
+  if (!firstFrame || firstFrame.ready) {
+    if (finish()) return finish;
+  }
+  state.beginInterval = setInterval(() => {
+    if (!firstFrame || firstFrame.ready) finish();
+  }, 40);
+  state.beginTimeout = setTimeout(finish, 1500);
+  return finish;
+}
+
+function clearTransientInteractions(state) {
+  for (const cleanup of [...(state.transientCleanups || [])]) {
+    try { cleanup(); } catch (e) {}
+  }
+  state.transientCleanups?.clear();
+}
+
+function closeAudioContext(node, clearBuffers = false) {
+  const state = node.__dvp;
+  if (!state) return;
+  state.audioController?.abort();
+  state.audioController = null;
+  state.audioRun = (state.audioRun || 0) + 1;
+  try { stopAudioSources(node); } catch (e) {}
+  if (state.actx) {
+    try { state.actx.close(); } catch (e) {}
+  }
+  state.actx = null;
+  state.master = null;
+  state.gA = null;
+  state.gB = null;
+  if (clearBuffers) {
+    state.bufA = null;
+    state.bufB = null;
+  }
+}
+
+function stopDetachedVideoCompare(node, state) {
+  state.resumeOnAttach = state.playing;
+  state.detached = true;
+  state.playing = false;
+  cancelPendingPlaybackBegin(state);
+  clearTransientInteractions(state);
+  closeAudioContext(node);
+  if (state.dom?.playBtn) {
+    state.dom.playBtn.textContent = "▶";
+    state.dom.playBtn.classList.remove("on");
+  }
+}
+
+function disposeVideoCompareNode(node) {
+  const state = node.__dvp;
+  if (!state || state.destroyed) return;
+  state.destroyed = true;
+  state.playing = false;
+  cancelPendingPlaybackBegin(state);
+  clearTransientInteractions(state);
+  if (state.raf) {
+    cancelAnimationFrame(state.raf);
+    state.raf = 0;
+  }
+  closeAudioContext(node, true);
+  if (state.cache) {
+    for (const entry of state.cache.values()) {
+      try { entry.img.src = ""; } catch (e) {}
+    }
+    state.cache.clear();
+  }
+  if (state.dom?.onFullscreenChange) {
+    document.removeEventListener("fullscreenchange", state.dom.onFullscreenChange);
+    document.removeEventListener("webkitfullscreenchange", state.dom.onFullscreenChange);
+  }
+}
 
 function applyOutputLabel(node) {
   const o = node && node.outputs && node.outputs[0];
@@ -257,6 +351,8 @@ function setupNode(node) {
   if (!node || node.__dvpSetup) return;
   node.__dvpSetup = true;
   const st = getState(node);
+  st.destroyed = false;
+  st.detached = false;
   st.manualSized = isManualSized(node);
 
   for (const n of HIDDEN_WIDGETS) hideWidget(getWidget(node, n));
@@ -290,8 +386,25 @@ function setupNode(node) {
       return r;
     };
   }
+  if (!node.__dvpDrawWrapped) {
+    node.__dvpDrawWrapped = true;
+    const originalDraw = node.onDrawBackground;
+    node.onDrawBackground = function () {
+      const result = originalDraw?.apply(this, arguments);
+      const state = this.__dvp;
+      if (state && !state.destroyed && state.dom?.root?.isConnected) {
+        const shouldResume = state.detached && state.resumeOnAttach;
+        ensureAnimationLoop(this);
+        if (shouldResume) {
+          state.resumeOnAttach = false;
+          startPlayback(this);
+        }
+      }
+      return result;
+    };
+  }
   queueMicrotask(() => { st.resizeTrackingArmed = true; });
-  if (!st.raf) st.raf = requestAnimationFrame(loopOf(node));
+  ensureAnimationLoop(node);
 }
 
 function buildDom(node) {
@@ -513,13 +626,27 @@ function stepFrame(node, dir) {
   s.t = Math.max(0, Math.min((i + 0.5) / Math.max(1e-6, s.fps), durOf(node)));
   render(node);
 }
+function ensureAnimationLoop(node) {
+  const state = getState(node);
+  if (state.destroyed || state.raf) return;
+  state.detached = false;
+  state.raf = requestAnimationFrame(loopOf(node));
+}
 function loopOf(node) {
   const tick = () => {
     const s = node.__dvp;
-    if (!s) return;
+    if (!s || s.destroyed) return;
     if (!s.dom || !s.dom.root.isConnected) {
-      s.raf = requestAnimationFrame(tick); return;
+      if (s.connectedOnce) {
+        s.raf = 0;
+        stopDetachedVideoCompare(node, s);
+        return;
+      }
+      s.raf = requestAnimationFrame(tick);
+      return;
     }
+    s.connectedOnce = true;
+    s.detached = false;
     if (s.playing && s.frameCount > 0) {
       const dur = durOf(node);
       const t = s.startT + (performance.now() - s.playMs) / 1000 * s.speed;
@@ -531,7 +658,7 @@ function loopOf(node) {
       } else s.t = t;
     }
     render(node);
-    s.raf = requestAnimationFrame(tick);
+    if (!s.destroyed) s.raf = requestAnimationFrame(tick);
   };
   return tick;
 }
@@ -547,6 +674,7 @@ function unlinkAudioNode(source) {
 }
 function ensureCtx(node) {
   const s = getState(node);
+  if (s.destroyed || s.detached) return null;
   if (!s.actx) {
     const AC = window.AudioContext || window.webkitAudioContext;
     if (!AC) return null;
@@ -566,8 +694,8 @@ function markGesture(node) {
   ensureCtx(node);
   applyAudioGains(node);
 }
-async function decodeF32(url, ch, samples, sr, ctx) {
-  const res = await fetch(url);
+async function decodeF32(url, ch, samples, sr, ctx, signal = undefined) {
+  const res = await fetch(url, { signal });
   const pcm = new Float32Array(await res.arrayBuffer());
   const buf = ctx.createBuffer(Math.max(1, ch), Math.max(1, samples), sr || 44100);
   for (let c = 0; c < ch; c++) {
@@ -584,22 +712,35 @@ function audioViewUrl(node, fn) {
 }
 async function loadAudio(node) {
   const s = getState(node);
+  s.audioController?.abort();
+  s.audioController = null;
+  if (s.destroyed || s.detached) return;
+  const controller = new AbortController();
+  s.audioController = controller;
+  const run = ++s.audioRun;
   s.bufA = s.bufB = null;
   s.metaA = (s.metaA && s.metaA.filename) ? s.metaA : null;
   s.metaB = (s.metaB && s.metaB.filename) ? s.metaB : null;
-  if (!s.metaA && !s.metaB) { applyAudioGains(node); return; }
+  if (!s.metaA && !s.metaB) {
+    if (s.audioController === controller) s.audioController = null;
+    applyAudioGains(node);
+    return;
+  }
   const ctx = ensureCtx(node);
-  if (!ctx) return;
-  const run = ++s.audioRun;
+  if (!ctx) {
+    if (s.audioController === controller) s.audioController = null;
+    return;
+  }
   const jobs = [];
   if (s.metaA) jobs.push(decodeF32(audioViewUrl(node, s.metaA.filename),
-    s.metaA.channels, s.metaA.samples, s.metaA.sample_rate, ctx)
-    .then((b) => { if (run === s.audioRun) s.bufA = b; }).catch(() => {}));
+    s.metaA.channels, s.metaA.samples, s.metaA.sample_rate, ctx, controller.signal)
+    .then((b) => { if (run === s.audioRun && !s.destroyed) s.bufA = b; }).catch(() => {}));
   if (s.metaB) jobs.push(decodeF32(audioViewUrl(node, s.metaB.filename),
-    s.metaB.channels, s.metaB.samples, s.metaB.sample_rate, ctx)
-    .then((b) => { if (run === s.audioRun) s.bufB = b; }).catch(() => {}));
+    s.metaB.channels, s.metaB.samples, s.metaB.sample_rate, ctx, controller.signal)
+    .then((b) => { if (run === s.audioRun && !s.destroyed) s.bufB = b; }).catch(() => {}));
   await Promise.all(jobs);
-  if (run !== s.audioRun) return;
+  if (s.audioController === controller) s.audioController = null;
+  if (run !== s.audioRun || controller.signal.aborted || s.destroyed || s.detached) return;
   // default the A/B selector to a side that actually carries sound
   if (s.audio === "A" && !physAudioBuf(node, "A") && physAudioBuf(node, "B")) s.audio = "B";
   else if (s.audio === "B" && !physAudioBuf(node, "B") && physAudioBuf(node, "A")) s.audio = "A";
@@ -818,7 +959,10 @@ function updateLabels(node) {
 function handleExecuted(node, output) {
   setupNode(node);
   const s = getState(node), d = s.dom;
-  if (!d) return;
+  if (!d || s.destroyed) return;
+  cancelPendingPlaybackBegin(s);
+  s.resumeOnAttach = false;
+  ensureAnimationLoop(node);
   const m = Array.isArray(output.deno_video_compare)
     ? (output.deno_video_compare[0] || {}) : {};
   s.filesA = Array.isArray(m.files_a) ? m.files_a : [];
@@ -876,21 +1020,16 @@ function handleExecuted(node, output) {
   // the original waiting on loadedmetadata before playing)
   const refSide = s.haveA ? "a" : (s.haveB ? "b" : null);
   const begin = () => {
-    if (!(s.haveA || s.haveB)) return;
+    if (s.destroyed || s.detached || !d.root.isConnected || !(s.haveA || s.haveB)) return false;
     s.t = 0; s.startT = 0;
     if (s.mode === "Toggle") pausePlayback(node);
     else startPlayback(node);
     render(node);
+    return true;
   };
   if (!refSide) { render(node); return; }
   const e0 = getImg(node, refSide, 0);
-  if (e0 && e0.ready) begin();
-  else if (e0) {
-    const wait = setInterval(() => {
-      if (e0.ready) { clearInterval(wait); begin(); }
-    }, 40);
-    setTimeout(() => { clearInterval(wait); begin(); }, 1500);
-  } else begin();
+  schedulePlaybackBegin(s, e0, begin);
   render(node);
 }
 
@@ -944,6 +1083,7 @@ function startFullscreenHorizontalPan(node, event) {
   if (s.zoom <= 1 || (!s.haveA && !s.haveB)) return true;
 
   let startX = event.clientX - s.panX;
+  let active = true;
   d.stage.classList.add("grabbing");
 
   const move = (ev) => {
@@ -953,15 +1093,22 @@ function startFullscreenHorizontalPan(node, event) {
     clampPan(node);
     render(node);
   };
-  const done = (ev) => {
-    ev?.preventDefault?.();
-    ev?.stopPropagation?.();
+  const cleanup = () => {
+    if (!active) return;
+    active = false;
     d.stage.classList.remove("grabbing");
     window.removeEventListener("pointermove", move, true);
     window.removeEventListener("pointerup", done, true);
     window.removeEventListener("pointercancel", done, true);
+    s.transientCleanups.delete(cleanup);
+  };
+  const done = (ev) => {
+    ev?.preventDefault?.();
+    ev?.stopPropagation?.();
+    cleanup();
   };
 
+  s.transientCleanups.add(cleanup);
   window.addEventListener("pointermove", move, true);
   window.addEventListener("pointerup", done, true);
   window.addEventListener("pointercancel", done, true);
@@ -1055,6 +1202,7 @@ function wireInteractions(node, d, btns) {
     const cv = app.canvas;
     if (!cv || !cv.ds || !cv.ds.offset) return;
     let lx = e.clientX, ly = e.clientY;
+    let active = true;
     const mv = (ev) => {
       const sc = cv.ds.scale || 1;
       cv.ds.offset[0] += (ev.clientX - lx) / sc;
@@ -1063,12 +1211,19 @@ function wireInteractions(node, d, btns) {
       (cv.setDirty ? cv.setDirty(true, true)
         : app.graph?.setDirtyCanvas(true, true));
     };
-    const up = () => {
+    const cleanup = () => {
+      if (!active) return;
+      active = false;
       window.removeEventListener("pointermove", mv, true);
       window.removeEventListener("pointerup", up, true);
+      window.removeEventListener("pointercancel", up, true);
+      s.transientCleanups.delete(cleanup);
     };
+    const up = () => cleanup();
+    s.transientCleanups.add(cleanup);
     window.addEventListener("pointermove", mv, true);
     window.addEventListener("pointerup", up, true);
+    window.addEventListener("pointercancel", up, true);
   }, true);
   d.root.addEventListener("auxclick", (e) => {
     if (e.button !== 1 || !isFullscreenRoot(d.root)) return;
@@ -1159,4 +1314,11 @@ function scrubTo(node, clientX) {
   const r = s.dom.scrub.getBoundingClientRect();
   const ratio = Math.max(0, Math.min(1, (clientX - r.left) / (r.width || 1)));
   seekAll(node, ratio * (getTimeline(node).dur || 0));
+}
+
+if (typeof window !== "undefined" && typeof window.__DENO_VIDEO_COMPARE_TEST_HOOK__ === "function") {
+  window.__DENO_VIDEO_COMPARE_TEST_HOOK__({
+    cancelPendingPlaybackBegin,
+    schedulePlaybackBegin,
+  });
 }

--- a/web/js/deno_video_preview.js
+++ b/web/js/deno_video_preview.js
@@ -48,6 +48,7 @@ function ensureStyles() {
 }
 
 function installMiddleMouseCanvasPan(root) {
+  let activePanCleanup = null;
   root.addEventListener("pointerdown", (e) => {
     if (e.button !== 1) return;
     const canvas = app.canvas;
@@ -58,11 +59,15 @@ function installMiddleMouseCanvasPan(root) {
 
     let lastX = e.clientX;
     let lastY = e.clientY;
+    let active = true;
 
     const cleanup = () => {
+      if (!active) return;
+      active = false;
       window.removeEventListener("pointermove", move, true);
       window.removeEventListener("pointerup", done, true);
       window.removeEventListener("pointercancel", done, true);
+      if (activePanCleanup === cleanup) activePanCleanup = null;
     };
     const move = (ev) => {
       ev.preventDefault();
@@ -83,6 +88,8 @@ function installMiddleMouseCanvasPan(root) {
       cleanup();
     };
 
+    activePanCleanup?.();
+    activePanCleanup = cleanup;
     window.addEventListener("pointermove", move, true);
     window.addEventListener("pointerup", done, true);
     window.addEventListener("pointercancel", done, true);
@@ -93,6 +100,11 @@ function installMiddleMouseCanvasPan(root) {
     e.preventDefault();
     e.stopPropagation();
   }, true);
+
+  return () => {
+    activePanCleanup?.();
+    activePanCleanup = null;
+  };
 }
 
 function ensureProperties(node) {
@@ -383,7 +395,7 @@ function buildDom(node) {
       bubbles: true, cancelable: true,
     }));
   }, { passive: false });
-  installMiddleMouseCanvasPan(root);
+  state.panCleanup = installMiddleMouseCanvasPan(root);
 
   return state;
 }
@@ -464,6 +476,8 @@ app.registerExtension({
     const onRemoved = nodeType.prototype.onRemoved;
     nodeType.prototype.onRemoved = function () {
       const s = this.__dvprev;
+      s?.panCleanup?.();
+      if (s) s.panCleanup = null;
       if (s?.video) {
         try { s.video.pause(); } catch (e) {}
         s.video.removeAttribute("src");


### PR DESCRIPTION
## What changed

- Hardened cache, path, preview-file, and frontend lifecycle handling across the existing public nodes.
- Fixed Local LLM cleanup, action races, reviewer verdict parsing, and workflow-scoped reviewer snapshots.
- Preserved retired LTX video-only sampler workflows through ComfyUI's native node-replacement path without re-exposing the retired node.
- Fixed unequal-length Video Compare alignment, inactive LoRA validation, Bernini option validation, LTX no-op identity, and RTX all-off passthrough behavior.
- Updated the package version and public changelog to 0.7.69.

## Why

Several existing paths could fail under malformed cache data, overlapping asynchronous actions, missing local resources, parallel preview writes, or older saved workflows. These changes repair those defects while preserving the current controls, normal-path outputs, and saved-workflow values.

## Validation

- Full GitHub Actions-shaped test suite: 385 passed.
- Changed JavaScript and harness files: 18/18 passed `node --check`.
- Public node metadata: 21 intended nodes; the retired LTX node remains absent.
- Main Easy-Install runtime: object metadata, native LTX replacement, visible widget values, save/reopen, and prompt serialization verified.

Separate Official Portable, Official Desktop, EZi Desktop WebView, live provider streaming, and GPU model execution were not part of this validation pass.