### PR TITLE
Release v0.7.78 Local LLM and SOS fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This file intentionally stays short. Detailed engineering notes belong in privat
 
 ## Unreleased
 
+## 0.7.78 - 2026-08-06
+
+- Improved `(Deno) Local LLM Loader` with applied System Prompt preset status, an optional `video seconds` FLOAT socket, and workflow-tab model restoration that waits for a successful model-list refresh before declaring a saved model missing.
+- Fixed DENO Floating Tools so the first-aid error icon returns to normal after the matching retry succeeds without being reactivated by an old ComfyUI error toast.
+
 ## 0.7.77 - 2026-08-06
 
 - Added durable per-user system-prompt presets to `(Deno) Local LLM Loader`, including a one-time browser-preset import when legacy presets are detected. Fixes #54.

--- a/README.md
+++ b/README.md
@@ -442,6 +442,8 @@ Main features:
 - optionally attach an IMAGE to a vision-capable local model call
 - preview Thinking and Result text directly on the node
 - keep named System Prompt presets in ComfyUI user data so they survive browser-profile cleanup; existing browser presets can be imported once while the browser copy stays untouched as a backup
+- see the actually applied System Prompt preset name on the node and in the editor; edited unmatched text is shown as `Custom`
+- connect a positive FLOAT to `video seconds` to append a sentence such as `This is an 8-second video.` to each LLM user prompt without changing the saved Prompt text
 - use `(Deno) Local LLM Reviewer` as a gate before Save nodes
 - pass or block IMAGE and AUDIO outputs from a review text result
 - approve the current reviewed result once, or rerun the path before the reviewer

--- a/deno_local_llm_refiner.py
+++ b/deno_local_llm_refiner.py
@@ -8,6 +8,7 @@ import itertools
 from io import BytesIO
 import json
 import logging
+import math
 import os
 import queue
 import random
@@ -830,6 +831,37 @@ def _flatten_prompts(value: Any) -> List[str]:
             prompts.extend(_flatten_prompts(item))
         return prompts or [""]
     return [str(value)]
+
+
+def _video_duration_prompt_sentence(value: Any) -> str:
+    raw_value = _extract_scalar(value, None)
+    if raw_value is None or isinstance(raw_value, bool):
+        return ""
+    try:
+        seconds = float(raw_value)
+    except (TypeError, ValueError):
+        return ""
+    if not math.isfinite(seconds) or seconds <= 0:
+        return ""
+    seconds_text = str(int(seconds)) if seconds.is_integer() else format(seconds, ".15g")
+    article = "an" if (
+        seconds_text.startswith("8")
+        or seconds_text == "11"
+        or seconds_text.startswith("11.")
+        or seconds_text == "18"
+        or seconds_text.startswith("18.")
+    ) else "a"
+    return f"This is {article} {seconds_text}-second video."
+
+
+def _append_video_duration_to_prompt(prompt: Any, video_seconds: Any) -> str:
+    prompt_text = str(prompt or "")
+    sentence = _video_duration_prompt_sentence(video_seconds)
+    if not sentence:
+        return prompt_text
+    if not prompt_text.strip():
+        return sentence
+    return f"{prompt_text.rstrip()}\n\n{sentence}"
 
 
 def _seed_for_index(seed: int, mode: str = "fixed", index: int = 0) -> int:
@@ -2485,7 +2517,8 @@ class DenoLocalLLMRefiner:
         "Call a local Ollama, LM Studio, llama.cpp, vLLM, Custom, or llama-swap model "
         "from ComfyUI and help rewrite or review prompt text.\n\n"
         "An optional IMAGE input can be attached to the local model call. "
-        "Use a vision-capable local model for image review.\n\n"
+        "Use a vision-capable local model for image review. An optional Video Seconds FLOAT input "
+        "adds a short English duration sentence to each user prompt.\n\n"
         "Designed for prompt-batcher workflows: use the in-node Prompt field or connect STRING into Prompt, "
         "and this node processes the whole prompt batch in one execution so the local LLM can stay "
         "loaded until the batch is complete.\n\n"
@@ -2533,6 +2566,17 @@ class DenoLocalLLMRefiner:
             },
             "optional": {
                 "image": ("IMAGE",),
+                "video_seconds": (
+                    "FLOAT",
+                    {
+                        "default": 0.0,
+                        "min": 0.0,
+                        "max": 86400.0,
+                        "step": 0.1,
+                        "forceInput": True,
+                        "tooltip": "When connected with a positive value, adds an English video-duration sentence to each LLM user prompt.",
+                    },
+                ),
             },
             "hidden": {
                 "unique_id": "UNIQUE_ID",
@@ -2616,6 +2660,7 @@ class DenoLocalLLMRefiner:
         comfy_vram_policy=COMFY_VRAM_AUTO,
         prompt="",
         image=None,
+        video_seconds=None,
         unique_id=None,
     ):
         provider_value = _normalize_provider(str(_extract_scalar(provider, PROVIDER_OLLAMA)))
@@ -2703,6 +2748,7 @@ class DenoLocalLLMRefiner:
             for index, prompt in enumerate(prompts):
                 current_seed = _seed_for_index(seed_value, seed_mode_value, index)
                 is_last = index == total - 1
+                effective_prompt = _append_video_duration_to_prompt(prompt, video_seconds)
                 active_key = _mark_local_llm_active(provider_value, server_value, model_value)
                 batch_request_started = True
                 batch_cleanup_state = {"provider_cleanup_attempted": False}
@@ -2712,7 +2758,7 @@ class DenoLocalLLMRefiner:
                         server_url=server_value,
                         model=model_value,
                         system_prompt=system_value,
-                        prompt=prompt,
+                        prompt=effective_prompt,
                         thinking=thinking_value,
                         seed=current_seed,
                         model_memory=memory_value,

--- a/deno_node_metadata.py
+++ b/deno_node_metadata.py
@@ -225,6 +225,7 @@ NODE_INPUT_TOOLTIPS = {
         "comfy_vram_policy": "Choose whether ComfyUI models should be unloaded before local LLM work.",
         "prompt": "Main prompt text. The in-node textarea and STRING socket feed this same backend input.",
         "image": "Optional image sent to a vision-capable local model.",
+        "video_seconds": "Optional video length. A positive FLOAT adds an English duration sentence to every user prompt sent to the local LLM.",
     },
     "DenoAIReviewGate": {
         "review": "Text or JSON verdict from a reviewer LLM or text node.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "deno-custom-nodes"
 description = "DENO RTX node pack for ComfyUI: MiniMax H3 multi-reference image and Reference to Video helpers, Ideogram Director visual JSON/bbox prompt builder, Local LLM Loader and Reviewer helpers, GPT/Gemini-ready Error Help reports, Prompt Only final prompt extraction, RTX Video Super Resolution, RTX Super Resolution, Video SR/VSR, NVIDIA VFX/nvvfx, RTX upscale helpers, LTX 2.3 workflows, LTX tiled second-pass refinement helpers, Bernini Prompt Guide, audio/image review gates, Bernini conditioning helpers, Wan 2.2 reference video edit workflows, image and video compare, video preview, Video to GIF/WebP tools, multi-image loading, resize tools, LoRA/model helpers, prompt guides, and visual workflow utilities."
-version = "0.7.77"
+version = "0.7.78"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = []

--- a/tests/js/floating_tools_sos_state_harness.mjs
+++ b/tests/js/floating_tools_sos_state_harness.mjs
@@ -11,6 +11,9 @@ function makeHarness(options = {}) {
   let now = 0;
   const queueSnapshots = options.queueSnapshots || null;
   let registeredExtension = null;
+  let mutationObserverCallback = null;
+  let globalAlertScanCount = 0;
+  const eventListeners = new Map();
 
   class FakeDate extends Date {
     constructor(...args) {
@@ -26,6 +29,11 @@ function makeHarness(options = {}) {
     console,
     Date: FakeDate,
     URL,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+    queueMicrotask,
     localStorage: {
       getItem() {
         return null;
@@ -54,6 +62,10 @@ function makeHarness(options = {}) {
       querySelector() {
         return null;
       },
+      querySelectorAll() {
+        globalAlertScanCount += 1;
+        return options.existingAlerts || [];
+      },
     },
     window: {
       location: { origin: "http://127.0.0.1:8188" },
@@ -65,7 +77,10 @@ function makeHarness(options = {}) {
       },
     },
     api: {
-      addEventListener() {},
+      addEventListener(name, callback) {
+        if (!eventListeners.has(name)) eventListeners.set(name, []);
+        eventListeners.get(name).push(callback);
+      },
       async fetchApi(path) {
         if (!queueSnapshots) {
           throw new Error("fetchApi should not be called by SOS state harness");
@@ -81,6 +96,14 @@ function makeHarness(options = {}) {
         };
       },
     },
+    MutationObserver: class FakeMutationObserver {
+      constructor(callback) {
+        mutationObserverCallback = callback;
+      }
+
+      observe() {}
+      disconnect() {}
+    },
   };
   context.window = { ...context.window, ...context };
   context.globalThis = context;
@@ -95,10 +118,17 @@ globalThis.__sosHooks = {
   noteSosRunStartedAfterError,
   noteSosQueueStateAfterError,
   handleSosStatusEvent,
+  handleSosExecutionSuccess,
+  handleSosExecutionInterrupted,
+  installSosEventListeners,
+  installSosValidationObserver,
   state: () => ({
     hasError: Boolean(lastExecutionError),
     sosRunClearCandidate,
     sosQueueWasBusyAfterError,
+    sosRunClearGeneration,
+    sosRunClearPromptId,
+    sosErrorGeneration,
     sosErrorStickyUntil,
     sosLastErrorAt,
     lastExecutionError,
@@ -113,7 +143,35 @@ globalThis.__sosHooks = {
     setNow(value) {
       now = value;
     },
+    dispatch(name, detail = {}) {
+      for (const callback of eventListeners.get(name) || []) callback({ detail });
+    },
+    dispatchMutation(mutations) {
+      assert.equal(typeof mutationObserverCallback, "function", "validation observer must be installed first");
+      mutationObserverCallback(mutations);
+    },
+    globalAlertScanCount() {
+      return globalAlertScanCount;
+    },
   };
+}
+
+function makeElement({ text = "", matchesAlert = false } = {}) {
+  const element = {
+    nodeType: 1,
+    textContent: text,
+    parentElement: null,
+    matches() {
+      return matchesAlert;
+    },
+    closest() {
+      return matchesAlert ? element : null;
+    },
+    querySelector() {
+      return null;
+    },
+  };
+  return element;
 }
 
 async function flushMicrotasks() {
@@ -148,6 +206,93 @@ async function flushMicrotasks() {
   assert.equal(state.lastExecutionError.traceback.length, 40);
   assert.equal(state.lastExecutionError.traceback[0], "trace 80");
   assert.equal(state.lastExecutionError.traceback[39], "trace 119");
+}
+
+{
+  const harness = makeHarness();
+  harness.hooks.installSosEventListeners();
+  harness.setNow(45_000);
+
+  harness.dispatch("execution_error", { prompt_id: "failed-event", exception_message: "boom" });
+  harness.dispatch("execution_success", { prompt_id: "unrelated-success" });
+  assert.equal(
+    harness.hooks.state().hasError,
+    true,
+    "a success without a post-error execution_start candidate must preserve the error",
+  );
+
+  harness.dispatch("execution_start", { prompt_id: "retry-event" });
+  harness.dispatch("execution_success", { prompt_id: "unrelated-success" });
+  assert.equal(
+    harness.hooks.state().hasError,
+    true,
+    "a concurrent success with another prompt id must not clear the retry candidate's error",
+  );
+  harness.dispatch("execution_success", { prompt_id: "retry-event" });
+  assert.equal(harness.hooks.state().hasError, false, "the matching successful retry restores the normal icon");
+}
+
+{
+  const harness = makeHarness();
+  harness.hooks.installSosEventListeners();
+  harness.setNow(50_000);
+
+  harness.dispatch("execution_error", { prompt_id: "failed-old", exception_message: "old boom" });
+  harness.dispatch("execution_start", { prompt_id: "retry-old" });
+  const oldGeneration = harness.hooks.state().sosRunClearGeneration;
+  harness.dispatch("execution_error", { prompt_id: "failed-new", exception_message: "new boom" });
+  assert.ok(harness.hooks.state().sosErrorGeneration > oldGeneration);
+  harness.dispatch("execution_success", { prompt_id: "retry-old" });
+  assert.equal(
+    harness.hooks.state().lastExecutionError.prompt_id,
+    "failed-new",
+    "a late success from an older generation must not clear a newer error",
+  );
+}
+
+{
+  const harness = makeHarness();
+  harness.hooks.installSosEventListeners();
+  harness.setNow(55_000);
+
+  harness.dispatch("execution_error", { prompt_id: "failed-interrupt", exception_message: "boom" });
+  harness.dispatch("execution_start", { prompt_id: "retry-interrupt" });
+  harness.dispatch("execution_interrupted", { prompt_id: "retry-interrupt" });
+  assert.equal(harness.hooks.state().sosRunClearCandidate, false, "interruption cancels the retry clear candidate");
+  harness.dispatch("execution_success", { prompt_id: "retry-interrupt" });
+  assert.equal(harness.hooks.state().hasError, true, "an interrupted retry must keep the error icon active");
+}
+
+{
+  const staleAlert = makeElement({
+    text: "",
+    matchesAlert: true,
+  });
+  const harness = makeHarness({ existingAlerts: [staleAlert] });
+  harness.hooks.installSosEventListeners();
+  harness.hooks.installSosValidationObserver();
+  harness.setNow(60_000);
+
+  harness.dispatch("execution_error", { prompt_id: "failed-stale-dom", exception_message: "boom" });
+  harness.dispatch("execution_start", { prompt_id: "retry-stale-dom" });
+  harness.dispatchMutation([{ addedNodes: [staleAlert] }]);
+  staleAlert.textContent = "1 ERROR Required input is missing See Errors";
+  harness.dispatch("execution_success", { prompt_id: "retry-stale-dom" });
+  await flushMicrotasks();
+  assert.equal(harness.hooks.state().hasError, false, "a pre-success deferred alert scan must be retired with that run");
+
+  harness.dispatchMutation([{ addedNodes: [makeElement()] }]);
+  await flushMicrotasks();
+  assert.equal(harness.globalAlertScanCount(), 0, "unrelated DOM mutations must not trigger a global stale-alert rescan");
+  assert.equal(harness.hooks.state().hasError, false, "a stale validation dialog must not re-arm after success");
+
+  const newAlert = makeElement({
+    text: "1 ERROR Required input is missing See Errors",
+    matchesAlert: true,
+  });
+  harness.setNow(64_000);
+  harness.dispatchMutation([{ addedNodes: [newAlert] }]);
+  assert.equal(harness.hooks.state().hasError, true, "a newly added validation error must still activate SOS state");
 }
 
 {

--- a/tests/js/local_llm_async_action_harness.mjs
+++ b/tests/js/local_llm_async_action_harness.mjs
@@ -175,7 +175,7 @@ const staleStopCall = fetchCalls.at(-1);
 const newerStopRefresh = api.refreshModels(stopNode);
 const newerStopRefreshCall = fetchCalls.at(-1);
 assert(staleStopCall.options.signal?.aborted === false, "Superseding a Stop must not cancel its backend side effect");
-newerStopRefreshCall.pending.resolve(response({ models: [{ id: "fresh-after-stop" }] }));
+newerStopRefreshCall.pending.resolve(response({ models: [{ id: "qwen3" }] }));
 await newerStopRefresh;
 assert(api.getLocalLLMNodeState(stopNode).status === "1 models found", "The newer Refresh must own state after Stop");
 staleStopCall.pending.resolve(response({ ok: true, message: "late stop response" }));
@@ -189,7 +189,7 @@ const staleUnloadCall = fetchCalls.at(-1);
 const newerUnloadRefresh = api.refreshModels(unloadNode);
 const newerUnloadRefreshCall = fetchCalls.at(-1);
 assert(staleUnloadCall.options.signal?.aborted === false, "Superseding Unload must not cancel its backend side effect");
-newerUnloadRefreshCall.pending.resolve(response({ models: [{ id: "fresh-after-unload" }] }));
+newerUnloadRefreshCall.pending.resolve(response({ models: [{ id: "qwen3" }] }));
 await newerUnloadRefresh;
 assert(api.getLocalLLMNodeState(unloadNode).status === "1 models found", "The newer Refresh must own state after Unload");
 staleUnloadCall.pending.resolve(response({ ok: true, message: "late unload response" }));
@@ -365,5 +365,129 @@ assert(
 queueStopCall.pending.resolve(response({ ok: true, message: "stop completed" }));
 appQueueRequests.at(-1).resolve(true);
 await Promise.all([queueStop, queuedSuccess]);
+
+function configureLMStudioNode(node, model, choices = [model]) {
+    const providerWidget = api.getWidget(node, "provider");
+    const modelWidget = api.getWidget(node, "lm_studio_model");
+    providerWidget.value = "LM Studio";
+    modelWidget.value = model;
+    modelWidget.options = {
+        ...(modelWidget.options || {}),
+        values: [...choices],
+        list: [...choices],
+    };
+    return modelWidget;
+}
+
+const savedLMStudioModel = "google/gemma-4-12b-qat";
+const canonicalSavedValues = [
+    "LM Studio",
+    "qwen3",
+    savedLMStudioModel,
+    "http://127.0.0.1:8000/v1",
+    "custom-model",
+    "",
+    false,
+    1,
+    "fixed",
+    "Unload after run",
+    5,
+    "Auto: unload only before first LLM call",
+    "",
+];
+
+const tabRestoreNode = makeNode(19);
+const tabRestoreModelWidget = configureLMStudioNode(tabRestoreNode, "", [""]);
+api.preserveLocalLLMLoaderSavedComboOptions(tabRestoreNode, canonicalSavedValues);
+api.applyLocalLLMLoaderSavedWidgetValues(tabRestoreNode, canonicalSavedValues);
+assert(
+    tabRestoreModelWidget.value === savedLMStudioModel,
+    "A tab-like configure with cold LM Studio options must preserve the raw saved model id",
+);
+assert(
+    tabRestoreModelWidget.options.values.includes(savedLMStudioModel),
+    "A tab-like configure must keep the raw saved model selectable until a model refresh proves otherwise",
+);
+
+const presentRefreshNode = makeNode(20);
+const presentRefreshWidget = configureLMStudioNode(presentRefreshNode, savedLMStudioModel);
+graph._nodes = [presentRefreshNode];
+const presentRefresh = api.refreshModels(presentRefreshNode);
+fetchCalls.at(-1).pending.resolve(response({
+    models: [
+        { id: savedLMStudioModel },
+        { id: "google/gemma-4-27b-qat" },
+    ],
+}));
+await presentRefresh;
+assert(
+    presentRefreshWidget.value === savedLMStudioModel,
+    "A successful authoritative refresh containing the saved model must keep its raw id selected",
+);
+
+const missingRefreshNode = makeNode(21);
+const missingRefreshWidget = configureLMStudioNode(missingRefreshNode, savedLMStudioModel);
+graph._nodes = [missingRefreshNode];
+const missingRefresh = api.refreshModels(missingRefreshNode);
+fetchCalls.at(-1).pending.resolve(response({ models: [{ id: "google/gemma-4-27b-qat" }] }));
+await missingRefresh;
+assert(
+    missingRefreshWidget.value === `Missing saved model: ${savedLMStudioModel}`,
+    "A successful authoritative refresh omitting the saved model must mark it missing",
+);
+assert(
+    api.getLocalLLMNodeState(missingRefreshNode).status === "saved model not found",
+    "An authoritative missing-model refresh must expose the saved-model-not-found state",
+);
+
+const emptyRefreshNode = makeNode(22);
+const emptyRefreshWidget = configureLMStudioNode(emptyRefreshNode, savedLMStudioModel);
+graph._nodes = [emptyRefreshNode];
+const emptyRefresh = api.refreshModels(emptyRefreshNode);
+fetchCalls.at(-1).pending.resolve(response({ models: [] }));
+await emptyRefresh;
+assert(
+    emptyRefreshWidget.value === `Missing saved model: ${savedLMStudioModel}`,
+    "A successful authoritative empty model list must mark the saved model missing",
+);
+assert(
+    api.getLocalLLMNodeState(emptyRefreshNode).status === "saved model not found",
+    "An authoritative empty model list must expose the saved-model-not-found state",
+);
+
+const failedRefreshNode = makeNode(23);
+const failedRefreshChoices = [savedLMStudioModel, "google/gemma-4-27b-qat"];
+const failedRefreshWidget = configureLMStudioNode(
+    failedRefreshNode,
+    savedLMStudioModel,
+    failedRefreshChoices,
+);
+graph._nodes = [failedRefreshNode];
+const failedRefresh = api.refreshModels(failedRefreshNode);
+fetchCalls.at(-1).pending.reject(new Error("LM Studio temporarily unavailable"));
+await failedRefresh;
+assert(
+    failedRefreshWidget.value === savedLMStudioModel,
+    "A failed refresh must preserve the raw saved model instead of treating failure as proof of absence",
+);
+assert(
+    JSON.stringify(failedRefreshWidget.options.values) === JSON.stringify(failedRefreshChoices) &&
+        JSON.stringify(failedRefreshWidget.options.list) === JSON.stringify(failedRefreshChoices),
+    "A failed refresh must preserve the previous model choices",
+);
+assert(
+    api.getLocalLLMNodeState(failedRefreshNode).status === "model refresh failed",
+    "A failed refresh must report model refresh failed rather than saved model not found",
+);
+
+failedRefreshWidget.value = `Missing saved model: ${savedLMStudioModel}`;
+const serializedMissingModel = api.localLLMLoaderSerializedValuesFromWidgets(
+    failedRefreshNode,
+    canonicalSavedValues,
+);
+assert(
+    serializedMissingModel[2] === savedLMStudioModel,
+    "Workflow serialization must store the raw model id instead of the Missing display prefix",
+);
 
 console.log("local_llm_async_action_harness: ok");

--- a/tests/js/local_llm_preset_storage_harness.mjs
+++ b/tests/js/local_llm_preset_storage_harness.mjs
@@ -194,4 +194,51 @@ const secondMerge = hooks.mergeSystemPromptPresetLists(JSON.parse(importApi.file
 assert.equal(secondMerge.importedCount, 0, "the unchanged browser backup must not be imported twice");
 assert.equal(localStorageWrites, 0, "durable save/delete/import must leave browser storage untouched");
 
+const describe = (text, presets = [], status = "ready") =>
+    JSON.parse(JSON.stringify(hooks.describeSystemPromptPreset(text, presets, status)));
+assert.equal(describe("   \n\t").label, "Empty", "whitespace-only prompts are execution-equivalent to Empty");
+const promptOnly = JSON.parse(JSON.stringify(hooks.BUILTIN_SYSTEM_PROMPT_PRESETS)).find(
+    (preset) => preset.id === "prompt_only",
+);
+assert.equal(describe(promptOnly.text).label, "Prompt Only", "built-in presets must be identified without durable data");
+const testPreset = { id: "user_test", label: "Test", text: "line one\nline two" };
+assert.equal(describe("line one\r\nline two", [testPreset]).label, "Test", "CRLF and LF must compare equally");
+assert.equal(describe(" line one\nline two", [testPreset]).label, "Custom", "meaningful surrounding whitespace must not be normalized away");
+assert.equal(describe("unmatched", [], "loading").label, "Checking...", "unknown text must not be called Custom before durable presets load");
+assert.equal(
+    describe(testPreset.text, [testPreset, { id: "user_test_copy", label: "Test Copy", text: testPreset.text }]).label,
+    "2 matches",
+    "duplicate exact preset bodies must not claim one arbitrary active name",
+);
+assert.equal(describe("unmatched", [], "error").label, "Custom", "preset-read failure must leave prompt use available as Custom");
+
+hooks.systemPromptPresetPageCache.status = "idle";
+hooks.systemPromptPresetPageCache.presets = [];
+hooks.systemPromptPresetPageCache.promise = null;
+hooks.systemPromptPresetPageCache.readStatus = "idle";
+hooks.systemPromptPresetPageCache.error = "";
+let pageCacheReads = 0;
+let resolvePageCacheRead;
+context.api.getUserData = async () => {
+    pageCacheReads += 1;
+    return await new Promise((resolve) => {
+        resolvePageCacheRead = resolve;
+    });
+};
+context.api.storeUserData = async () => jsonResponse({}, 200);
+const firstPageCacheLoad = hooks.loadSystemPromptPresetPageCache();
+const secondPageCacheLoad = hooks.loadSystemPromptPresetPageCache();
+assert.equal(pageCacheReads, 1, "concurrent Local LLM nodes must share one durable preset read");
+resolvePageCacheRead(jsonResponse({ version: 1, presets: [testPreset] }, 200));
+const [firstPageCacheResult, secondPageCacheResult] = await Promise.all([firstPageCacheLoad, secondPageCacheLoad]);
+assert.deepEqual(JSON.parse(JSON.stringify(firstPageCacheResult.presets)), [testPreset]);
+assert.deepEqual(JSON.parse(JSON.stringify(secondPageCacheResult.presets)), [testPreset]);
+assert.equal(hooks.systemPromptPresetPageCache.status, "ready");
+assert.equal(hooks.describeSystemPromptPreset(testPreset.text).label, "Test", "canvas status must use the loaded page cache");
+
+hooks.setSystemPromptPresetPageCache([{ ...testPreset, label: "Renamed Test" }]);
+assert.equal(hooks.describeSystemPromptPreset(testPreset.text).label, "Renamed Test", "verified preset renames must update applied status immediately");
+hooks.setSystemPromptPresetPageCache([]);
+assert.equal(hooks.describeSystemPromptPreset(testPreset.text).label, "Custom", "deleting a preset must preserve node text and reclassify it as Custom");
+
 console.log("local_llm_preset_storage_harness: ok");

--- a/tests/test_floating_tools.py
+++ b/tests/test_floating_tools.py
@@ -133,7 +133,9 @@ def test_floating_tools_sos_surface_is_simple_and_read_only():
     assert "let sosQueueIdleConfirmBusy = false;" in script
     assert "let sosErrorGeneration = 0;" in script
     assert "function markSosErrorSticky()" in script
-    assert "function noteSosRunStartedAfterError()" in script
+    assert "function noteSosRunStartedAfterError(detail = {})" in script
+    assert "function handleSosExecutionSuccess(detail = {})" in script
+    assert "function handleSosExecutionInterrupted(detail = {})" in script
     assert "function noteSosQueueStateAfterError(isBusy, options = {})" in script
     assert "async function confirmSosQueueIdleForClear()" in script
     assert "hasSosQueueIdleClearCandidate()" in script
@@ -149,6 +151,7 @@ def test_floating_tools_sos_surface_is_simple_and_read_only():
     assert "if (!force && lastExecutionError && Date.now() < sosErrorStickyUntil)" in script
     assert "clearExecutionErrorState({ force: true });" in script
     assert 'api?.addEventListener?.("execution_success"' in script
+    assert 'api?.addEventListener?.("execution_interrupted"' in script
     assert 'api?.addEventListener?.("status"' in script
     assert "if (!lastExecutionError) {" in script
     assert "function safeEventScalar(value, maxLength = 900)" in script
@@ -171,7 +174,8 @@ def test_floating_tools_sos_surface_is_simple_and_read_only():
     assert "See Errors" in script
     assert "function limitedSosText(value, maxLength = SOS_TEXT_SCAN_LIMIT)" in script
     assert "function promptFailureElementFromNode(node)" in script
-    assert "function schedulePromptFailureAlertInspection()" in script
+    assert "function schedulePromptFailureAlertInspection(elements = [])" in script
+    assert "document.querySelectorAll(PROMPT_FAILURE_ALERT_SELECTOR)" not in script
     assert "node.innerText" not in script
     assert "characterData: true" not in script
     assert "history_errors: compactHistoryErrors(history)" in script

--- a/tests/test_image_resize_node.py
+++ b/tests/test_image_resize_node.py
@@ -3676,6 +3676,7 @@ def test_local_llm_refiner_declares_batch_prompt_contract_and_frontend_preview()
     assert node_cls.RETURN_NAMES == ("result",)
     assert node_cls.CATEGORY == "Deno/LLM"
     assert node_cls.IS_CHANGED(seed_mode=["fixed"], seed=[1], prompt=["same"]) == node_cls.IS_CHANGED(seed_mode=["fixed"], seed=[1], prompt=["same"])
+    assert node_cls.IS_CHANGED(seed_mode=["fixed"], seed=[1], prompt=["same"], video_seconds=[8.0]) != node_cls.IS_CHANGED(seed_mode=["fixed"], seed=[1], prompt=["same"], video_seconds=[9.0])
     assert "help rewrite or review prompt text" in node_cls.DESCRIPTION
     assert "Ollama, LM Studio, llama.cpp, vLLM, Custom, or llama-swap" in node_cls.DESCRIPTION
     assert "An optional IMAGE input" in node_cls.DESCRIPTION
@@ -3710,6 +3711,11 @@ def test_local_llm_refiner_declares_batch_prompt_contract_and_frontend_preview()
     ]
     assert required["comfy_vram_policy"][1]["default"] == "Auto: unload only before first LLM call"
     assert optional["image"][0] == "IMAGE"
+    assert list(optional) == ["image", "video_seconds"]
+    assert optional["video_seconds"][0] == "FLOAT"
+    assert optional["video_seconds"][1]["forceInput"] is True
+    assert optional["video_seconds"][1]["default"] == 0.0
+    assert "duration sentence" in optional["video_seconds"][1]["tooltip"]
     assert "user_prompt" not in optional
     assert "audio" not in optional
     assert list(hidden) == ["unique_id"]
@@ -3844,7 +3850,9 @@ def test_local_llm_refiner_declares_batch_prompt_contract_and_frontend_preview()
     assert '"lm_studio_model",' in script
     assert '"prompt"' not in loader_socket_block
     assert '"Prompt"' not in loader_socket_block
+    assert '"video_seconds"' not in loader_socket_block
     assert "normalizeLoaderPromptInputSocket" in script
+    assert "ensureLoaderVideoSecondsInputSocket" in script
     assert "setPromptInputSocketFields" in script
     assert "const PROMPT_WIDGET_SIDE_INSET = 0;" in script
     assert "removeLoaderWidgetInputSockets" in script
@@ -3872,6 +3880,11 @@ def test_local_llm_refiner_declares_batch_prompt_contract_and_frontend_preview()
     assert "PROMPT_ONLY_SYSTEM_PROMPT" in script
     assert "DENO_FINAL_PROMPT:" in script
     assert "Reviewer JSON" in script
+    assert "describeSystemPromptPreset" in script
+    assert "Applied to node:" in script
+    assert "Editor:" in script
+    assert 'label: "Checking..."' in script
+    assert 'label: "Custom"' in script
     assert "Return only valid JSON. Do not write markdown." in script
     assert "SYSTEM_PROMPT_PRESET_USERDATA_FILE" in script
     assert "apiClient.getUserData" in script
@@ -4094,6 +4107,7 @@ def test_local_llm_refiner_processes_prompt_batch_in_one_node_call():
 
     node._run_single = fake_run_single
 
+    original_prompts = ["first prompt", "second prompt", "third prompt"]
     output = node.refine(
         provider=["Ollama"],
         ollama_model=["qwen3"],
@@ -4101,7 +4115,8 @@ def test_local_llm_refiner_processes_prompt_batch_in_one_node_call():
         custom_server_url=["http://127.0.0.1:8000/v1"],
         custom_model=["custom-model"],
         system_prompt=["make a prompt"],
-        prompt=["first prompt", "second prompt", "third prompt"],
+        prompt=original_prompts,
+        video_seconds=[8.0],
         thinking=[True],
         seed=[10],
         seed_mode=["fixed"],
@@ -4118,6 +4133,32 @@ def test_local_llm_refiner_processes_prompt_batch_in_one_node_call():
     assert all(call["provider"] == "Ollama" for call in calls)
     assert all(call["server_url"] == "http://127.0.0.1:11434" for call in calls)
     assert all(call["model"] == "qwen3" for call in calls)
+    assert [call["prompt"] for call in calls] == [
+        "first prompt\n\nThis is an 8-second video.",
+        "second prompt\n\nThis is an 8-second video.",
+        "third prompt\n\nThis is an 8-second video.",
+    ]
+    assert original_prompts == ["first prompt", "second prompt", "third prompt"]
+
+
+@pytest.mark.parametrize("video_seconds", [None, [], 0, -1, float("nan"), float("inf"), "bad"])
+def test_local_llm_video_seconds_invalid_or_inactive_values_leave_prompt_unchanged(video_seconds):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+
+    assert module._append_video_duration_to_prompt("keep this exact", video_seconds) == "keep this exact"
+
+
+def test_local_llm_video_seconds_formats_fractional_duration_without_mutating_prompt():
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+
+    prompt = "A slow camera move.  "
+    assert module._append_video_duration_to_prompt(prompt, [8.5]) == (
+        "A slow camera move.\n\nThis is an 8.5-second video."
+    )
+    assert prompt == "A slow camera move.  "
+    assert module._append_video_duration_to_prompt("", [1.0]) == "This is a 1-second video."
 
 
 def test_local_llm_refiner_passes_image_attachments_to_reviewer_call():

--- a/tests/test_local_llm_reviewer_graph_transform.py
+++ b/tests/test_local_llm_reviewer_graph_transform.py
@@ -366,6 +366,19 @@ def test_reviewer_graph_transform_submit_modes(tmp_path):
             assert(configuredLoader.onSerialize(serializedInfo) === "serialized", "Loader serialize wrapper must preserve the original serialize result");
             assert(serializedInfo.widgets_values.length === 13, "Loader serialize must remove generated buttons and keep canonical widget count");
             assert(serializedInfo.properties.deno_local_llm_state.answer === "workflow answer", "Loader serialize must include saved result state in properties");
+            const legacyInputNode = {{
+                inputs: [
+                    {{ name: "image", label: "image", type: "IMAGE", link: 501 }},
+                    {{ name: "prompt", label: "prompt", type: "STRING", link: 502 }},
+                ],
+                graph,
+                setDirtyCanvas() {{}},
+            }};
+            assert(api.ensureLoaderVideoSecondsInputSocket(legacyInputNode) === true, "Old Loader workflows must gain the new video seconds socket");
+            assert(legacyInputNode.inputs.length === 3, "Adding video seconds must not replace an existing image or prompt socket");
+            assert(legacyInputNode.inputs[0].link === 501 && legacyInputNode.inputs[1].link === 502, "Adding video seconds must preserve existing socket links and order");
+            assert(legacyInputNode.inputs[2].name === "video_seconds" && legacyInputNode.inputs[2].type === "FLOAT", "Video seconds must be appended as a FLOAT socket on old workflows");
+            assert(api.ensureLoaderVideoSecondsInputSocket(legacyInputNode) === false, "Video seconds migration must be idempotent");
             const modelChoices = api.modelChoiceValuesWithSavedValue(
                 [{{ id: "google/gemma-4-e4b" }}, {{ id: "google/gemma-4-12b" }}],
                 "codex/missing-saved-lm-studio-model"
@@ -382,12 +395,12 @@ def test_reviewer_graph_transform_submit_modes(tmp_path):
             api.preserveLocalLLMLoaderSavedComboOptions(comboNode, normalizedLoaderValues);
             assert(
                 comboNode.widgets[2].options.values[0] === "codex/missing-saved-lm-studio-model",
-                "Loader configure must add saved missing LM Studio model before combo restore can replace it"
+                "Loader configure must add an unknown saved LM Studio model before the cold combo restore runs"
             );
             api.applyLocalLLMLoaderSavedWidgetValues(comboNode, normalizedLoaderValues);
             assert(
-                comboNode.widgets[2].value === "Missing saved model: codex/missing-saved-lm-studio-model",
-                "After configure, the visible combo value must clearly say the saved model is missing on this PC"
+                comboNode.widgets[2].value === "codex/missing-saved-lm-studio-model",
+                "Configure must preserve an unknown saved LM Studio model without treating cold combo options as proof that it is missing"
             );
             const savedExistingComboNode = {{
                 widgets: [

--- a/web/js/deno_floating_tools.js
+++ b/web/js/deno_floating_tools.js
@@ -62,6 +62,11 @@ let sosToastHookTimer = null;
 let sosValidationScanScheduled = false;
 let sosQueueIdleConfirmBusy = false;
 let sosErrorGeneration = 0;
+let sosRunClearGeneration = 0;
+let sosRunClearPromptId = "";
+let sosQueueBusyGeneration = 0;
+let sosStateRevision = 0;
+const sosPendingValidationElements = new Map();
 
 const PROMPT_FAILURE_ALERT_SELECTORS = [
     "[role='alert']",
@@ -786,15 +791,50 @@ function markSosErrorSticky() {
 function resetSosClearCandidate() {
     sosRunClearCandidate = false;
     sosQueueWasBusyAfterError = false;
+    sosRunClearGeneration = 0;
+    sosRunClearPromptId = "";
+    sosQueueBusyGeneration = 0;
 }
 
-function noteSosRunStartedAfterError() {
+function sosPromptIdFromEventDetail(detail) {
+    return safeEventScalar(detail?.prompt_id ?? detail?.promptId);
+}
+
+function noteSosRunStartedAfterError(detail = {}) {
     if (!lastExecutionError) return;
     sosRunClearCandidate = true;
+    sosRunClearGeneration = sosErrorGeneration;
+    sosRunClearPromptId = sosPromptIdFromEventDetail(detail);
 }
 
 function hasSosQueueIdleClearCandidate() {
-    return Boolean(lastExecutionError && (sosRunClearCandidate || sosQueueWasBusyAfterError));
+    if (!lastExecutionError) return false;
+    const startedRunMatches = sosRunClearCandidate && sosRunClearGeneration === sosErrorGeneration;
+    const busyRunMatches = sosQueueWasBusyAfterError && sosQueueBusyGeneration === sosErrorGeneration;
+    return Boolean(startedRunMatches || busyRunMatches);
+}
+
+function sosCompletionMatchesClearCandidate(detail = {}) {
+    if (!lastExecutionError || !sosRunClearCandidate || sosRunClearGeneration !== sosErrorGeneration) return false;
+    const completedPromptId = sosPromptIdFromEventDetail(detail);
+    if (sosRunClearPromptId || completedPromptId) {
+        return Boolean(sosRunClearPromptId && completedPromptId && sosRunClearPromptId === completedPromptId);
+    }
+    return true;
+}
+
+function handleSosExecutionSuccess(detail = {}) {
+    if (!sosCompletionMatchesClearCandidate(detail)) return false;
+    return clearExecutionErrorState({ force: true, expectedGeneration: sosRunClearGeneration });
+}
+
+function handleSosExecutionInterrupted(detail = {}) {
+    if (!sosRunClearCandidate || sosRunClearGeneration !== sosErrorGeneration) return false;
+    const interruptedPromptId = sosPromptIdFromEventDetail(detail);
+    if (sosRunClearPromptId && interruptedPromptId && sosRunClearPromptId !== interruptedPromptId) return false;
+    resetSosClearCandidate();
+    applySosIconState();
+    return true;
 }
 
 async function confirmSosQueueIdleForClear() {
@@ -821,12 +861,13 @@ function noteSosQueueStateAfterError(isBusy, options = {}) {
     if (isBusy) {
         if (Date.now() - sosLastErrorAt >= SOS_QUEUE_BUSY_RETRY_GRACE_MS) {
             sosQueueWasBusyAfterError = true;
+            sosQueueBusyGeneration = sosErrorGeneration;
         }
         return;
     }
     if (!hasSosQueueIdleClearCandidate()) return;
     if (options?.confirmedIdle === true) {
-        clearExecutionErrorState({ force: true });
+        clearExecutionErrorState({ force: true, expectedGeneration: sosErrorGeneration });
         return;
     }
     void confirmSosQueueIdleForClear();
@@ -846,6 +887,7 @@ function handleSosStatusEvent(detail) {
 }
 
 function rememberExecutionError(detail) {
+    sosStateRevision += 1;
     sosErrorGeneration += 1;
     lastExecutionError = compactExecutionError(detail);
     lastExecutionError.received_at = new Date().toISOString();
@@ -856,6 +898,7 @@ function rememberExecutionError(detail) {
 }
 
 function rememberPromptFailure(error) {
+    sosStateRevision += 1;
     sosErrorGeneration += 1;
     lastExecutionError = compactPromptFailure(error);
     resetSosClearCandidate();
@@ -968,10 +1011,13 @@ function scheduleSosToastHooks() {
 
 function clearExecutionErrorState(options = {}) {
     const force = options === true || options?.force === true;
+    const expectedGeneration = Number(options?.expectedGeneration);
+    if (Number.isFinite(expectedGeneration) && expectedGeneration !== sosErrorGeneration) return false;
     if (!force && lastExecutionError && Date.now() < sosErrorStickyUntil) {
         applySosIconState();
         return false;
     }
+    sosStateRevision += 1;
     lastExecutionError = null;
     sosErrorStickyUntil = 0;
     sosLastErrorAt = 0;
@@ -1055,20 +1101,29 @@ function promptFailureTextFromNode(node) {
     return element ? limitedSosText(element.textContent) : "";
 }
 
-function inspectPromptFailureAlerts() {
-    const elements = Array.from(document.querySelectorAll(PROMPT_FAILURE_ALERT_SELECTOR)).slice(-20);
+function inspectPromptFailureAlerts(elements = []) {
     for (const element of elements) {
         if (rememberFrontendPromptFailure(promptFailureTextFromNode(element))) return true;
     }
     return false;
 }
 
-function schedulePromptFailureAlertInspection() {
+function schedulePromptFailureAlertInspection(elements = []) {
+    for (const element of elements) {
+        const candidate = promptFailureElementFromNode(element);
+        if (candidate) sosPendingValidationElements.set(candidate, sosStateRevision);
+    }
+    if (!sosPendingValidationElements.size) return;
     if (sosValidationScanScheduled) return;
     sosValidationScanScheduled = true;
     const inspect = () => {
         sosValidationScanScheduled = false;
-        inspectPromptFailureAlerts();
+        const candidates = Array.from(sosPendingValidationElements.entries())
+            .filter(([, revision]) => revision === sosStateRevision)
+            .map(([element]) => element)
+            .slice(-20);
+        sosPendingValidationElements.clear();
+        inspectPromptFailureAlerts(candidates);
     };
     if (typeof window.requestAnimationFrame === "function") window.requestAnimationFrame(inspect);
     else window.setTimeout(inspect, 0);
@@ -1077,12 +1132,16 @@ function schedulePromptFailureAlertInspection() {
 function installSosValidationObserver() {
     if (sosValidationObserver || typeof MutationObserver !== "function" || !document?.body) return;
     sosValidationObserver = new MutationObserver((mutations) => {
+        const pendingCandidates = [];
         for (const mutation of mutations) {
             for (const node of mutation.addedNodes || []) {
-                if (rememberFrontendPromptFailure(promptFailureTextFromNode(node))) return;
+                const candidate = promptFailureElementFromNode(node);
+                if (!candidate) continue;
+                if (rememberFrontendPromptFailure(promptFailureTextFromNode(candidate))) return;
+                pendingCandidates.push(candidate);
             }
         }
-        schedulePromptFailureAlertInspection();
+        schedulePromptFailureAlertInspection(pendingCandidates);
     });
     sosValidationObserver.observe(document.body, {
         childList: true,
@@ -1815,12 +1874,14 @@ function installSosEventListeners() {
     api?.addEventListener?.("execution_error", (event) => {
         rememberExecutionError(event?.detail || {});
     });
-    api?.addEventListener?.("execution_start", () => {
-        noteSosRunStartedAfterError();
+    api?.addEventListener?.("execution_start", (event) => {
+        noteSosRunStartedAfterError(event?.detail || {});
     });
-    api?.addEventListener?.("execution_success", () => {
-        noteSosRunStartedAfterError();
-        clearExecutionErrorState({ force: true });
+    api?.addEventListener?.("execution_success", (event) => {
+        handleSosExecutionSuccess(event?.detail || {});
+    });
+    api?.addEventListener?.("execution_interrupted", (event) => {
+        handleSosExecutionInterrupted(event?.detail || {});
     });
     api?.addEventListener?.("status", (event) => {
         handleSosStatusEvent(event?.detail || {});

--- a/web/js/deno_local_llm_refiner.js
+++ b/web/js/deno_local_llm_refiner.js
@@ -236,6 +236,13 @@ const BUILTIN_SYSTEM_PROMPT_PRESETS = Object.freeze([
         text: REVIEWER_JSON_SYSTEM_PROMPT,
     },
 ]);
+const systemPromptPresetPageCache = {
+    status: "idle",
+    presets: [],
+    promise: null,
+    readStatus: "idle",
+    error: "",
+};
 const REVIEWER_HOW_TO_USE_SECTIONS = Object.freeze([
     {
         title: "What this node does",
@@ -1160,7 +1167,13 @@ function normalizeLocalLLMLoaderSerializedValues(values) {
         generatedButtonStart = findLocalLLMGeneratedButtonRunStart(normalized);
     }
     normalized = normalizeLocalLLMLoaderGeneratedPickerValues(normalized);
-    return normalized.slice(0, LOADER_SERIALIZED_WIDGET_COUNT);
+    normalized = normalized.slice(0, LOADER_SERIALIZED_WIDGET_COUNT);
+    for (const modelIndex of [1, 2]) {
+        if (modelIndex < normalized.length) {
+            normalized[modelIndex] = originalModelValueFromDisplay(normalized[modelIndex]);
+        }
+    }
+    return normalized;
 }
 
 function normalizeLocalLLMLoaderGeneratedPickerValues(values) {
@@ -1199,7 +1212,9 @@ function localLLMLoaderSerializedValuesFromWidgets(node, fallbackValues) {
         const widget = getWidget(node, name);
         if (widget) {
             foundNamedWidget = true;
-            return widget.value;
+            return name === "ollama_model" || name === "lm_studio_model"
+                ? originalModelValueFromDisplay(widget.value)
+                : widget.value;
         }
         return index < fallback.length ? fallback[index] : "";
     });
@@ -1330,6 +1345,10 @@ function displayModelValueForCurrentChoices(widget, value) {
     const original = originalModelValueFromDisplay(value);
     if (!hasUsableSavedModelValue(original)) {
         return "";
+    }
+    if (widget?.__denoLocalLLMModelChoicesAuthoritative !== true) {
+        preserveWidgetOption(widget, original);
+        return original;
     }
     if (currentModelChoiceIds(widget).includes(original)) {
         return original;
@@ -2128,7 +2147,10 @@ if (typeof globalThis !== "undefined" && typeof globalThis.__DENO_LOCAL_LLM_REVI
         setLocalLLMNodeState,
         setupNode,
         applyLocalLLMLoaderSavedWidgetValues,
+        displayModelValueForCurrentChoices,
         getWidget,
+        ensureLoaderVideoSecondsInputSocket,
+        localLLMLoaderSerializedValuesFromWidgets,
         preserveLocalLLMLoaderSavedComboOptions,
         preserveWidgetOption,
         migrateLocalLLMPromptInputNames,
@@ -2170,6 +2192,8 @@ if (typeof globalThis !== "undefined" && typeof globalThis.__DENO_LOCAL_LLM_REVI
         setReviewerSeedTarget,
         splitPreviewLinesForWidth,
         durableSystemPromptPresetApiAvailable,
+        describeSystemPromptPreset,
+        loadSystemPromptPresetPageCache,
         makeSystemPromptPresetEnvelope,
         mergeSystemPromptPresetLists,
         normalizeSystemPromptPresetEnvelope,
@@ -2177,10 +2201,14 @@ if (typeof globalThis !== "undefined" && typeof globalThis.__DENO_LOCAL_LLM_REVI
         readDurableSystemPromptUserPresets,
         readLegacySystemPromptUserPresetState,
         readSystemPromptUserPresets,
+        setSystemPromptPresetPageCache,
+        systemPromptPresetPageCache,
         writeDurableSystemPromptUserPresets,
+        updateModelChoices,
         refreshModels,
         stopLocalModel,
         unloadLocalModel,
+        BUILTIN_SYSTEM_PROMPT_PRESETS,
         SYSTEM_PROMPT_PRESET_STORAGE_KEY,
         SYSTEM_PROMPT_PRESET_USERDATA_FILE,
         SYSTEM_PROMPT_PRESET_MAX_FILE_BYTES,
@@ -2784,6 +2812,7 @@ function setupNode(node) {
         ensurePromptWidget(node);
         removePromptWidgets(node);
         normalizeLoaderPromptInputSocket(node);
+        ensureLoaderVideoSecondsInputSocket(node);
         removeLoaderWidgetInputSockets(node);
         ensureSeedModeWidget(node);
         migrateLegacyModelWidgets(node);
@@ -4077,6 +4106,7 @@ function schedulePostSetupCleanup(node) {
         ensurePromptWidget(node);
         removePromptWidgets(node);
         normalizeLoaderPromptInputSocket(node);
+        ensureLoaderVideoSecondsInputSocket(node);
         removeLoaderWidgetInputSockets(node);
         ensureProviderWidgets(node);
         migrateLegacyModelWidgets(node);
@@ -4297,6 +4327,33 @@ function setPromptInputSocketFields(input) {
     input.type = "STRING";
 }
 
+function ensureLoaderVideoSecondsInputSocket(node) {
+    if (!Array.isArray(node?.inputs)) {
+        return false;
+    }
+    let input = node.inputs.find((candidate) =>
+        loaderSocketIdentifiers(candidate).some((identifier) => identifier === "video_seconds" || identifier === "video seconds"),
+    );
+    if (input) {
+        input.name = "video_seconds";
+        input.localized_name = "video seconds";
+        input.label = "video seconds";
+        input.type = "FLOAT";
+        return false;
+    }
+    input = {
+        name: "video_seconds",
+        localized_name: "video seconds",
+        label: "video seconds",
+        type: "FLOAT",
+        link: null,
+    };
+    node.inputs.push(input);
+    node.inputs.forEach((candidate, index) => updateInputLinkSlots(node, asInputLinkList(candidate), index));
+    markGraphDirty(node);
+    return true;
+}
+
 function removeLoaderWidgetInputSockets(node) {
     if (!Array.isArray(node?.inputs)) {
         return false;
@@ -4480,6 +4537,9 @@ function addSystemPromptButton(node) {
     if (!systemWidget) {
         return;
     }
+    void loadSystemPromptPresetPageCache().catch(() => {
+        // Preset storage errors never block prompt editing or execution.
+    });
     ensureSingleSystemPromptButton(node);
     if (getWidget(node, `${GENERATED_PREFIX}system_prompt_button`)) {
         return;
@@ -4492,8 +4552,9 @@ function addSystemPromptButton(node) {
         callback: () => openSystemPromptDialog(node),
         computeSize: (width) => [width, LiteGraph.NODE_WIDGET_HEIGHT],
         draw: (ctx, nodeRef, width, y, height) => {
-            const prompt = String(getWidget(nodeRef, "system_prompt")?.value || "").trim();
-            drawWideButtonWithStatus(ctx, 15, y, width - 30, height, "System Prompt", prompt ? "set" : "empty", false);
+            const prompt = String(getWidget(nodeRef, "system_prompt")?.value || "");
+            const status = describeSystemPromptPreset(prompt);
+            drawWideButtonWithStatus(ctx, 15, y, width - 30, height, "System Prompt", status.label, status.kind, false);
         },
         mouse: (event, pos, nodeRef) => {
             if (event.type === "pointerdown") {
@@ -4965,6 +5026,7 @@ function polishWidgetLabels(node) {
 function polishInputLabels(node) {
     const labels = {
         image: "image",
+        video_seconds: "video seconds",
     };
     for (const input of node.inputs || []) {
         if (labels[input.name]) {
@@ -5760,7 +5822,6 @@ async function refreshModels(node) {
         }
         const savedModelMissing =
             hasUsableSavedModelValue(savedModel) &&
-            choices.length > 0 &&
             !savedModelStillExists &&
             isMissingSavedModelDisplayValue(modelWidget?.value);
         setLocalLLMNodeState(node, {
@@ -5778,18 +5839,12 @@ async function refreshModels(node) {
         if (!isLocalLLMAsyncActionCurrent(node, action)) {
             return;
         }
-        updateModelChoices(node, provider, []);
-        if (!OPENAI_COMPATIBLE_PROVIDERS.has(provider) && modelWidget && hasUsableSavedModelValue(savedModel)) {
-            modelWidget.value = missingSavedModelDisplayValue(savedModel);
-        }
         setLocalLLMNodeState(node, {
-            status: !OPENAI_COMPATIBLE_PROVIDERS.has(provider) && hasUsableSavedModelValue(savedModel) ? "saved model not found" : "model refresh failed",
+            status: "model refresh failed",
             provider,
             model: String(modelWidget?.value || ""),
             answer: "",
-            thinking: !OPENAI_COMPATIBLE_PROVIDERS.has(provider) && hasUsableSavedModelValue(savedModel)
-                ? `Saved ${provider} model "${savedModel}" could not be verified on this PC. ${String(error?.message || error)}`
-                : String(error?.message || error),
+            thinking: `The current model selection was kept because the ${provider} model list could not be verified. ${String(error?.message || error)}`,
         });
     } finally {
         if (finishLocalLLMAsyncAction(node, action)) {
@@ -5826,6 +5881,7 @@ function updateModelChoices(node, provider, choices) {
     const widget = getWidget(node, activeModelNameForProvider(providerKey));
     if (widget) {
         widget.__denoLocalLLMPreservedSavedModels = new Set();
+        widget.__denoLocalLLMModelChoicesAuthoritative = true;
     }
     if (OPENAI_COMPATIBLE_PROVIDERS.has(providerKey)) {
         if (widget && Array.isArray(choices) && choices.length && !hasUsableSavedModelValue(widget.value)) {
@@ -5840,9 +5896,9 @@ function updateModelChoices(node, provider, choices) {
         widget.options = widget.options || {};
         widget.options.values = values;
         widget.options.list = values;
-        if (!hasUsableSavedModelValue(widget.value)) {
-            widget.value = firstValidWidgetChoice(widget);
-        }
+        widget.value = hasUsableSavedModelValue(savedValue)
+            ? values[0]
+            : firstValidWidgetChoice(widget);
     } else if (widget && hasUsableSavedModelValue(widget.value)) {
         const display = missingSavedModelDisplayValue(widget.value);
         widget.options = widget.options || {};
@@ -5941,6 +5997,7 @@ function refreshNode(node) {
         ensurePromptWidget(node);
         removePromptWidgets(node);
         normalizeLoaderPromptInputSocket(node);
+        ensureLoaderVideoSecondsInputSocket(node);
         removeLoaderWidgetInputSockets(node);
         ensureSeedModeWidget(node);
         setActiveProviderModelVisibility(node);
@@ -6351,14 +6408,19 @@ function drawWideButton(ctx, x, y, width, height, label, pressed) {
     ctx.restore();
 }
 
-function drawWideButtonWithStatus(ctx, x, y, width, height, label, status, pressed) {
+function drawWideButtonWithStatus(ctx, x, y, width, height, label, status, statusKind, pressed) {
     drawWideButton(ctx, x, y, width, height, label, pressed);
     ctx.save();
-    ctx.fillStyle = status === "set" ? "#9dffba" : "#9aa0a6";
+    ctx.fillStyle = statusKind === "preset"
+        ? "#9dffba"
+        : statusKind === "custom" || statusKind === "multiple"
+          ? "#f2c879"
+          : "#9aa0a6";
     ctx.textAlign = "right";
     ctx.textBaseline = "middle";
     ctx.font = "700 10px sans-serif";
-    ctx.fillText(status, x + width - 12, y + height / 2 + (pressed ? 1 : 0));
+    const availableWidth = Math.max(36, Math.min(150, width * 0.36));
+    ctx.fillText(fitString(ctx, status, availableWidth), x + width - 12, y + height / 2 + (pressed ? 1 : 0));
     ctx.restore();
 }
 
@@ -6590,6 +6652,105 @@ function systemPromptPresetEntries(userPresets) {
     ];
 }
 
+function normalizeSystemPromptComparisonText(value) {
+    return String(value ?? "").replace(/\r\n?/g, "\n");
+}
+
+function describeSystemPromptPreset(value, userPresets = systemPromptPresetPageCache.presets, cacheStatus = systemPromptPresetPageCache.status) {
+    const text = normalizeSystemPromptComparisonText(value);
+    if (!text.trim()) {
+        return { kind: "empty", label: "Empty", matches: [] };
+    }
+    const matches = systemPromptPresetEntries(userPresets).filter(
+        (preset) => normalizeSystemPromptComparisonText(preset.text) === text,
+    );
+    if (matches.length === 1) {
+        return { kind: "preset", label: matches[0].label, matches };
+    }
+    if (matches.length > 1) {
+        return { kind: "multiple", label: `${matches.length} matches`, matches };
+    }
+    if (cacheStatus === "idle" || cacheStatus === "loading") {
+        return { kind: "loading", label: "Checking...", matches: [] };
+    }
+    return { kind: "custom", label: "Custom", matches: [] };
+}
+
+function refreshSystemPromptPresetStatusNodes() {
+    const seen = new Set();
+    for (const graph of localLLMCandidateGraphs()) {
+        for (const node of localLLMGraphNodes(graph)) {
+            if (node?.type !== NODE_NAME || seen.has(node)) {
+                continue;
+            }
+            seen.add(node);
+            markGraphDirty(node);
+        }
+    }
+}
+
+function setSystemPromptPresetPageCache(presets, options = {}) {
+    const normalized = normalizeSystemPromptPresetList(Array.isArray(presets) ? presets : []).presets;
+    systemPromptPresetPageCache.presets = normalized;
+    systemPromptPresetPageCache.status = String(options.status || "ready");
+    systemPromptPresetPageCache.readStatus = String(options.readStatus || "loaded");
+    systemPromptPresetPageCache.error = String(options.error || "");
+    refreshSystemPromptPresetStatusNodes();
+    return normalized;
+}
+
+async function loadSystemPromptPresetPageCache(options = {}) {
+    const force = options?.force === true;
+    if (!force && systemPromptPresetPageCache.status === "ready") {
+        return {
+            status: systemPromptPresetPageCache.readStatus,
+            presets: systemPromptPresetPageCache.presets,
+        };
+    }
+    if (!force && systemPromptPresetPageCache.status === "error") {
+        if (systemPromptPresetPageCache.readStatus === "unavailable") {
+            return { status: "unavailable", presets: [] };
+        }
+        throw new Error(systemPromptPresetPageCache.error || "Could not load ComfyUI user presets.");
+    }
+    if (!force && systemPromptPresetPageCache.promise) {
+        return systemPromptPresetPageCache.promise;
+    }
+    if (!durableSystemPromptPresetApiAvailable()) {
+        setSystemPromptPresetPageCache([], { status: "error", readStatus: "unavailable" });
+        return { status: "unavailable", presets: [] };
+    }
+    systemPromptPresetPageCache.status = "loading";
+    systemPromptPresetPageCache.error = "";
+    refreshSystemPromptPresetStatusNodes();
+    const request = (async () => {
+        try {
+            const result = await readDurableSystemPromptUserPresets();
+            setSystemPromptPresetPageCache(result.presets, {
+                status: "ready",
+                readStatus: result.status,
+            });
+            return {
+                status: result.status,
+                presets: systemPromptPresetPageCache.presets,
+            };
+        } catch (error) {
+            setSystemPromptPresetPageCache([], {
+                status: "error",
+                readStatus: "error",
+                error: String(error?.message || error),
+            });
+            throw error;
+        } finally {
+            if (systemPromptPresetPageCache.promise === request) {
+                systemPromptPresetPageCache.promise = null;
+            }
+        }
+    })();
+    systemPromptPresetPageCache.promise = request;
+    return request;
+}
+
 function populateSystemPromptPresetSelect(select, userPresets, selectedValue) {
     if (!select) {
         return null;
@@ -6668,19 +6829,32 @@ function openSystemPromptDialog(node) {
 
     const header = document.createElement("div");
     header.style.cssText = "display:flex;align-items:center;justify-content:space-between;gap:16px;";
+    const titleBlock = document.createElement("div");
+    titleBlock.style.cssText = "display:flex;min-width:0;flex-direction:column;gap:5px;";
     const title = document.createElement("div");
     title.textContent = "System Prompt";
     title.style.cssText = "font-size:18px;font-weight:750;color:#c8f1d2;";
+    const promptStatusRow = document.createElement("div");
+    promptStatusRow.style.cssText = "display:flex;flex-wrap:wrap;gap:8px 16px;font-size:11px;line-height:1.35;color:#aebdb3;";
+    const appliedPromptStatus = document.createElement("span");
+    appliedPromptStatus.textContent = "Applied to node: Checking...";
+    const editorPromptStatus = document.createElement("span");
+    editorPromptStatus.textContent = "Editor: Checking...";
+    promptStatusRow.append(appliedPromptStatus, editorPromptStatus);
+    titleBlock.append(title, promptStatusRow);
     const closeButton = document.createElement("button");
     closeButton.textContent = "Close";
     closeButton.style.cssText = buttonStyle(false);
-    header.append(title, closeButton);
+    header.append(titleBlock, closeButton);
 
     const legacyPresetState = readLegacySystemPromptUserPresetState();
     const legacyPresets = legacyPresetState.presets;
-    let userPresets = [];
+    let userPresets = systemPromptPresetPageCache.status === "ready"
+        ? systemPromptPresetPageCache.presets.map((preset) => ({ ...preset }))
+        : [];
     let durablePresetStoreReady = false;
     let presetStoreBusy = true;
+    let updatePromptStatusLabels = () => {};
     const presetPanel = document.createElement("div");
     presetPanel.style.cssText = [
         "display:flex",
@@ -6757,6 +6931,7 @@ function openSystemPromptDialog(node) {
         if (updateHint) {
             presetHint.textContent = selected?.description || "Load a preset into the editor, then save it to the node.";
         }
+        updatePromptStatusLabels();
     };
     populateSystemPromptPresetSelect(presetSelect, userPresets);
     updatePresetControls(false);
@@ -6781,6 +6956,19 @@ function openSystemPromptDialog(node) {
         "white-space:pre-wrap",
         "overscroll-behavior:contain",
     ].join(";");
+    updatePromptStatusLabels = () => {
+        const cacheStatus = presetStoreBusy ? "loading" : "ready";
+        const applied = describeSystemPromptPreset(systemWidget.value, userPresets, cacheStatus);
+        const editor = describeSystemPromptPreset(textarea.value, userPresets, cacheStatus);
+        const editorIsApplied =
+            normalizeSystemPromptComparisonText(textarea.value) ===
+            normalizeSystemPromptComparisonText(systemWidget.value);
+        appliedPromptStatus.textContent = `Applied to node: ${applied.label}`;
+        editorPromptStatus.textContent = `Editor: ${editor.label}${editorIsApplied ? "" : " — not applied"}`;
+        appliedPromptStatus.style.color = applied.kind === "preset" ? "#9dffba" : "#cbd5ce";
+        editorPromptStatus.style.color = editorIsApplied ? "#cbd5ce" : "#f2c879";
+    };
+    updatePromptStatusLabels();
 
     const footer = document.createElement("div");
     footer.style.cssText = "display:flex;justify-content:flex-end;gap:10px;";
@@ -6797,6 +6985,7 @@ function openSystemPromptDialog(node) {
         systemWidget.value = textarea.value;
         node.properties = node.properties || {};
         node.properties.denoLocalLLMSystemPromptUpdatedAt = Date.now();
+        updatePromptStatusLabels();
         refreshNode(node);
         close();
     };
@@ -6815,7 +7004,10 @@ function openSystemPromptDialog(node) {
         setPresetStoreBusy(true);
         try {
             const savedPresets = await writeDurableSystemPromptUserPresets(candidatePresets);
-            userPresets = savedPresets;
+            userPresets = setSystemPromptPresetPageCache(savedPresets, {
+                status: "ready",
+                readStatus: "loaded",
+            }).map((preset) => ({ ...preset }));
             populateSystemPromptPresetSelect(presetSelect, userPresets, selectedValue);
             updatePresetControls(false, true);
             presetHint.textContent = successMessage;
@@ -6840,8 +7032,8 @@ function openSystemPromptDialog(node) {
             return;
         }
         try {
-            const result = await readDurableSystemPromptUserPresets();
-            userPresets = result.presets;
+            const result = await loadSystemPromptPresetPageCache();
+            userPresets = result.presets.map((preset) => ({ ...preset }));
             durablePresetStoreReady = true;
             populateSystemPromptPresetSelect(presetSelect, userPresets);
             setPresetStoreBusy(false);
@@ -6880,6 +7072,7 @@ function openSystemPromptDialog(node) {
         if (selected.kind === "user") {
             presetName.value = selected.label;
         }
+        updatePromptStatusLabels();
         textarea.focus();
     });
     savePresetButton.addEventListener("click", async () => {
@@ -6934,6 +7127,7 @@ function openSystemPromptDialog(node) {
     });
     clearButton.addEventListener("click", () => {
         textarea.value = "";
+        updatePromptStatusLabels();
         textarea.focus();
     });
     saveButton.addEventListener("click", save);
@@ -6945,6 +7139,7 @@ function openSystemPromptDialog(node) {
     panel.addEventListener("pointerdown", (event) => event.stopPropagation());
     panel.addEventListener("wheel", (event) => event.stopPropagation(), { passive: true });
     textarea.addEventListener("wheel", (event) => event.stopPropagation(), { passive: true });
+    textarea.addEventListener("input", updatePromptStatusLabels);
     textarea.addEventListener("keydown", (event) => {
         if (event.key === "Escape") {
             event.preventDefault();


### PR DESCRIPTION
## Summary

- show the actually applied System Prompt preset on `(Deno) Local LLM Loader`
- preserve saved LM Studio model IDs until a successful authoritative refresh proves they are missing
- add an optional `video seconds` FLOAT socket that appends an English duration sentence to the runtime user prompt copy
- restore the normal DENO Floating Tools icon after the matching retry succeeds
- bump the public package to `0.7.78`

## Verification

- Python compile checks
- frontend syntax checks
- affected JavaScript regression harnesses
- full test suite: `441 passed`
- Registry package manifest/private-path audit
- live isolated canvas checks on 8191
- main 8188 runtime sync, restart, `/object_info`, served-JS hash, and DENO console-error checks
