### PR TITLE
v0.7.77: durable Local LLM presets and res_2s audio freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This file intentionally stays short. Detailed engineering notes belong in privat
 
 ## Unreleased
 
+## 0.7.77 - 2026-08-06
+
+- Added durable per-user system-prompt presets to `(Deno) Local LLM Loader`, including a one-time browser-preset import when legacy presets are detected. Fixes #54.
+- Kept frozen audio exact in both outputs of `(Deno) LTX High resolution Tiled Sampler` when external samplers such as RES4LYF `res_2s` introduce finite internal audio drift, while retaining structural and non-finite-value validation. Fixes #55.
+
 ## 0.7.76 - 2026-08-06
 
 - Added aspect-ratio-locked zoom cropping to `(Deno) Resize Box`: drag the crop area to reposition it or drag any corner to zoom while keeping the selected output megapixels and dimensions fixed. Crop position and zoom persist with the workflow.

--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ Main features:
 - connect prompt batches through one node run so the local model can stay loaded until the batch finishes
 - optionally attach an IMAGE to a vision-capable local model call
 - preview Thinking and Result text directly on the node
+- keep named System Prompt presets in ComfyUI user data so they survive browser-profile cleanup; existing browser presets can be imported once while the browser copy stays untouched as a backup
 - use `(Deno) Local LLM Reviewer` as a gate before Save nodes
 - pass or block IMAGE and AUDIO outputs from a review text result
 - approve the current reviewed result once, or rerun the path before the reviewer

--- a/deno_ltx_tiled_nodes.py
+++ b/deno_ltx_tiled_nodes.py
@@ -676,25 +676,9 @@ def _validate_unpacked_shapes(
             )
 
 
-def _assert_same_tensor(
-    actual: torch.Tensor,
-    expected: torch.Tensor,
-    label: str,
-    *,
-    rtol: float = 1e-5,
-    atol: float = 1e-6,
-) -> None:
-    comparable = actual.to(device=expected.device, dtype=expected.dtype)
-    if tuple(comparable.shape) != tuple(expected.shape) or not torch.allclose(
-        comparable,
-        expected,
-        rtol=rtol,
-        atol=atol,
-    ):
-        raise RuntimeError(
-            f"{label} changed even though audio_mode='freeze'. An incompatible "
-            "wrapper or sampler path may have bypassed the audio denoise mask."
-        )
+def _require_finite_tensor(value: torch.Tensor, label: str) -> None:
+    if not bool(torch.isfinite(value).all().item()):
+        raise RuntimeError(f"{label} contains non-finite values.")
 
 
 def _wrapper_key_name(key: Any) -> str:
@@ -1741,6 +1725,7 @@ class DenoLTXAVStepFusedTiledSampler:
 
         latent = latent_image.copy()
         video, audio = self._validate_av_samples(latent["samples"])
+        _require_finite_tensor(audio, "AV input audio")
         video = self._fix_video_channels(guider, latent, video)
         source = _make_nested_latent([video, audio])
         latent["samples"] = source
@@ -1801,9 +1786,7 @@ class DenoLTXAVStepFusedTiledSampler:
             expected_video_shape=video.shape,
             expected_audio_shape=audio.shape,
         )
-        terminal_sigma = float(sigmas[-1].detach().flatten()[0].cpu())
-        if math.isclose(terminal_sigma, 0.0, abs_tol=1e-8):
-            _assert_same_tensor(audio_out, audio, "AV sampler output audio")
+        _require_finite_tensor(audio_out, "AV sampler output audio")
 
         if predictor.call_count == 0:
             raise RuntimeError(
@@ -1842,7 +1825,7 @@ class DenoLTXAVStepFusedTiledSampler:
             _validate_packed_latent_shape(processed_x0, latent_shapes, "AV x0")
             x0_parts = _unpack_latents(processed_x0, latent_shapes)
         _validate_unpacked_shapes(x0_parts, latent_shapes, "AV x0")
-        _assert_same_tensor(x0_parts[1], audio, "AV x0 audio")
+        _require_finite_tensor(x0_parts[1], "AV x0 audio")
 
         denoised = latent.copy()
         denoised.pop("downscale_ratio_spacial", None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "deno-custom-nodes"
 description = "DENO RTX node pack for ComfyUI: MiniMax H3 multi-reference image and Reference to Video helpers, Ideogram Director visual JSON/bbox prompt builder, Local LLM Loader and Reviewer helpers, GPT/Gemini-ready Error Help reports, Prompt Only final prompt extraction, RTX Video Super Resolution, RTX Super Resolution, Video SR/VSR, NVIDIA VFX/nvvfx, RTX upscale helpers, LTX 2.3 workflows, LTX tiled second-pass refinement helpers, Bernini Prompt Guide, audio/image review gates, Bernini conditioning helpers, Wan 2.2 reference video edit workflows, image and video compare, video preview, Video to GIF/WebP tools, multi-image loading, resize tools, LoRA/model helpers, prompt guides, and visual workflow utilities."
-version = "0.7.76"
+version = "0.7.77"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = []

--- a/tests/js/local_llm_preset_storage_harness.mjs
+++ b/tests/js/local_llm_preset_storage_harness.mjs
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..", "..");
+const sourcePath = path.join(repoRoot, "web", "js", "deno_local_llm_refiner.js");
+const source = fs
+    .readFileSync(sourcePath, "utf8")
+    .replace(/^import\s+\{[^}]+\}\s+from\s+["'][^"']+["'];\r?\n/gm, "");
+
+const localStorageState = new Map();
+let localStorageWrites = 0;
+const context = {
+    console,
+    process,
+    Date,
+    Math,
+    JSON,
+    Number,
+    String,
+    Boolean,
+    Array,
+    Object,
+    Set,
+    Map,
+    WeakMap,
+    WeakSet,
+    URL,
+    URLSearchParams,
+    AbortController,
+    TextEncoder,
+    app: {
+        graph: { _nodes: [], getNodeById() { return null; }, setDirtyCanvas() {} },
+        canvas: { graph: { _nodes: [], getNodeById() { return null; } } },
+        registerExtension() {},
+    },
+    api: {
+        addEventListener() {},
+        apiURL(value) { return value; },
+    },
+    window: {
+        addEventListener() {},
+        setTimeout() { return 0; },
+        requestAnimationFrame() { return 0; },
+        cancelAnimationFrame() {},
+    },
+    queueMicrotask(callback) { callback(); },
+    document: {
+        addEventListener() {},
+        querySelectorAll() { return []; },
+        querySelector() { return null; },
+    },
+    localStorage: {
+        getItem(key) { return localStorageState.get(String(key)) ?? null; },
+        setItem(key, value) {
+            localStorageWrites += 1;
+            localStorageState.set(String(key), String(value));
+        },
+    },
+    LiteGraph: {
+        NODE_WIDGET_HEIGHT: 24,
+        WIDGET_BGCOLOR: "#222",
+        WIDGET_OUTLINE_COLOR: "#555",
+    },
+    Image: class {},
+    capturedApi: null,
+};
+context.globalThis = context;
+context.__DENO_LOCAL_LLM_REVIEWER_TEST_HOOK__ = (testApi) => {
+    context.capturedApi = testApi;
+};
+
+vm.createContext(context);
+vm.runInContext(source, context, { filename: sourcePath });
+const hooks = context.capturedApi;
+assert(hooks, "Local LLM preset-storage test API was not exposed");
+
+function jsonResponse(payload, status = 200) {
+    const text = typeof payload === "string" ? payload : JSON.stringify(payload);
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        async text() { return text; },
+    };
+}
+
+class FakeUserDataApi {
+    constructor(initialFile = null) {
+        this.file = initialFile;
+        this.getCalls = [];
+        this.storeCalls = [];
+        this.storeStatus = 200;
+        this.throwOnStore = null;
+    }
+
+    async getUserData(file, options) {
+        this.getCalls.push({ file, options });
+        return this.file === null ? jsonResponse("", 404) : jsonResponse(this.file, 200);
+    }
+
+    async storeUserData(file, data, options) {
+        this.storeCalls.push({ file, data, options });
+        if (this.throwOnStore) throw this.throwOnStore;
+        if (this.storeStatus === 200) this.file = String(data);
+        return jsonResponse({}, this.storeStatus);
+    }
+}
+
+const legacyValid = { id: "user_legacy_a", label: "Legacy A", text: "legacy text" };
+localStorageState.set(hooks.SYSTEM_PROMPT_PRESET_STORAGE_KEY, JSON.stringify([
+    legacyValid,
+    { id: "user_legacy_duplicate", label: "legacy a", text: "duplicate" },
+    { id: "../escape", label: "Bad id", text: "bad" },
+    { id: "user_too_large", label: "Too large", text: "x".repeat(64 * 1024 + 1) },
+]));
+const legacyState = hooks.readLegacySystemPromptUserPresetState(context.localStorage);
+assert.deepEqual(JSON.parse(JSON.stringify(legacyState.presets)), [legacyValid]);
+assert.equal(legacyState.rejectedCount, 3, "invalid, duplicate, and oversized legacy entries must be ignored visibly");
+assert.equal(localStorageWrites, 0, "reading or normalizing legacy presets must never rewrite browser storage");
+
+assert.equal(hooks.durableSystemPromptPresetApiAvailable({}), false);
+assert.deepEqual(
+    JSON.parse(JSON.stringify(await hooks.readDurableSystemPromptUserPresets({}))),
+    { status: "unavailable", presets: [] },
+    "missing core userdata methods must produce the safe read-only fallback state",
+);
+
+const missingApi = new FakeUserDataApi();
+const missing = await hooks.readDurableSystemPromptUserPresets(missingApi);
+assert.equal(missing.status, "missing");
+assert.deepEqual(JSON.parse(JSON.stringify(missing.presets)), []);
+assert.equal(missingApi.getCalls[0].file, hooks.SYSTEM_PROMPT_PRESET_USERDATA_FILE);
+
+const durableA = { id: "user_durable_a", label: "Durable A", text: "first" };
+const durableApi = new FakeUserDataApi(JSON.stringify({ version: 1, presets: [durableA] }));
+const loaded = await hooks.readDurableSystemPromptUserPresets(durableApi);
+assert.equal(loaded.status, "loaded");
+assert.deepEqual(JSON.parse(JSON.stringify(loaded.presets)), [durableA]);
+
+const malformedApi = new FakeUserDataApi("{bad json");
+await assert.rejects(
+    hooks.readDurableSystemPromptUserPresets(malformedApi),
+    /malformed JSON/,
+    "malformed durable JSON must fail instead of becoming an empty preset list",
+);
+const oversizedFileApi = new FakeUserDataApi("x".repeat(hooks.SYSTEM_PROMPT_PRESET_MAX_FILE_BYTES + 1));
+await assert.rejects(hooks.readDurableSystemPromptUserPresets(oversizedFileApi), /exceeds/);
+assert.throws(
+    () => hooks.normalizeSystemPromptPresetEnvelope({
+        version: 1,
+        presets: [{ id: "user_large", label: "Large", text: "x".repeat(64 * 1024 + 1) }],
+    }),
+    /text exceeds/,
+);
+
+const saveApi = new FakeUserDataApi();
+const saved = await hooks.writeDurableSystemPromptUserPresets([durableA], saveApi);
+assert.deepEqual(JSON.parse(JSON.stringify(saved)), [durableA]);
+assert.equal(saveApi.storeCalls.length, 1);
+assert.equal(saveApi.storeCalls[0].file, hooks.SYSTEM_PROMPT_PRESET_USERDATA_FILE);
+assert.equal(saveApi.storeCalls[0].options.stringify, false);
+assert.deepEqual(JSON.parse(saveApi.file), { version: 1, presets: [durableA] });
+
+const updatedA = { ...durableA, text: "updated" };
+await hooks.writeDurableSystemPromptUserPresets([updatedA], saveApi);
+assert.deepEqual(JSON.parse(saveApi.file), { version: 1, presets: [updatedA] }, "Save Preset must replace durable content");
+await hooks.writeDurableSystemPromptUserPresets([], saveApi);
+assert.deepEqual(JSON.parse(saveApi.file), { version: 1, presets: [] }, "Delete must persist the remaining durable list");
+
+const failedApi = new FakeUserDataApi(JSON.stringify({ version: 1, presets: [durableA] }));
+failedApi.storeStatus = 500;
+const beforeFailure = failedApi.file;
+await assert.rejects(hooks.writeDurableSystemPromptUserPresets([], failedApi), /HTTP 500/);
+assert.equal(failedApi.file, beforeFailure, "a failed save must leave the prior durable file untouched");
+
+const legacyNew = { id: "user_legacy_new", label: "Legacy New", text: "new" };
+const merge = hooks.mergeSystemPromptPresetLists(
+    [durableA],
+    [
+        { id: durableA.id, label: "Different label", text: "id conflict" },
+        { id: "user_label_conflict", label: "durable a", text: "label conflict" },
+        legacyNew,
+    ],
+);
+assert.deepEqual(JSON.parse(JSON.stringify(merge.presets)), [durableA, legacyNew]);
+assert.equal(merge.importedCount, 1);
+assert.equal(merge.skippedCount, 2);
+const importApi = new FakeUserDataApi(JSON.stringify({ version: 1, presets: [durableA] }));
+await hooks.writeDurableSystemPromptUserPresets(merge.presets, importApi);
+const secondMerge = hooks.mergeSystemPromptPresetLists(JSON.parse(importApi.file).presets, [legacyNew]);
+assert.equal(secondMerge.importedCount, 0, "the unchanged browser backup must not be imported twice");
+assert.equal(localStorageWrites, 0, "durable save/delete/import must leave browser storage untouched");
+
+console.log("local_llm_preset_storage_harness: ok");

--- a/tests/test_image_resize_node.py
+++ b/tests/test_image_resize_node.py
@@ -3873,7 +3873,13 @@ def test_local_llm_refiner_declares_batch_prompt_contract_and_frontend_preview()
     assert "DENO_FINAL_PROMPT:" in script
     assert "Reviewer JSON" in script
     assert "Return only valid JSON. Do not write markdown." in script
-    assert "writeSystemPromptUserPresets" in script
+    assert "SYSTEM_PROMPT_PRESET_USERDATA_FILE" in script
+    assert "apiClient.getUserData" in script
+    assert "apiClient.storeUserData" in script
+    assert "writeDurableSystemPromptUserPresets" in script
+    assert "writeSystemPromptUserPresets" not in script
+    assert 'importBrowserPresetsButton.textContent = "Import Browser Presets";' in script
+    assert "Browser storage was kept unchanged as a backup." in script
     assert 'loadPresetButton.textContent = "Load";' in script
     assert 'savePresetButton.textContent = "Save Preset";' in script
     assert 'saveButton.textContent = "Save to Node";' in script

--- a/tests/test_local_llm_regressions.py
+++ b/tests/test_local_llm_regressions.py
@@ -635,3 +635,17 @@ def test_local_llm_frontend_async_actions_are_latest_wins():
     )
 
     assert result.returncode == 0, f"node harness failed:\n{result.stdout}\n{result.stderr}"
+
+
+def test_local_llm_system_prompt_presets_use_durable_user_data():
+    node = shutil.which("node")
+    assert node, "node executable is required for the Local LLM preset-storage harness"
+
+    result = subprocess.run(
+        [node, str(REPO_ROOT / "tests" / "js" / "local_llm_preset_storage_harness.mjs")],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, f"node harness failed:\n{result.stdout}\n{result.stderr}"

--- a/tests/test_ltx_tiled_nodes_predictor.py
+++ b/tests/test_ltx_tiled_nodes_predictor.py
@@ -1052,6 +1052,38 @@ def test_av_sampler_freezes_audio_output_and_denoised_output(monkeypatch, fake_c
     assert torch.allclose(denoised_audio, audio)
 
 
+def test_av_sampler_restores_audio_after_terminal_sampler_output_drift(
+    monkeypatch,
+    fake_comfy_latent_utils,
+):
+    _patch_av_sampler_runtime(monkeypatch)
+    video = torch.zeros((1, 2, 3, 6, 4))
+    audio = torch.ones((1, 1, 4, 4)) * 5.0
+    raw_output_audio = torch.ones_like(audio) * 6.25
+    x0_video = torch.ones_like(video) * 7.0
+
+    output, denoised = DenoLTXAVStepFusedTiledSampler().sample(
+        _FakeNoise(),
+        _FakeSamplerGuider(
+            x0_video=x0_video,
+            x0_audio=audio.clone(),
+            output_audio=raw_output_audio,
+        ),
+        object(),
+        torch.tensor([1.0, 0.0]),
+        {"samples": _FakeNestedTensor([video, audio])},
+        overlap=2,
+    )
+
+    output_video, output_audio = output["samples"].unbind()
+    denoised_video, denoised_audio = denoised["samples"].unbind()
+    assert torch.equal(output_video, video + 1.0)
+    assert torch.equal(denoised_video, x0_video)
+    assert torch.equal(output_audio, audio)
+    assert torch.equal(denoised_audio, audio)
+    assert not torch.equal(raw_output_audio, audio)
+
+
 @pytest.mark.parametrize("callback_x0_kind", ["packed_tensor", "nested_tensor"])
 def test_av_sampler_accepts_both_callback_x0_contracts(
     monkeypatch,
@@ -1327,7 +1359,7 @@ def test_av_sampler_rejects_packed_x0_extra_elements(monkeypatch, fake_comfy_lat
         ("extra_part", "AV x0 unpacked into 3 parts, expected 2"),
         ("video_shape", "AV x0 part 0 shape mismatch"),
         ("audio_shape", "AV x0 part 1 shape mismatch"),
-        ("audio_value", "AV x0 audio changed"),
+        ("audio_nonfinite", "AV x0 audio contains non-finite values"),
     ],
 )
 def test_av_sampler_strictly_validates_nested_callback_x0(
@@ -1349,8 +1381,8 @@ def test_av_sampler_strictly_validates_nested_callback_x0(
         parts[0] = torch.zeros((1, 2, 3, 5, 4))
     elif violation == "audio_shape":
         parts[1] = torch.zeros((1, 1, 4, 3))
-    elif violation == "audio_value":
-        parts[1] = torch.full_like(audio, 99.0)
+    elif violation == "audio_nonfinite":
+        parts[1] = torch.full_like(audio, float("nan"))
 
     with pytest.raises(RuntimeError, match=message):
         DenoLTXAVStepFusedTiledSampler().sample(
@@ -1363,21 +1395,32 @@ def test_av_sampler_strictly_validates_nested_callback_x0(
         )
 
 
-def test_av_sampler_rejects_changed_x0_audio(monkeypatch, fake_comfy_latent_utils):
+def test_av_sampler_restores_audio_after_callback_x0_drift(
+    monkeypatch,
+    fake_comfy_latent_utils,
+):
     _patch_av_sampler_runtime(monkeypatch)
     video = torch.zeros((1, 2, 3, 6, 4))
     audio = torch.ones((1, 1, 4, 4))
-    x0_audio = torch.ones_like(audio) * 99.0
+    raw_x0_audio = torch.ones_like(audio) * 99.0
+    x0_video = torch.ones_like(video) * 7.0
 
-    with pytest.raises(RuntimeError, match="AV x0 audio changed"):
-        DenoLTXAVStepFusedTiledSampler().sample(
-            _FakeNoise(),
-            _FakeSamplerGuider(x0_video=torch.ones_like(video), x0_audio=x0_audio),
-            object(),
-            torch.tensor([1.0, 0.0]),
-            {"samples": _FakeNestedTensor([video, audio])},
-            overlap=2,
-        )
+    output, denoised = DenoLTXAVStepFusedTiledSampler().sample(
+        _FakeNoise(),
+        _FakeSamplerGuider(x0_video=x0_video, x0_audio=raw_x0_audio),
+        object(),
+        torch.tensor([1.0, 0.0]),
+        {"samples": _FakeNestedTensor([video, audio])},
+        overlap=2,
+    )
+
+    output_video, output_audio = output["samples"].unbind()
+    denoised_video, denoised_audio = denoised["samples"].unbind()
+    assert torch.equal(output_video, video + 1.0)
+    assert torch.equal(denoised_video, x0_video)
+    assert torch.equal(output_audio, audio)
+    assert torch.equal(denoised_audio, audio)
+    assert not torch.equal(raw_x0_audio, audio)
 
 
 def test_av_sampler_rejects_output_shape_changes(monkeypatch, fake_comfy_latent_utils):
@@ -1406,6 +1449,29 @@ def test_av_sampler_rejects_output_shape_changes(monkeypatch, fake_comfy_latent_
                 x0_video=torch.ones_like(video),
                 x0_audio=audio.clone(),
                 output_audio=torch.zeros((1, 1, 4, 3)),
+            ),
+            object(),
+            torch.tensor([1.0, 0.0]),
+            {"samples": _FakeNestedTensor([video, audio])},
+            overlap=2,
+        )
+
+
+def test_av_sampler_rejects_non_finite_raw_output_audio(
+    monkeypatch,
+    fake_comfy_latent_utils,
+):
+    _patch_av_sampler_runtime(monkeypatch)
+    video = torch.zeros((1, 2, 3, 6, 4))
+    audio = torch.ones((1, 1, 4, 4))
+
+    with pytest.raises(RuntimeError, match="AV sampler output audio contains non-finite values"):
+        DenoLTXAVStepFusedTiledSampler().sample(
+            _FakeNoise(),
+            _FakeSamplerGuider(
+                x0_video=torch.ones_like(video),
+                x0_audio=audio.clone(),
+                output_audio=torch.full_like(audio, float("inf")),
             ),
             object(),
             torch.tensor([1.0, 0.0]),

--- a/web/js/deno_local_llm_refiner.js
+++ b/web/js/deno_local_llm_refiner.js
@@ -183,6 +183,13 @@ const REVIEWER_PROP_AUTO_RETRY = "deno_auto_retry_on_fail";
 const REVIEWER_PROP_SEED_TARGET = "deno_auto_retry_seed_target";
 const REVIEWER_FALLBACK_MAX_SEED = 1125899906842624;
 const SYSTEM_PROMPT_PRESET_STORAGE_KEY = "deno.localLLM.systemPromptPresets.v1";
+const SYSTEM_PROMPT_PRESET_USERDATA_FILE = "deno/local_llm/system_prompt_presets.v1.json";
+const SYSTEM_PROMPT_PRESET_SCHEMA_VERSION = 1;
+const SYSTEM_PROMPT_PRESET_MAX_COUNT = 128;
+const SYSTEM_PROMPT_PRESET_MAX_ID_LENGTH = 96;
+const SYSTEM_PROMPT_PRESET_MAX_LABEL_LENGTH = 128;
+const SYSTEM_PROMPT_PRESET_MAX_TEXT_BYTES = 64 * 1024;
+const SYSTEM_PROMPT_PRESET_MAX_FILE_BYTES = 1024 * 1024;
 const REVIEWER_JSON_SYSTEM_PROMPT = [
     "You are an image review judge for a ComfyUI workflow.",
     "",
@@ -2162,9 +2169,21 @@ if (typeof globalThis !== "undefined" && typeof globalThis.__DENO_LOCAL_LLM_REVI
         setReviewerAutoRetryEnabled,
         setReviewerSeedTarget,
         splitPreviewLinesForWidth,
+        durableSystemPromptPresetApiAvailable,
+        makeSystemPromptPresetEnvelope,
+        mergeSystemPromptPresetLists,
+        normalizeSystemPromptPresetEnvelope,
+        normalizeSystemPromptPresetList,
+        readDurableSystemPromptUserPresets,
+        readLegacySystemPromptUserPresetState,
+        readSystemPromptUserPresets,
+        writeDurableSystemPromptUserPresets,
         refreshModels,
         stopLocalModel,
         unloadLocalModel,
+        SYSTEM_PROMPT_PRESET_STORAGE_KEY,
+        SYSTEM_PROMPT_PRESET_USERDATA_FILE,
+        SYSTEM_PROMPT_PRESET_MAX_FILE_BYTES,
         wrapModelCallback,
         wrapProviderCallback,
     });
@@ -6343,35 +6362,210 @@ function drawWideButtonWithStatus(ctx, x, y, width, height, label, status, press
     ctx.restore();
 }
 
-function readSystemPromptUserPresets() {
+function systemPromptPresetUtf8Bytes(value) {
+    const text = String(value ?? "");
     try {
-        const raw = localStorage?.getItem?.(SYSTEM_PROMPT_PRESET_STORAGE_KEY);
-        const parsed = JSON.parse(raw || "[]");
-        if (!Array.isArray(parsed)) {
-            return [];
+        if (typeof TextEncoder !== "undefined") {
+            return new TextEncoder().encode(text).byteLength;
         }
-        return parsed
-            .map((preset) => ({
-                id: String(preset?.id || "").trim(),
-                label: String(preset?.label || "").trim(),
-                text: String(preset?.text || ""),
-            }))
-            .filter((preset) => preset.id && preset.label);
     } catch {
-        return [];
+        // Fall back to a conservative bound in old browser runtimes.
+    }
+    return text.length * 4;
+}
+
+function normalizeSystemPromptPresetList(value, options = {}) {
+    const legacy = options?.legacy === true;
+    if (!Array.isArray(value)) {
+        throw new Error("Preset data must contain a presets array.");
+    }
+    if (!legacy && value.length > SYSTEM_PROMPT_PRESET_MAX_COUNT) {
+        throw new Error(`Preset data exceeds the ${SYSTEM_PROMPT_PRESET_MAX_COUNT}-preset limit.`);
+    }
+
+    const presets = [];
+    const seenIds = new Set();
+    const seenLabels = new Set();
+    let rejectedCount = legacy ? Math.max(0, value.length - SYSTEM_PROMPT_PRESET_MAX_COUNT) : 0;
+    const valueLimit = legacy ? Math.min(value.length, SYSTEM_PROMPT_PRESET_MAX_COUNT) : value.length;
+    for (let index = 0; index < valueLimit; index += 1) {
+        try {
+            const entry = value[index];
+            if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+                throw new Error("entry must be an object");
+            }
+            if (!legacy && (
+                typeof entry.id !== "string"
+                || typeof entry.label !== "string"
+                || typeof entry.text !== "string"
+            )) {
+                throw new Error("id, label, and text must be strings");
+            }
+            const id = String(entry.id ?? "").trim();
+            const label = String(entry.label ?? "").trim();
+            const text = String(entry.text ?? "");
+            if (!id || !label) {
+                throw new Error("id and label cannot be empty");
+            }
+            if (id.length > SYSTEM_PROMPT_PRESET_MAX_ID_LENGTH || !/^[A-Za-z0-9._-]+$/.test(id)) {
+                throw new Error("id contains unsupported characters or is too long");
+            }
+            if (label.length > SYSTEM_PROMPT_PRESET_MAX_LABEL_LENGTH) {
+                throw new Error(`label exceeds ${SYSTEM_PROMPT_PRESET_MAX_LABEL_LENGTH} characters`);
+            }
+            if (systemPromptPresetUtf8Bytes(text) > SYSTEM_PROMPT_PRESET_MAX_TEXT_BYTES) {
+                throw new Error(`text exceeds ${SYSTEM_PROMPT_PRESET_MAX_TEXT_BYTES} UTF-8 bytes`);
+            }
+            const labelKey = label.toLowerCase();
+            if (seenIds.has(id) || seenLabels.has(labelKey)) {
+                throw new Error("duplicate id or label");
+            }
+            seenIds.add(id);
+            seenLabels.add(labelKey);
+            presets.push({ id, label, text });
+        } catch (error) {
+            if (!legacy) {
+                throw new Error(`Preset ${index + 1} is invalid: ${error?.message || error}`);
+            }
+            rejectedCount += 1;
+        }
+    }
+    return { presets, rejectedCount };
+}
+
+function normalizeSystemPromptPresetEnvelope(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+        throw new Error("Preset file must be a versioned JSON object.");
+    }
+    if (value.version !== SYSTEM_PROMPT_PRESET_SCHEMA_VERSION) {
+        throw new Error(`Unsupported preset file version: ${String(value.version ?? "missing")}.`);
+    }
+    const normalized = normalizeSystemPromptPresetList(value.presets);
+    return {
+        version: SYSTEM_PROMPT_PRESET_SCHEMA_VERSION,
+        presets: normalized.presets,
+    };
+}
+
+function makeSystemPromptPresetEnvelope(presets) {
+    const normalized = normalizeSystemPromptPresetList(presets);
+    const envelope = {
+        version: SYSTEM_PROMPT_PRESET_SCHEMA_VERSION,
+        presets: normalized.presets,
+    };
+    const serialized = JSON.stringify(envelope);
+    if (systemPromptPresetUtf8Bytes(serialized) > SYSTEM_PROMPT_PRESET_MAX_FILE_BYTES) {
+        throw new Error(`Preset file exceeds ${SYSTEM_PROMPT_PRESET_MAX_FILE_BYTES} UTF-8 bytes.`);
+    }
+    return envelope;
+}
+
+function readLegacySystemPromptUserPresetState(storage) {
+    try {
+        const targetStorage = storage ?? (typeof localStorage !== "undefined" ? localStorage : null);
+        const raw = targetStorage?.getItem?.(SYSTEM_PROMPT_PRESET_STORAGE_KEY);
+        if (!raw) {
+            return { presets: [], rejectedCount: 0, available: Boolean(targetStorage) };
+        }
+        const parsed = JSON.parse(raw);
+        const normalized = normalizeSystemPromptPresetList(parsed, { legacy: true });
+        return { ...normalized, available: true };
+    } catch {
+        return { presets: [], rejectedCount: 1, available: false };
     }
 }
 
-function writeSystemPromptUserPresets(presets) {
-    try {
-        localStorage?.setItem?.(
-            SYSTEM_PROMPT_PRESET_STORAGE_KEY,
-            JSON.stringify(Array.isArray(presets) ? presets : [])
-        );
-        return true;
-    } catch {
-        return false;
+function readSystemPromptUserPresets(storage) {
+    return readLegacySystemPromptUserPresetState(storage).presets;
+}
+
+function durableSystemPromptPresetApiAvailable(apiClient = api) {
+    return Boolean(
+        apiClient
+        && typeof apiClient.getUserData === "function"
+        && typeof apiClient.storeUserData === "function"
+    );
+}
+
+async function readDurableSystemPromptUserPresets(apiClient = api) {
+    if (!durableSystemPromptPresetApiAvailable(apiClient)) {
+        return { status: "unavailable", presets: [] };
     }
+    let response;
+    try {
+        response = await apiClient.getUserData(SYSTEM_PROMPT_PRESET_USERDATA_FILE, { cache: "no-store" });
+    } catch (error) {
+        throw new Error(`Could not load ComfyUI user presets: ${error?.message || error}`);
+    }
+    if (response?.status === 404) {
+        return { status: "missing", presets: [] };
+    }
+    if (!response || response.ok === false || (Number(response.status) && Number(response.status) !== 200)) {
+        throw new Error(`Could not load ComfyUI user presets (HTTP ${response?.status || "unknown"}).`);
+    }
+    const raw = await response.text();
+    if (systemPromptPresetUtf8Bytes(raw) > SYSTEM_PROMPT_PRESET_MAX_FILE_BYTES) {
+        throw new Error(`Preset file exceeds ${SYSTEM_PROMPT_PRESET_MAX_FILE_BYTES} UTF-8 bytes.`);
+    }
+    let parsed;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        throw new Error("ComfyUI user preset file contains malformed JSON.");
+    }
+    const envelope = normalizeSystemPromptPresetEnvelope(parsed);
+    return { status: "loaded", presets: envelope.presets };
+}
+
+async function writeDurableSystemPromptUserPresets(presets, apiClient = api) {
+    if (!durableSystemPromptPresetApiAvailable(apiClient)) {
+        throw new Error("ComfyUI user data API is unavailable; presets were not saved.");
+    }
+    const envelope = makeSystemPromptPresetEnvelope(presets);
+    const serialized = JSON.stringify(envelope);
+    let response;
+    try {
+        response = await apiClient.storeUserData(
+            SYSTEM_PROMPT_PRESET_USERDATA_FILE,
+            serialized,
+            { overwrite: true, stringify: false, throwOnError: false }
+        );
+    } catch (error) {
+        throw new Error(`Preset save failed: ${error?.message || error}`);
+    }
+    if (!response || response.ok === false || (Number(response.status) && Number(response.status) !== 200)) {
+        throw new Error(`Preset save failed (HTTP ${response?.status || "unknown"}).`);
+    }
+    const readBack = await readDurableSystemPromptUserPresets(apiClient);
+    if (readBack.status !== "loaded" || JSON.stringify(readBack.presets) !== JSON.stringify(envelope.presets)) {
+        throw new Error("Preset save could not be verified; the previous in-memory list was kept.");
+    }
+    return readBack.presets;
+}
+
+function mergeSystemPromptPresetLists(durablePresets, legacyPresets) {
+    const durable = normalizeSystemPromptPresetList(durablePresets).presets;
+    const legacy = normalizeSystemPromptPresetList(legacyPresets).presets;
+    const merged = durable.map((preset) => ({ ...preset }));
+    const seenIds = new Set(merged.map((preset) => preset.id));
+    const seenLabels = new Set(merged.map((preset) => preset.label.toLowerCase()));
+    let importedCount = 0;
+    let skippedCount = 0;
+    for (const preset of legacy) {
+        const labelKey = preset.label.toLowerCase();
+        if (seenIds.has(preset.id) || seenLabels.has(labelKey)) {
+            skippedCount += 1;
+            continue;
+        }
+        if (merged.length >= SYSTEM_PROMPT_PRESET_MAX_COUNT) {
+            throw new Error(`Import would exceed the ${SYSTEM_PROMPT_PRESET_MAX_COUNT}-preset limit.`);
+        }
+        merged.push({ ...preset });
+        seenIds.add(preset.id);
+        seenLabels.add(labelKey);
+        importedCount += 1;
+    }
+    return { presets: merged, importedCount, skippedCount };
 }
 
 function makeSystemPromptPresetId(label) {
@@ -6391,7 +6585,7 @@ function systemPromptPresetEntries(userPresets) {
             ...preset,
             kind: "user",
             value: `user:${preset.id}`,
-            description: "Saved in this browser.",
+            description: "Saved in ComfyUI user data.",
         })),
     ];
 }
@@ -6482,7 +6676,11 @@ function openSystemPromptDialog(node) {
     closeButton.style.cssText = buttonStyle(false);
     header.append(title, closeButton);
 
-    let userPresets = readSystemPromptUserPresets();
+    const legacyPresetState = readLegacySystemPromptUserPresetState();
+    const legacyPresets = legacyPresetState.presets;
+    let userPresets = [];
+    let durablePresetStoreReady = false;
+    let presetStoreBusy = true;
     const presetPanel = document.createElement("div");
     presetPanel.style.cssText = [
         "display:flex",
@@ -6510,25 +6708,58 @@ function openSystemPromptDialog(node) {
     const deletePresetButton = document.createElement("button");
     deletePresetButton.textContent = "Delete";
     deletePresetButton.style.cssText = buttonStyle(false);
+    const importBrowserPresetsButton = legacyPresets.length ? document.createElement("button") : null;
+    if (importBrowserPresetsButton) {
+        importBrowserPresetsButton.textContent = "Import Browser Presets";
+        importBrowserPresetsButton.style.cssText = `${buttonStyle(false)};align-self:flex-start;display:none;`;
+    }
     const presetHint = document.createElement("div");
-    presetHint.textContent = "Load a preset into the editor, then save it to the node.";
+    presetHint.textContent = "Loading presets from ComfyUI user data...";
     presetHint.style.cssText = "font-size:11px;line-height:1.35;color:#aebdb3;";
     presetRow.append(presetSelect, presetName, loadPresetButton, savePresetButton, deletePresetButton);
-    presetPanel.append(presetRow, presetHint);
+    presetPanel.append(presetRow);
+    if (importBrowserPresetsButton) {
+        presetPanel.append(importBrowserPresetsButton);
+    }
+    presetPanel.append(presetHint);
 
-    const updatePresetControls = () => {
-        const selected = selectedSystemPromptPreset(presetSelect, userPresets);
-        deletePresetButton.disabled = selected?.kind !== "user";
-        deletePresetButton.style.opacity = selected?.kind === "user" ? "1" : "0.45";
-        if (selected?.kind === "user") {
-            presetName.value = selected.label;
-        } else if (selected?.kind === "builtin") {
-            presetName.value = "";
+    const importableBrowserPresetCount = () => {
+        if (!legacyPresets.length) {
+            return 0;
         }
-        presetHint.textContent = selected?.description || "Load a preset into the editor, then save it to the node.";
+        try {
+            return mergeSystemPromptPresetLists(userPresets, legacyPresets).importedCount;
+        } catch {
+            return 0;
+        }
+    };
+    const updatePresetControls = (updateHint = true, syncPresetName = true) => {
+        const selected = selectedSystemPromptPreset(presetSelect, userPresets);
+        loadPresetButton.disabled = presetStoreBusy || !selected;
+        savePresetButton.disabled = presetStoreBusy || !durablePresetStoreReady;
+        deletePresetButton.disabled = presetStoreBusy || !durablePresetStoreReady || selected?.kind !== "user";
+        loadPresetButton.style.opacity = loadPresetButton.disabled ? "0.45" : "1";
+        savePresetButton.style.opacity = savePresetButton.disabled ? "0.45" : "1";
+        deletePresetButton.style.opacity = deletePresetButton.disabled ? "0.45" : "1";
+        if (syncPresetName) {
+            if (selected?.kind === "user") {
+                presetName.value = selected.label;
+            } else if (selected?.kind === "builtin") {
+                presetName.value = "";
+            }
+        }
+        if (importBrowserPresetsButton) {
+            const showImport = durablePresetStoreReady && importableBrowserPresetCount() > 0;
+            importBrowserPresetsButton.style.display = showImport ? "block" : "none";
+            importBrowserPresetsButton.disabled = presetStoreBusy || !showImport;
+            importBrowserPresetsButton.style.opacity = importBrowserPresetsButton.disabled ? "0.45" : "1";
+        }
+        if (updateHint) {
+            presetHint.textContent = selected?.description || "Load a preset into the editor, then save it to the node.";
+        }
     };
     populateSystemPromptPresetSelect(presetSelect, userPresets);
-    updatePresetControls();
+    updatePresetControls(false);
 
     const textarea = document.createElement("textarea");
     textarea.value = String(systemWidget.value || "");
@@ -6570,8 +6801,74 @@ function openSystemPromptDialog(node) {
         close();
     };
 
+    const setPresetStoreBusy = (busy) => {
+        presetStoreBusy = Boolean(busy);
+        presetSelect.disabled = presetStoreBusy;
+        presetName.disabled = presetStoreBusy;
+        updatePresetControls(false, false);
+    };
+    const persistPresetList = async (candidatePresets, selectedValue, successMessage) => {
+        if (!durablePresetStoreReady) {
+            presetHint.textContent = "ComfyUI user data is unavailable; presets were not changed.";
+            return false;
+        }
+        setPresetStoreBusy(true);
+        try {
+            const savedPresets = await writeDurableSystemPromptUserPresets(candidatePresets);
+            userPresets = savedPresets;
+            populateSystemPromptPresetSelect(presetSelect, userPresets, selectedValue);
+            updatePresetControls(false, true);
+            presetHint.textContent = successMessage;
+            return true;
+        } catch (error) {
+            presetHint.textContent = `${error?.message || error} No save was confirmed; the displayed preset list was kept unchanged.`;
+            return false;
+        } finally {
+            setPresetStoreBusy(false);
+        }
+    };
+    const initializePresetStore = async () => {
+        setPresetStoreBusy(true);
+        if (!durableSystemPromptPresetApiAvailable()) {
+            userPresets = legacyPresets;
+            durablePresetStoreReady = false;
+            populateSystemPromptPresetSelect(presetSelect, userPresets);
+            setPresetStoreBusy(false);
+            presetHint.textContent = legacyPresets.length
+                ? "ComfyUI user data is unavailable. Browser presets are available read-only; Save and Delete are disabled."
+                : "ComfyUI user data is unavailable. Durable preset Save and Delete are disabled.";
+            return;
+        }
+        try {
+            const result = await readDurableSystemPromptUserPresets();
+            userPresets = result.presets;
+            durablePresetStoreReady = true;
+            populateSystemPromptPresetSelect(presetSelect, userPresets);
+            setPresetStoreBusy(false);
+            const importCount = importableBrowserPresetCount();
+            if (result.status === "missing") {
+                presetHint.textContent = importCount
+                    ? `${importCount} browser preset${importCount === 1 ? " is" : "s are"} ready to import. No ComfyUI preset file exists yet.`
+                    : "No durable presets yet. Save Preset will create the ComfyUI user-data file.";
+            } else {
+                presetHint.textContent = importCount
+                    ? `${userPresets.length} durable preset${userPresets.length === 1 ? "" : "s"} loaded. ${importCount} browser preset${importCount === 1 ? " is" : "s are"} available to import.`
+                    : `${userPresets.length} durable preset${userPresets.length === 1 ? "" : "s"} loaded from ComfyUI user data.`;
+            }
+            if (legacyPresetState.rejectedCount) {
+                presetHint.textContent += ` ${legacyPresetState.rejectedCount} invalid browser preset entr${legacyPresetState.rejectedCount === 1 ? "y was" : "ies were"} ignored.`;
+            }
+        } catch (error) {
+            userPresets = legacyPresets;
+            durablePresetStoreReady = false;
+            populateSystemPromptPresetSelect(presetSelect, userPresets);
+            setPresetStoreBusy(false);
+            presetHint.textContent = `${error?.message || error} Browser presets are available read-only; nothing was overwritten.`;
+        }
+    };
+
     closeButton.addEventListener("click", close);
-    presetSelect.addEventListener("change", updatePresetControls);
+    presetSelect.addEventListener("change", () => updatePresetControls(true));
     loadPresetButton.addEventListener("click", () => {
         const selected = selectedSystemPromptPreset(presetSelect, userPresets);
         if (!selected) {
@@ -6585,7 +6882,7 @@ function openSystemPromptDialog(node) {
         }
         textarea.focus();
     });
-    savePresetButton.addEventListener("click", () => {
+    savePresetButton.addEventListener("click", async () => {
         const name = String(presetName.value || "").trim() || "My System Prompt";
         const existing = userPresets.find((preset) => preset.label.toLowerCase() === name.toLowerCase());
         const nextPreset = {
@@ -6593,30 +6890,46 @@ function openSystemPromptDialog(node) {
             label: name,
             text: textarea.value,
         };
-        userPresets = existing
+        const candidatePresets = existing
             ? userPresets.map((preset) => (preset.id === existing.id ? nextPreset : preset))
             : [...userPresets, nextPreset];
-        if (writeSystemPromptUserPresets(userPresets)) {
-            populateSystemPromptPresetSelect(presetSelect, userPresets, `user:${nextPreset.id}`);
-            updatePresetControls();
-            presetHint.textContent = `${name} saved in this browser.`;
-        } else {
-            presetHint.textContent = "Preset save failed. Browser storage is unavailable.";
-        }
+        await persistPresetList(
+            candidatePresets,
+            `user:${nextPreset.id}`,
+            `${name} saved in ComfyUI user data.`
+        );
     });
-    deletePresetButton.addEventListener("click", () => {
+    deletePresetButton.addEventListener("click", async () => {
         const selected = selectedSystemPromptPreset(presetSelect, userPresets);
         if (selected?.kind !== "user") {
             presetHint.textContent = "Built-in presets cannot be deleted.";
             return;
         }
-        userPresets = userPresets.filter((preset) => preset.id !== selected.id);
-        if (writeSystemPromptUserPresets(userPresets)) {
-            populateSystemPromptPresetSelect(presetSelect, userPresets, "builtin:reviewer_json");
-            updatePresetControls();
-            presetHint.textContent = `${selected.label} deleted.`;
-        } else {
-            presetHint.textContent = "Preset delete failed. Browser storage is unavailable.";
+        const candidatePresets = userPresets.filter((preset) => preset.id !== selected.id);
+        await persistPresetList(
+            candidatePresets,
+            "builtin:reviewer_json",
+            `${selected.label} deleted from ComfyUI user data.`
+        );
+    });
+    importBrowserPresetsButton?.addEventListener("click", async () => {
+        try {
+            const merged = mergeSystemPromptPresetLists(userPresets, legacyPresets);
+            if (!merged.importedCount) {
+                updatePresetControls(false);
+                presetHint.textContent = "All browser presets are already represented in ComfyUI user data.";
+                return;
+            }
+            const imported = await persistPresetList(
+                merged.presets,
+                `user:${legacyPresets.find((preset) => merged.presets.some((entry) => entry.id === preset.id))?.id || merged.presets.at(-1)?.id}`,
+                `${merged.importedCount} browser preset${merged.importedCount === 1 ? "" : "s"} imported. Browser storage was kept unchanged as a backup.${merged.skippedCount ? ` ${merged.skippedCount} conflicting preset${merged.skippedCount === 1 ? " was" : "s were"} kept from the durable file.` : ""}`
+            );
+            if (imported) {
+                updatePresetControls(false);
+            }
+        } catch (error) {
+            presetHint.textContent = `Browser preset import failed: ${error?.message || error} No import was confirmed; the displayed list and browser backup were kept unchanged.`;
         }
     });
     clearButton.addEventListener("click", () => {
@@ -6647,6 +6960,7 @@ function openSystemPromptDialog(node) {
     overlay.append(panel);
     document.body.append(overlay);
     textarea.focus();
+    void initializePresetStore();
 }
 
 function openPreviewTextDialog(node, kind, titleText, textValue) {


### PR DESCRIPTION
## Summary

- persist named `(Deno) Local LLM Loader` system-prompt presets in ComfyUI per-user data with strict validation, verified writes, safe read-only fallback, and an explicit one-time browser-preset import
- preserve exact input audio in both outputs of `(Deno) LTX High resolution Tiled Sampler` when external samplers such as RES4LYF `res_2s` introduce finite terminal drift
- bump the package to v0.7.77 and document both user-facing changes

Related to #54 and #55.

## Verification

- `433 passed` with the CI-equivalent pytest command
- frontend syntax checks and LTX Sequencer / Local LLM preset-storage harnesses passed
- real ComfyUI 8191 canvas: durable preset save, read-back, reopen, delete, and saved-workflow restore passed
- installed RES4LYF `res_2s` controlled CPU integration reproduced finite frozen-audio drift; DENO regression tests verify exact restoration in both public outputs
- Registry package boundary and scanner-trigger tests passed; no public node IDs or display names changed