### PR TITLE
fix(deno-video-compare): clamp split_position drag value to declared widget range

### DIFF
--- a/web/js/deno_video_compare.js
+++ b/web/js/deno_video_compare.js
@@ -1039,7 +1039,11 @@ function frameFrac(node, clientX) {
   const r = s.dom.stage.getBoundingClientRect();
   const W = r.width || 1, cx = W / 2;
   const p = cx + (((clientX - r.left) - cx - s.panX) / s.zoom);
-  return Math.max(0, Math.min(1, p / W));
+  // Clamp to the backend's declared split_position range (0.02-0.98), not
+  // the raw 0-1 pixel fraction — dragging to the stage edge could write an
+  // out-of-range value (e.g. 0.993) that the backend FLOAT widget rejects,
+  // silently dropping the queued prompt.
+  return clamp(p / W, 0.02, 0.98, 0.5);
 }
 function clampPan(node) {
   const s = getState(node);


### PR DESCRIPTION
## Summary
- `DenoVideoCompare`'s slider drag wrote an unclamped `split_position` (e.g. `0.993` at the stage edge), but the backend widget declares `min=0.02`/`max=0.98`, so the queued prompt failed validation and the output was silently dropped.
- `split_position` is a hidden widget with no visible UI control, and a failed prompt means the node never executes — so the preview never renders either, leaving no divider to drag a correction with. A saved workflow with an out-of-range value had no way to recover from the UI.
- Fixed by clamping in `frameFrac()` to the backend's declared `0.02–0.98` range instead of the raw `0–1` pixel fraction, which covers all three call sites that write `split_position` from a drag.
- `deno_image_compare.js` already clamps correctly (both on drag and on load) — no change needed there.

## Test plan
- [x] `node --check web/js/deno_video_compare.js` — syntax OK
- [x] Confirmed `split_position` range (`0.02`–`0.98`) is declared identically in `deno_video_compare.py` and `deno_image_compare.py`
- [x] Confirmed `deno_image_compare.js`'s existing clamp logic as the reference behavior this brings `deno_video_compare.js` in line with

🤖 Generated with [Claude Code](https://claude.com/claude-code)