### PR TITLE
Preserve MiniMax H3 reference preview aspect ratios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file intentionally stays short. Detailed engineering notes belong in privat
 
 ## Unreleased
 
+## 0.7.79 - 2026-08-06
+
+- Changed `(Deno) MiniMax H3 Multi Reference Image Loader` preview cards to follow each source image's aspect ratio, keeping mixed landscape and portrait references fully visible without preview cropping.
+
 ## 0.7.78 - 2026-08-06
 
 - Improved `(Deno) Local LLM Loader` with applied System Prompt preset status, an optional `video seconds` FLOAT socket, and workflow-tab model restoration that waits for a successful model-list refresh before declaring a saved model missing.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Main features:
 - the same upload, paste, drag-and-drop, Input Folder, card reorder, and clear workflow as `(Deno) Multi Image Loader`
 - up to 9 ordered reference images through one dedicated socket
 - keeps each decoded image's own dimensions and aspect ratio without resize, crop, pad, or letterbox processing
+- displays each preview card at the source image's own aspect ratio, so mixed landscape and portrait references stay fully visible without preview cropping
 - card order maps directly to `<Picture 1>`, `<Picture 2>`, and so on
 - connects to the single `ref_images` input on `(Deno) MiniMax H3 Reference to Video`
 - also exposes the same ordered sources as an `image_list` output that connects directly to `(Deno) Local LLM Loader`'s `image` input

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -79,7 +79,7 @@ ComfyUI용 해상도 도우미와 이미지 리사이즈 노드입니다.
 
 ComfyUI 순정 MiniMax H3 Reference to Video용 한 줄 연결 다중 참조 이미지 로더입니다.
 
-기존 `(Deno) Multi Image Loader`와 동일한 업로드, 붙여넣기, 드래그 앤 드롭, Input Folder, 카드 정렬, 삭제 사용감을 유지합니다. 최대 9장을 전용 `ref_images` 소켓 하나로 전달하며, 각 이미지의 디코딩된 원본 크기와 비율을 리사이즈·크롭·패딩 없이 개별 보존합니다. 카드 순서는 `<Picture 1>`, `<Picture 2>` 순서로 대응합니다. 같은 이미지들은 별도의 `image_list` 출력으로도 제공되어 `(Deno) Local LLM Loader`의 `image` 입력에 바로 연결할 수 있습니다.
+기존 `(Deno) Multi Image Loader`와 동일한 업로드, 붙여넣기, 드래그 앤 드롭, Input Folder, 카드 정렬, 삭제 사용감을 유지합니다. 최대 9장을 전용 `ref_images` 소켓 하나로 전달하며, 각 이미지의 디코딩된 원본 크기와 비율을 리사이즈·크롭·패딩 없이 개별 보존합니다. 미리보기 카드도 각 원본 비율을 그대로 사용하므로 가로·세로 이미지가 섞여 있어도 잘림 없이 표시됩니다. 카드 순서는 `<Picture 1>`, `<Picture 2>` 순서로 대응합니다. 같은 이미지들은 별도의 `image_list` 출력으로도 제공되어 `(Deno) Local LLM Loader`의 `image` 입력에 바로 연결할 수 있습니다.
 
 함께 제공되는 `(Deno) MiniMax H3 Reference to Video`는 이미지 입력만 한 단자로 바꾸고, 참조 비디오·비디오 오디오·단독 오디오의 순정 Autogrow 입력은 그대로 유지합니다. 일반 `IMAGE` 배치는 모든 이미지가 같은 가로·세로 크기여야 하므로 혼합 원본 크기 보존에는 사용할 수 없습니다. 추가된 `image_list`는 동일 크기 배치가 아니라 각 원본을 분리해 유지하는 리스트 출력입니다. H3 내부의 `ref_image_size` 처리는 실행 시 비율을 유지한 채 참조 이미지를 축소할 수 있습니다.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "deno-custom-nodes"
 description = "DENO RTX node pack for ComfyUI: MiniMax H3 multi-reference image and Reference to Video helpers, Ideogram Director visual JSON/bbox prompt builder, Local LLM Loader and Reviewer helpers, GPT/Gemini-ready Error Help reports, Prompt Only final prompt extraction, RTX Video Super Resolution, RTX Super Resolution, Video SR/VSR, NVIDIA VFX/nvvfx, RTX upscale helpers, LTX 2.3 workflows, LTX tiled second-pass refinement helpers, Bernini Prompt Guide, audio/image review gates, Bernini conditioning helpers, Wan 2.2 reference video edit workflows, image and video compare, video preview, Video to GIF/WebP tools, multi-image loading, resize tools, LoRA/model helpers, prompt guides, and visual workflow utilities."
-version = "0.7.78"
+version = "0.7.79"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = []

--- a/tests/js/ltx_sequencer_input_slots_harness.mjs
+++ b/tests/js/ltx_sequencer_input_slots_harness.mjs
@@ -1411,6 +1411,27 @@ assert.equal(
   false,
   "sub-pixel renderer drift within one pixel must not create a resize feedback loop",
 );
+
+const landscapeAspectCard = hooks.resolveLoaderAspectCardLayout(1920, 1080, 96);
+assert.equal(landscapeAspectCard.validSourceSize, true);
+assert.equal(landscapeAspectCard.width, 170.667);
+assert.equal(landscapeAspectCard.height, 96);
+assert.equal(landscapeAspectCard.aspectRatio, "1920 / 1080");
+
+const portraitAspectCard = hooks.resolveLoaderAspectCardLayout(1080, 1920, 96);
+assert.equal(portraitAspectCard.width, 54);
+assert.equal(portraitAspectCard.height, 96);
+assert.equal(portraitAspectCard.aspectRatio, "1080 / 1920");
+assert.ok(
+  landscapeAspectCard.width * 2 + portraitAspectCard.width + 20 <= 420,
+  "two 16:9 cards and one 9:16 card should fit a 420px H3 gallery content area with two gaps",
+);
+
+const fallbackAspectCard = hooks.resolveLoaderAspectCardLayout(0, Number.NaN, -1);
+assert.equal(fallbackAspectCard.validSourceSize, false);
+assert.equal(fallbackAspectCard.width, 96);
+assert.equal(fallbackAspectCard.height, 96);
+assert.equal(fallbackAspectCard.aspectRatio, "1 / 1");
 assert.equal(
   hooks.shouldApplyLoaderNodeSize([431.1, 520], [430, 520]),
   true,

--- a/tests/test_image_resize_node.py
+++ b/tests/test_image_resize_node.py
@@ -2044,12 +2044,18 @@ def test_minimax_h3_frontend_reuses_loader_ui_without_patching_h3_wrapper():
     assert "notifySequencers: false" in script
     assert "maxImages: 9" in script
     assert "H3_REFERENCE_LOADER_MIN_SIZE = [360, 370]" in script
+    assert "H3_REFERENCE_CARD_PREVIEW_HEIGHT = 96" in script
     assert "minSize: H3_REFERENCE_LOADER_MIN_SIZE" in script
+    assert "preserveCardAspectRatio: true" in script
+    assert "cardPreviewHeight: H3_REFERENCE_CARD_PREVIEW_HEIGHT" in script
     assert "legacyDefaultHeight: LOADER_MIN_SIZE[1]" in script
     assert "layoutVersionProperty: H3_REFERENCE_LOADER_LAYOUT_VERSION_PROPERTY" in script
     assert "resolveLoaderNodeSize" in script
+    assert "resolveLoaderAspectCardLayout" in script
     assert "appendPathsWithinLimit" in script
     assert "Original size and aspect ratio are preserved" in script
+    assert '"source-aspect-v1"' in script
+    assert 'object-fit:${preserveCardAspectRatio ? "contain" : "cover"}' in script
     assert "DenoMiniMaxH3ReferenceToVideo" not in script
 
 

--- a/web/js/deno_extra_nodes.js
+++ b/web/js/deno_extra_nodes.js
@@ -7,6 +7,7 @@ const SEQUENCER_NODE = "DenoLTXSequencer";
 const LTX_PRESET_NODE = "DenoLTX23PresetLoader";
 const LOADER_MIN_SIZE = [360, 520];
 const H3_REFERENCE_LOADER_MIN_SIZE = [360, 370];
+const H3_REFERENCE_CARD_PREVIEW_HEIGHT = 96;
 const LOADER_PANEL_MIN_HEIGHT = 320;
 const LOADER_PANEL_WIDGET_EXTRA_HEIGHT = 12;
 const LOADER_PANEL_WRAPPER_COMPENSATION = 4;
@@ -70,10 +71,12 @@ app.registerExtension({
                 notifySequencers: false,
                 maxImages: 9,
                 minSize: H3_REFERENCE_LOADER_MIN_SIZE,
+                preserveCardAspectRatio: true,
+                cardPreviewHeight: H3_REFERENCE_CARD_PREVIEW_HEIGHT,
                 legacyDefaultHeight: LOADER_MIN_SIZE[1],
                 layoutVersion: H3_REFERENCE_LOADER_LAYOUT_VERSION,
                 layoutVersionProperty: H3_REFERENCE_LOADER_LAYOUT_VERSION_PROPERTY,
-                hint: "Original size and aspect ratio are preserved. Card order maps to <Picture 1>, <Picture 2>, and so on.",
+                hint: "Original size and aspect ratio are preserved and shown without preview cropping. Card order maps to <Picture 1>, <Picture 2>, and so on.",
             });
         }
         if (nodeData.name === SEQUENCER_NODE) {
@@ -720,6 +723,26 @@ function normalizeLoaderMinSize(minSize) {
     ];
 }
 
+function resolveLoaderAspectCardLayout(width, height, previewHeight = H3_REFERENCE_CARD_PREVIEW_HEIGHT) {
+    const sourceWidth = Number(width);
+    const sourceHeight = Number(height);
+    const requestedHeight = Number(previewHeight);
+    const displayHeight = Number.isFinite(requestedHeight) && requestedHeight > 0
+        ? requestedHeight
+        : H3_REFERENCE_CARD_PREVIEW_HEIGHT;
+    const validSourceSize = Number.isFinite(sourceWidth)
+        && sourceWidth > 0
+        && Number.isFinite(sourceHeight)
+        && sourceHeight > 0;
+    const aspectRatio = validSourceSize ? sourceWidth / sourceHeight : 1;
+    return {
+        validSourceSize,
+        width: Math.round(displayHeight * aspectRatio * 1000) / 1000,
+        height: displayHeight,
+        aspectRatio: validSourceSize ? `${sourceWidth} / ${sourceHeight}` : "1 / 1",
+    };
+}
+
 function resolveLoaderNodeSize(
     currentSize,
     minSize = LOADER_MIN_SIZE,
@@ -852,6 +875,8 @@ function setupMultiImageLoader(node, options = {}) {
         ? Math.max(1, Math.floor(Number(options.maxImages)))
         : null;
     const loaderMinSize = normalizeLoaderMinSize(options.minSize);
+    const preserveCardAspectRatio = options.preserveCardAspectRatio === true;
+    const cardPreviewHeight = resolveLoaderAspectCardLayout(1, 1, options.cardPreviewHeight).height;
     const legacyDefaultHeight = Number(options.legacyDefaultHeight);
     const layoutVersionProperty = String(options.layoutVersionProperty || "").trim();
     const layoutVersion = Number(options.layoutVersion) || 0;
@@ -907,12 +932,22 @@ function setupMultiImageLoader(node, options = {}) {
         : "Drag files, press Ctrl+V, or use Upload. Drag cards to reorder.");
 
     const grid = document.createElement("div");
+    grid.dataset.denoLoaderGalleryLayout = preserveCardAspectRatio ? "source-aspect-v1" : "uniform-grid-v1";
+    const galleryLayoutCss = preserveCardAspectRatio
+        ? `
+            display: flex;
+            flex-wrap: wrap;
+            align-items: flex-start;
+        `
+        : `
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(92px, 1fr));
+        `;
     grid.style.cssText = `
         flex: 1;
         min-height: 0;
         overflow-y: auto;
-        display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(92px, 1fr));
+        ${galleryLayoutCss}
         gap: 10px;
         align-content: start;
         padding-right: 4px;
@@ -1023,13 +1058,22 @@ function setupMultiImageLoader(node, options = {}) {
         setOutputSizeHint(size);
     }
 
-    function createPlaceholder() {
+    function createPlaceholder(referenceCard = null) {
         const el = document.createElement("div");
+        const sourceAspectPlaceholderCss = preserveCardAspectRatio
+            ? `
+                width: ${referenceCard?.style?.width || `${cardPreviewHeight}px`};
+                max-width: 100%;
+                aspect-ratio: ${referenceCard?.style?.aspectRatio || "1 / 1"};
+                flex: 0 0 auto;
+                box-sizing: border-box;
+            `
+            : "min-height: 92px;";
         el.style.cssText = `
             border: 1px dashed rgba(72,255,132,0.55);
             border-radius: 10px;
             background: rgba(28,68,42,0.35);
-            min-height: 92px;
+            ${sourceAspectPlaceholderCss}
         `;
         return el;
     }
@@ -1038,9 +1082,21 @@ function setupMultiImageLoader(node, options = {}) {
         const card = document.createElement("div");
         card.draggable = true;
         card.dataset.path = path;
+        card.dataset.denoLoaderCardLayout = preserveCardAspectRatio ? "source-aspect-v1" : "uniform-grid-v1";
+        const initialCardLayout = resolveLoaderAspectCardLayout(1, 1, cardPreviewHeight);
+        const sourceAspectCardCss = preserveCardAspectRatio
+            ? `
+                width: ${initialCardLayout.width}px;
+                max-width: 100%;
+                aspect-ratio: ${initialCardLayout.aspectRatio};
+                flex: 0 0 auto;
+                min-height: 0;
+                box-sizing: border-box;
+            `
+            : "min-height: 92px;";
         card.style.cssText = `
             position: relative;
-            min-height: 92px;
+            ${sourceAspectCardCss}
             border-radius: 10px;
             overflow: hidden;
             background: #050707;
@@ -1050,8 +1106,26 @@ function setupMultiImageLoader(node, options = {}) {
         `;
 
         const image = document.createElement("img");
-        setInputImageSource(image, path);
-        image.style.cssText = "display:block; width:100%; height:100%; object-fit:cover; pointer-events:none;";
+        if (preserveCardAspectRatio) {
+            const applySourceAspectRatio = () => {
+                const layout = resolveLoaderAspectCardLayout(image.naturalWidth, image.naturalHeight, cardPreviewHeight);
+                if (!layout.validSourceSize) {
+                    return;
+                }
+                card.style.width = `${layout.width}px`;
+                card.style.aspectRatio = layout.aspectRatio;
+                card.dataset.denoSourceAspectRatio = layout.aspectRatio;
+            };
+            image.addEventListener("load", applySourceAspectRatio);
+            image.decoding = "async";
+            setInputImageSource(image, path);
+            if (image.complete) {
+                applySourceAspectRatio();
+            }
+        } else {
+            setInputImageSource(image, path);
+        }
+        image.style.cssText = `display:block; width:100%; height:100%; object-fit:${preserveCardAspectRatio ? "contain" : "cover"}; pointer-events:none;`;
 
         const badge = document.createElement("div");
         badge.textContent = String(index + 1);
@@ -1086,7 +1160,7 @@ function setupMultiImageLoader(node, options = {}) {
 
         card.addEventListener("dragstart", () => {
             draggedCard = card;
-            placeholder = createPlaceholder();
+            placeholder = createPlaceholder(card);
             isReordering = true;
             card.style.opacity = "0.35";
             setTimeout(() => {
@@ -4548,6 +4622,7 @@ if (typeof window !== "undefined" && typeof window.__DENO_EXTRA_NODES_TEST_HOOK_
         getSequencerInputPinReasons,
         collectUploadedPaths,
         appendPathsWithinLimit,
+        resolveLoaderAspectCardLayout,
         resolveLoaderNodeSize,
         shouldApplyLoaderNodeSize,
         installLoaderCanvasNavigation,


### PR DESCRIPTION
## What changed

- Preserve each source image’s aspect ratio in `(Deno) MiniMax H3 Multi Reference Image Loader` preview cards.
- Use a wrapping H3-only gallery: landscape cards stay wide, portrait cards stay narrow, and previews use `contain` without cropping.
- Keep the regular Multi Image Loader grid and `cover` previews unchanged.
- Preserve existing serialized widget order, layout version, card order, node sizing, and workflow compatibility.
- Document the behavior and bump the package to v0.7.79.

## Why

The shared grid previously stretched every card in a row to the tallest portrait image. Landscape previews therefore appeared as portrait-shaped, cropped cards even though decoded output sizes and aspect ratios were already correct.

## Validation

- `node --check web/js/deno_extra_nodes.js`
- `node tests/js/ltx_sequencer_input_slots_harness.mjs`
- `python -m pytest -q` — 441 passed
- `git diff --check`
- ComfyUI 0.30 live canvas: mixed landscape/portrait cards, resize behavior, wheel zoom, middle-button pan, and save/reopen
- Main 8188 runtime: source/runtime SHA-256 parity, v0.7.79 object info, served extension marker, and mixed 960×544 / 1088×2016 preview DOM and visual verification