### PR TITLE
Fix LM Studio Thinking off latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This file intentionally stays short. Detailed engineering notes belong in privat
 
 ## Unreleased
 
+## 0.7.80 - 2026-08-07
+
+- Fixed `(Deno) Local LLM Loader` so LM Studio reasoning-capable models receive an explicit `reasoning: off` request whenever Thinking is disabled, including after the model-list cache expires.
+- Removed the automatic second full generation after an empty LM Studio stream; the node now fails immediately and records the requested and actually applied reasoning modes accurately.
+
 ## 0.7.79 - 2026-08-06
 
 - Changed `(Deno) MiniMax H3 Multi Reference Image Loader` preview cards to follow each source image's aspect ratio, keeping mixed landscape and portrait references fully visible without preview cropping.

--- a/deno_local_llm_refiner.py
+++ b/deno_local_llm_refiner.py
@@ -1856,27 +1856,39 @@ def _lm_studio_empty_stream_error(message: str) -> str:
     )
 
 
-def _recover_lm_native_empty_stream(
-    native_base: str,
-    payload: Dict[str, Any],
-    include_reasoning: bool,
-) -> Tuple[str, str, Dict[str, Any]]:
-    diagnostic_payload = dict(payload)
-    diagnostic_payload["stream"] = False
-    try:
-        diagnostic = _http_json(
-            f"{native_base}/api/v1/chat",
-            diagnostic_payload,
-            method="POST",
-            timeout=120.0,
-        )
-    except RuntimeError as exc:
-        raise RuntimeError(_lm_studio_empty_stream_error(str(exc))) from exc
+def _looks_like_unsupported_lm_studio_reasoning_error(detail: Any) -> bool:
+    if isinstance(detail, dict):
+        message = str(detail.get("message") or detail)
+        param = str(detail.get("param") or "").strip().lower()
+        code = str(detail.get("code") or "").strip().lower()
+    else:
+        message = str(detail or "")
+        param = ""
+        code = ""
 
-    answer, thought = _extract_lm_native_final(diagnostic, include_reasoning)
-    if answer or thought:
-        return answer, thought, diagnostic
-    raise RuntimeError(_lm_studio_empty_stream_error(json.dumps(diagnostic, ensure_ascii=False)[:800]))
+    lowered = message.lower()
+    if "reasoning" not in lowered and param != "reasoning":
+        return False
+    markers = (
+        "does not support",
+        "doesn't support",
+        "not support",
+        "unsupported",
+        "unknown field",
+        "unknown parameter",
+        "unrecognized field",
+        "unrecognized parameter",
+        "unexpected field",
+        "unexpected parameter",
+        "invalid reasoning",
+        "invalid value",
+    )
+    return any(marker in lowered for marker in markers) or code in {
+        "invalid_parameter",
+        "invalid_request",
+        "unsupported_parameter",
+        "unsupported_value",
+    }
 
 
 def _lm_studio_models_cache_key(server_url: str) -> str:
@@ -3209,68 +3221,110 @@ class DenoLocalLLMRefiner:
             "input": _lm_native_input(prompt, image_attachments),
             "store": False,
         }
+        reasoning_requested = "on" if thinking else "off"
         if thinking:
             payload["reasoning"] = "on"
         else:
             reasoning_options = _lm_studio_reasoning_options(native_base, model)
-            if reasoning_options and "off" in reasoning_options:
+            # A missing or expired capability cache must not silently restore
+            # the model's default reasoning mode. Only a cached model that
+            # explicitly lacks `off` skips the field for compatibility.
+            if reasoning_options is None or "off" in reasoning_options:
                 payload["reasoning"] = "off"
         if system_prompt.strip():
             payload["system_prompt"] = system_prompt
 
-        answer_parts: List[str] = []
-        thinking_parts: List[str] = []
-        final_meta: Dict[str, Any] = {}
-        last_emit = 0.0
         # The active key still uses the OpenAI-style base saved in workflows,
         # while the real request uses LM Studio's native chat endpoint.
         cancel_key = _llm_state_key(PROVIDER_LM_STUDIO, openai_base, model)
 
-        diagnostic_meta: Optional[Dict[str, Any]] = None
+        reasoning_compat_fallback = False
+        reasoning_observed = False
         try:
-            for event_name, chunk in _http_stream_sse(f"{native_base}/api/v1/chat", payload, cancel_key=cancel_key):
-                if chunk.get("error"):
-                    error = chunk.get("error")
-                    if isinstance(error, dict):
-                        detail = str(error.get("message") or error)
-                    else:
-                        detail = str(error)
-                    if _looks_like_model_unavailable_error(detail):
-                        raise RuntimeError(_model_unavailable_message(model, detail))
-                    raise RuntimeError(detail)
-                event_type = str(chunk.get("type") or event_name or "")
-                content = str(chunk.get("content") or "") if event_type == "message.delta" else ""
-                thought = str(chunk.get("content") or "") if event_type == "reasoning.delta" else ""
-                if content:
-                    answer_parts.append(content)
-                if thought and thinking:
-                    thinking_parts.append(thought)
-                if event_type == "chat.end":
-                    final_meta = chunk
-                now = time.monotonic()
-                if now - last_emit > 0.12 or content or thought:
-                    last_emit = now
-                    _send_progress({
-                        "node_id": node_id,
-                        "status": "running",
-                        "provider": PROVIDER_LM_STUDIO,
-                        "model": model,
-                        "index": index,
-                        "total": total,
-                        "answer": "".join(answer_parts),
-                        "thinking": "".join(thinking_parts),
-                    })
+            while True:
+                answer_parts: List[str] = []
+                thinking_parts: List[str] = []
+                final_meta: Dict[str, Any] = {}
+                last_emit = 0.0
+                received_generation_output = False
+                try:
+                    for event_name, chunk in _http_stream_sse(
+                        f"{native_base}/api/v1/chat",
+                        payload,
+                        cancel_key=cancel_key,
+                    ):
+                        if chunk.get("error"):
+                            error = chunk.get("error")
+                            if isinstance(error, dict):
+                                detail = str(error.get("message") or error)
+                                error_param = str(error.get("param") or "").strip()
+                                if error_param:
+                                    detail = f"{detail} (param: {error_param})"
+                            else:
+                                detail = str(error)
+                            if _looks_like_model_unavailable_error(detail):
+                                raise RuntimeError(_model_unavailable_message(model, detail))
+                            raise RuntimeError(detail)
+                        event_type = str(chunk.get("type") or event_name or "")
+                        content = str(chunk.get("content") or "") if event_type == "message.delta" else ""
+                        thought = str(chunk.get("content") or "") if event_type == "reasoning.delta" else ""
+                        if content:
+                            received_generation_output = True
+                            answer_parts.append(content)
+                        if thought:
+                            received_generation_output = True
+                            reasoning_observed = True
+                            if thinking:
+                                thinking_parts.append(thought)
+                        if event_type == "chat.end":
+                            final_meta = chunk
+                        now = time.monotonic()
+                        if now - last_emit > 0.12 or content or thought:
+                            last_emit = now
+                            _send_progress({
+                                "node_id": node_id,
+                                "status": "running",
+                                "provider": PROVIDER_LM_STUDIO,
+                                "model": model,
+                                "index": index,
+                                "total": total,
+                                "answer": "".join(answer_parts),
+                                "thinking": "".join(thinking_parts),
+                            })
+                    break
+                except RuntimeError as exc:
+                    can_retry_without_reasoning = (
+                        not thinking
+                        and payload.get("reasoning") == "off"
+                        and not reasoning_compat_fallback
+                        and not received_generation_output
+                        and not final_meta
+                        and _looks_like_unsupported_lm_studio_reasoning_error(str(exc))
+                    )
+                    if not can_retry_without_reasoning:
+                        raise
+                    payload = dict(payload)
+                    payload.pop("reasoning", None)
+                    reasoning_compat_fallback = True
 
             answer = "".join(answer_parts).strip()
             thought = "".join(thinking_parts).strip()
             if not answer and not thought and final_meta:
                 answer, thought = _extract_lm_native_final(final_meta, thinking)
             if not answer and not thought:
-                answer, thought, diagnostic_meta = _recover_lm_native_empty_stream(
-                    native_base,
-                    payload,
-                    thinking,
+                _unused_answer, hidden_thought = _extract_lm_native_final(final_meta, True)
+                if not thinking and (reasoning_observed or hidden_thought):
+                    raise RuntimeError(
+                        "LM Studio returned reasoning without final text after Thinking was turned off. "
+                        "The model or server may have ignored reasoning='off'. Update LM Studio or choose "
+                        "a model that supports disabling reasoning."
+                    )
+                detail = (
+                    json.dumps(final_meta, ensure_ascii=False)[:800]
+                    if final_meta
+                    else "No final message was returned."
                 )
+                raise RuntimeError(_lm_studio_empty_stream_error(detail))
         finally:
             if _should_unload_after_run(memory_value, is_last):
                 if cleanup_state is not None:
@@ -3283,12 +3337,12 @@ class DenoLocalLLMRefiner:
             "seed": seed,
             "model_memory": memory_value,
             "keep_minutes": keep_minutes_value,
-            "reasoning": payload.get("reasoning", "off"),
+            "reasoning": payload.get("reasoning"),
+            "reasoning_requested": reasoning_requested,
+            "reasoning_compat_fallback": reasoning_compat_fallback,
             "api": "LM Studio /api/v1/chat",
             "meta": final_meta,
         }
-        if diagnostic_meta is not None:
-            raw["diagnostic"] = diagnostic_meta
         if image_attachments:
             raw["images"] = _image_attachment_metadata(image_attachments)
             raw["image"] = raw["images"][0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "deno-custom-nodes"
 description = "DENO RTX node pack for ComfyUI: MiniMax H3 multi-reference image and Reference to Video helpers, Ideogram Director visual JSON/bbox prompt builder, Local LLM Loader and Reviewer helpers, GPT/Gemini-ready Error Help reports, Prompt Only final prompt extraction, RTX Video Super Resolution, RTX Super Resolution, Video SR/VSR, NVIDIA VFX/nvvfx, RTX upscale helpers, LTX 2.3 workflows, LTX tiled second-pass refinement helpers, Bernini Prompt Guide, audio/image review gates, Bernini conditioning helpers, Wan 2.2 reference video edit workflows, image and video compare, video preview, Video to GIF/WebP tools, multi-image loading, resize tools, LoRA/model helpers, prompt guides, and visual workflow utilities."
-version = "0.7.79"
+version = "0.7.80"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = []

--- a/tests/test_image_resize_node.py
+++ b/tests/test_image_resize_node.py
@@ -4366,12 +4366,14 @@ def test_local_llm_refiner_lm_studio_keep_minutes_does_not_unload():
     assert answer == "kept"
     assert thought == ""
     assert stream_payloads[0]["url"] == "http://127.0.0.1:1234/api/v1/chat"
-    assert "reasoning" not in stream_payloads[0]["payload"]
+    assert stream_payloads[0]["payload"]["reasoning"] == "off"
     assert stream_payloads[0]["payload"]["input"] == "hello"
     assert stream_payloads[0]["payload"]["store"] is False
     assert "ttl" not in stream_payloads[0]["payload"]
     assert "seed" not in stream_payloads[0]["payload"]
     assert raw["reasoning"] == "off"
+    assert raw["reasoning_requested"] == "off"
+    assert raw["reasoning_compat_fallback"] is False
     assert raw["model_memory"] == "Keep for minutes"
     assert raw["keep_minutes"] == 3
     assert raw["api"] == "LM Studio /api/v1/chat"
@@ -4420,6 +4422,54 @@ def test_local_llm_refiner_lm_studio_sends_reasoning_off_when_model_supports_it(
     assert thought == ""
     assert stream_payloads[0]["payload"]["reasoning"] == "off"
     assert raw["reasoning"] == "off"
+    assert raw["reasoning_requested"] == "off"
+    assert raw["reasoning_compat_fallback"] is False
+
+
+def test_local_llm_refiner_lm_studio_omits_reasoning_when_cached_model_does_not_support_it():
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    stream_payloads = []
+
+    original_stream = module._http_stream_sse
+
+    def fake_stream(url, payload, **_kwargs):
+        stream_payloads.append({"url": url, "payload": dict(payload)})
+        yield "message.delta", {"type": "message.delta", "content": "kept"}
+        yield "chat.end", {"type": "chat.end", "result": {"output": [{"type": "message", "content": "kept"}]}}
+
+    module._http_stream_sse = fake_stream
+    module._cache_lm_studio_models(
+        "http://127.0.0.1:1234",
+        [{"id": "local/non-reasoning-model", "reasoning_options": []}],
+    )
+    try:
+        answer, thought, raw = node._run_lm_studio(
+            server_url="http://127.0.0.1:1234/v1",
+            model="local/non-reasoning-model",
+            system_prompt="",
+            prompt="hello",
+            thinking=False,
+            seed=7,
+            model_memory="Keep for minutes",
+            keep_minutes=3,
+            image_attachments=[],
+            is_last=True,
+            node_id="99",
+            index=1,
+            total=1,
+        )
+    finally:
+        module._http_stream_sse = original_stream
+        module._invalidate_lm_studio_models_cache("http://127.0.0.1:1234")
+
+    assert answer == "kept"
+    assert thought == ""
+    assert "reasoning" not in stream_payloads[0]["payload"]
+    assert raw["reasoning"] is None
+    assert raw["reasoning_requested"] == "off"
+    assert raw["reasoning_compat_fallback"] is False
 
 
 def test_local_llm_refiner_lm_studio_sends_reasoning_only_when_thinking_enabled():
@@ -4460,6 +4510,8 @@ def test_local_llm_refiner_lm_studio_sends_reasoning_only_when_thinking_enabled(
     assert thought == "visible thought"
     assert stream_payloads[0]["payload"]["reasoning"] == "on"
     assert raw["reasoning"] == "on"
+    assert raw["reasoning_requested"] == "on"
+    assert raw["reasoning_compat_fallback"] is False
 
 
 def test_local_llm_refiner_lm_studio_native_extracts_top_level_output():
@@ -4481,7 +4533,7 @@ def test_local_llm_refiner_lm_studio_native_extracts_top_level_output():
     assert thought == "internal"
 
 
-def test_local_llm_refiner_lm_studio_empty_stream_reports_context_error():
+def test_local_llm_refiner_lm_studio_empty_stream_fails_without_duplicate_generation():
     package = load_package()
     module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
     node = package.DenoLocalLLMRefiner()
@@ -4491,25 +4543,24 @@ def test_local_llm_refiner_lm_studio_empty_stream_reports_context_error():
     original_http_json = module._http_json
     original_list_models = module.list_local_llm_models
     original_unload = node._lm_unload_best_effort
-    diagnostic_payloads = []
+    stream_payloads = []
+    nonstream_calls = []
 
-    def fake_stream(_url, _payload, **_kwargs):
+    def fake_stream(_url, payload, **_kwargs):
+        stream_payloads.append(dict(payload))
         yield "chat.start", {"type": "chat.start", "model_instance_id": "google/gemma-4-12b"}
+        yield "chat.end", {"type": "chat.end", "result": {"output": []}}
 
-    def fake_http_json(_url, _payload=None, method="GET", timeout=20.0):
-        diagnostic_payloads.append(dict(_payload or {}))
-        raise RuntimeError(
-            "Local LLM server returned HTTP 500: "
-            "The number of tokens to keep from the initial prompt is greater than the context length "
-            "(n_keep: 6667>= n_ctx: 4096)."
-        )
+    def fake_http_json(url, _payload=None, method="GET", timeout=20.0):
+        nonstream_calls.append((url, dict(_payload or {}), method, timeout))
+        raise AssertionError("empty streams must not start a second generation request")
 
     module._http_stream_sse = fake_stream
     module._http_json = fake_http_json
     module.list_local_llm_models = lambda _provider, _server_url: []
     node._lm_unload_best_effort = lambda native_base, model: unload_calls.append((native_base, model))
     try:
-        with pytest.raises(RuntimeError, match="longer than the loaded model context"):
+        with pytest.raises(RuntimeError, match="ended the response stream without final text"):
             node._run_lm_studio(
                 server_url="http://127.0.0.1:1234/v1",
                 model="google/gemma-4-12b",
@@ -4531,10 +4582,54 @@ def test_local_llm_refiner_lm_studio_empty_stream_reports_context_error():
         module.list_local_llm_models = original_list_models
         node._lm_unload_best_effort = original_unload
 
-    assert diagnostic_payloads
-    assert diagnostic_payloads[0]["stream"] is False
-    assert "reasoning" not in diagnostic_payloads[0]
+    assert len(stream_payloads) == 1
+    assert stream_payloads[0]["reasoning"] == "off"
+    assert nonstream_calls == []
     assert unload_calls == [("http://127.0.0.1:1234", "google/gemma-4-12b")]
+
+
+def test_local_llm_refiner_lm_studio_reasoning_only_fails_fast_when_thinking_is_off(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    stream_payloads = []
+
+    def fake_stream(_url, payload, **_kwargs):
+        stream_payloads.append(dict(payload))
+        yield "reasoning.delta", {"type": "reasoning.delta", "content": "hidden only"}
+        yield "chat.end", {
+            "type": "chat.end",
+            "result": {"output": [{"type": "reasoning", "content": "hidden only"}]},
+        }
+
+    monkeypatch.setattr(module, "_http_stream_sse", fake_stream)
+    monkeypatch.setattr(
+        module,
+        "_http_json",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("reasoning-only output must not start a second generation request")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="reasoning without final text"):
+        node._run_lm_studio(
+            server_url="http://127.0.0.1:1234/v1",
+            model="google/gemma-4-12b",
+            system_prompt="",
+            prompt="hello",
+            thinking=False,
+            seed=7,
+            model_memory="Keep for minutes",
+            keep_minutes=3,
+            image_attachments=[],
+            is_last=True,
+            node_id="99",
+            index=1,
+            total=1,
+        )
+
+    assert len(stream_payloads) == 1
+    assert stream_payloads[0]["reasoning"] == "off"
 
 
 def test_local_llm_refiner_sends_progress_error_before_raising(monkeypatch):

--- a/tests/test_local_llm_regressions.py
+++ b/tests/test_local_llm_regressions.py
@@ -461,6 +461,7 @@ def test_lm_studio_keep_loaded_runs_do_not_query_model_list_during_generation(mo
     module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
     node = package.DenoLocalLLMRefiner()
     model_list_calls = []
+    stream_payloads = []
 
     with module._LM_STUDIO_MODELS_CACHE_LOCK:
         module._LM_STUDIO_MODELS_CACHE.clear()
@@ -471,7 +472,8 @@ def test_lm_studio_keep_loaded_runs_do_not_query_model_list_during_generation(mo
             raise AssertionError("generation must not synchronously query LM Studio's model list")
         raise AssertionError(f"unexpected non-stream request: {url}")
 
-    def fake_stream(*_args, **_kwargs):
+    def fake_stream(_url, payload, **_kwargs):
+        stream_payloads.append(dict(payload))
         yield "message.delta", {"type": "message.delta", "content": "ready"}
         yield "chat.end", {"type": "chat.end"}
 
@@ -496,8 +498,103 @@ def test_lm_studio_keep_loaded_runs_do_not_query_model_list_during_generation(mo
         )
         assert answer == "ready"
         assert raw["reasoning"] == "off"
+        assert raw["reasoning_requested"] == "off"
+        assert raw["reasoning_compat_fallback"] is False
 
     assert model_list_calls == []
+    assert [payload["reasoning"] for payload in stream_payloads] == ["off", "off"]
+
+
+def test_lm_studio_retries_once_without_reasoning_only_when_off_is_explicitly_unsupported(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    stream_payloads = []
+
+    with module._LM_STUDIO_MODELS_CACHE_LOCK:
+        module._LM_STUDIO_MODELS_CACHE.clear()
+
+    def fake_stream(_url, payload, **_kwargs):
+        stream_payloads.append(dict(payload))
+        if len(stream_payloads) == 1:
+            raise RuntimeError("This model does not support the reasoning setting 'off'.")
+        yield "message.delta", {"type": "message.delta", "content": "ready"}
+        yield "chat.end", {"type": "chat.end"}
+
+    monkeypatch.setattr(module, "_http_stream_sse", fake_stream)
+
+    answer, thought, raw = node._run_lm_studio(
+        server_url="http://127.0.0.1:1234/v1",
+        model="local/non-reasoning-model",
+        system_prompt="",
+        prompt="hello",
+        thinking=False,
+        seed=7,
+        model_memory="Keep loaded",
+        keep_minutes=5,
+        image_attachments=[],
+        is_last=True,
+        node_id="lm-studio-reasoning-compat",
+        index=1,
+        total=1,
+    )
+
+    assert answer == "ready"
+    assert thought == ""
+    assert stream_payloads[0]["reasoning"] == "off"
+    assert "reasoning" not in stream_payloads[1]
+    assert raw["reasoning"] is None
+    assert raw["reasoning_requested"] == "off"
+    assert raw["reasoning_compat_fallback"] is True
+
+
+@pytest.mark.parametrize(
+    ("partial_output", "error_message"),
+    [
+        (False, "LM Studio connection failed"),
+        (True, "This model does not support the reasoning setting 'off'."),
+    ],
+)
+def test_lm_studio_does_not_retry_unrelated_or_partial_output_failures(
+    monkeypatch,
+    partial_output,
+    error_message,
+):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    stream_payloads = []
+
+    with module._LM_STUDIO_MODELS_CACHE_LOCK:
+        module._LM_STUDIO_MODELS_CACHE.clear()
+
+    def fake_stream(_url, payload, **_kwargs):
+        stream_payloads.append(dict(payload))
+        if partial_output:
+            yield "message.delta", {"type": "message.delta", "content": "partial"}
+        raise RuntimeError(error_message)
+
+    monkeypatch.setattr(module, "_http_stream_sse", fake_stream)
+
+    with pytest.raises(RuntimeError, match="reasoning setting|connection failed"):
+        node._run_lm_studio(
+            server_url="http://127.0.0.1:1234/v1",
+            model="google/gemma",
+            system_prompt="",
+            prompt="hello",
+            thinking=False,
+            seed=7,
+            model_memory="Keep loaded",
+            keep_minutes=5,
+            image_attachments=[],
+            is_last=True,
+            node_id="lm-studio-no-retry",
+            index=1,
+            total=1,
+        )
+
+    assert len(stream_payloads) == 1
+    assert stream_payloads[0]["reasoning"] == "off"
 
 
 def test_local_llm_input_types_never_queries_lm_studio_during_prompt_validation(monkeypatch):


### PR DESCRIPTION
## Summary
- send `reasoning: off` when LM Studio Thinking is disabled even after the model-list cache expires
- retry once without the field only when LM Studio explicitly rejects the reasoning setting before any output
- remove the second 120-second non-stream generation after an empty stream and record requested/applied reasoning modes truthfully

## Verification
- focused LM Studio regressions: 14 passed
- full CI-equivalent suite: 398 passed, 47 skipped
- frontend syntax and LTX sequencer harness passed
- live Gemma 4 12B QAT cold run: 1 chat request, 0 reasoning tokens, 0 reasoning deltas, automatic unload confirmed
- Registry package manifest: 411 files, private/test surfaces excluded