### PR TITLE
v0.7.73: restore Resize Box input ratio preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file intentionally stays short. Detailed engineering notes belong in privat
 
 ## Unreleased
 
+## 0.7.73 - 2026-08-03
+
+- Fixed `(Deno) Resize Box` Keep Input Ratio live preview after ComfyUI changed newly created canvas node IDs to strings, while preserving numeric-ID workflows and backend sizing behavior.
+
 ## 0.7.72 - 2026-07-25
 
 - Added per-element enable/disable controls and optional connected Summary/Background overrides to `(Deno) Ideogram Director` while preserving saved element order, values, and disconnected board behavior.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "deno-custom-nodes"
 description = "DENO RTX node pack for ComfyUI: Ideogram Director visual JSON/bbox prompt builder, Local LLM Loader and Reviewer helpers, GPT/Gemini-ready Error Help reports, Prompt Only final prompt extraction, RTX Video Super Resolution, RTX Super Resolution, Video SR/VSR, NVIDIA VFX/nvvfx, RTX upscale helpers, LTX 2.3 workflows, LTX tiled second-pass refinement helpers, Bernini Prompt Guide, audio/image review gates, Bernini conditioning helpers, Wan 2.2 reference video edit workflows, image and video compare, video preview, Video to GIF/WebP tools, multi-image loading, resize tools, LoRA/model helpers, prompt guides, and visual workflow utilities."
-version = "0.7.72"
+version = "0.7.73"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = []

--- a/tests/js/resize_box_display_harness.mjs
+++ b/tests/js/resize_box_display_harness.mjs
@@ -38,7 +38,7 @@ vm.runInNewContext(source, context, { filename: scriptPath });
 
 assert.ok(hooks, "Resize Box frontend did not expose test hooks");
 
-function makeNode({ connected = false, width = 1001, height = 777 } = {}) {
+function makeNode({ connected = false, linkId = 99, width = 1001, height = 777 } = {}) {
   const values = {
     mode: "Keep Input Ratio",
     width,
@@ -48,7 +48,7 @@ function makeNode({ connected = false, width = 1001, height = 777 } = {}) {
     divisible_by: 32,
   };
   return {
-    inputs: [{ name: "image", link: connected ? 99 : null }],
+    inputs: [{ name: "image", link: connected ? linkId : null }],
     widgets: Object.entries(values).map(([name, value]) => ({ name, value })),
   };
 }
@@ -86,6 +86,25 @@ assert.deepEqual([knownInfo.previewWidth, knownInfo.previewHeight], Array.from(e
 assert.match(knownInfo.text, new RegExp(`^${knownInfo.width} x ${knownInfo.height}\\b`));
 assert.doesNotMatch(knownInfo.text, /Input-dependent/);
 assert.equal(JSON.stringify(known.widgets), knownBefore);
+
+const stringSourceId = "string-source-id";
+graph.nodes.set(stringSourceId, { id: stringSourceId, imgs: [{ naturalWidth: 1080, naturalHeight: 1920 }] });
+graph.links[100] = { origin_id: stringSourceId };
+const knownStringId = makeNode({ connected: true, linkId: 100 });
+const knownStringIdBefore = JSON.stringify(knownStringId.widgets);
+const expectedKnownStringId = hooks.computeKeepInputRatioDims(1080, 1920, 1, 32);
+const knownStringIdInfo = hooks.calculateDisplayInfo(knownStringId);
+assert.deepEqual(
+  [knownStringIdInfo.width, knownStringIdInfo.height],
+  Array.from(expectedKnownStringId),
+  "ComfyUI string node IDs must resolve the linked image size",
+);
+assert.deepEqual(
+  [knownStringIdInfo.previewWidth, knownStringIdInfo.previewHeight],
+  Array.from(expectedKnownStringId),
+);
+assert.doesNotMatch(knownStringIdInfo.text, /Input-dependent/);
+assert.equal(JSON.stringify(knownStringId.widgets), knownStringIdBefore);
 
 graph.nodes.set(7, { id: 7 });
 const unknown = makeNode({ connected: true });

--- a/web/js/deno_res_helper.js
+++ b/web/js/deno_res_helper.js
@@ -663,7 +663,7 @@ function getLinkedImageState(node) {
     }
 
     const linkInfo = app.graph?.links?.[imageInput.link];
-    if (!linkInfo || !Number.isFinite(linkInfo.origin_id)) {
+    if (!linkInfo || linkInfo.origin_id == null) {
         return { connected: true, size: null };
     }
 


### PR DESCRIPTION
## What changed

- let `(Deno) Resize Box` follow linked image previews when recent ComfyUI frontends use string node IDs
- keep numeric-ID workflows and backend sizing behavior unchanged
- add a frontend regression case for an opaque string source ID
- bump the release version to `0.7.73`

## Verification

- focused Resize Box tests: `159 passed`
- full Python suite: `403 passed`
- Resize Box frontend harness, frontend syntax check, and LTX input-slot harness passed
- real canvas: ComfyUI `0.29.0`, frontend `1.47.10`, string node/link IDs confirmed
- live preview followed `2016x1088` landscape and `1088x2016` portrait inputs
- disconnect/reconnect and save/reopen restored the expected preview
- expected Registry manifest remains the same 407 files as `v0.7.72`