### PR TITLE
Fix Local LLM prompt resize lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file intentionally stays short. Detailed engineering notes belong in privat
 
 ## Unreleased
 
+## 0.7.81 - 2026-08-08
+
+- Fixed `(Deno) Local LLM Loader` so a vertically enlarged prompt area can shrink again, follows ComfyUI's native DOM layout, and keeps its compact size after saving and reopening a workflow.
+
 ## 0.7.80 - 2026-08-07
 
 - Fixed `(Deno) Local LLM Loader` so LM Studio reasoning-capable models receive an explicit `reasoning: off` request whenever Thinking is disabled, including after the model-list cache expires.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "deno-custom-nodes"
 description = "DENO RTX node pack for ComfyUI: MiniMax H3 multi-reference image and Reference to Video helpers, Ideogram Director visual JSON/bbox prompt builder, Local LLM Loader and Reviewer helpers, GPT/Gemini-ready Error Help reports, Prompt Only final prompt extraction, RTX Video Super Resolution, RTX Super Resolution, Video SR/VSR, NVIDIA VFX/nvvfx, RTX upscale helpers, LTX 2.3 workflows, LTX tiled second-pass refinement helpers, Bernini Prompt Guide, audio/image review gates, Bernini conditioning helpers, Wan 2.2 reference video edit workflows, image and video compare, video preview, Video to GIF/WebP tools, multi-image loading, resize tools, LoRA/model helpers, prompt guides, and visual workflow utilities."
-version = "0.7.80"
+version = "0.7.81"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = []

--- a/tests/test_image_resize_node.py
+++ b/tests/test_image_resize_node.py
@@ -3871,7 +3871,11 @@ def test_local_llm_refiner_declares_batch_prompt_contract_and_frontend_preview()
     assert "ensurePromptWidget" in script
     assert "addPromptTextBox" not in script
     assert "positionPromptWidget" in script
-    assert "loaderPromptWidgetHeight" in script
+    assert "loaderPromptWidgetHeight" not in script
+    assert 'delete widget.computeSize;' in script
+    assert "widget.options.getMinHeight = () => PROMPT_WIDGET_MIN_HEIGHT;" in script
+    assert "widget.options.getMaxHeight = () => PROMPT_WIDGET_MAX_HEIGHT;" in script
+    assert 'element.style.height = "100%";' in script
     assert "PROMPT_WIDGET_SIDE_INSET" in script
     assert "element.style.marginLeft" in script
     assert "removeLegacyPromptBoxDomElements" in script

--- a/tests/test_local_llm_reviewer_graph_transform.py
+++ b/tests/test_local_llm_reviewer_graph_transform.py
@@ -580,6 +580,23 @@ def test_reviewer_graph_transform_submit_modes(tmp_path):
             assert(api.getWidget(clonedClipboardShiftNode, "deno_local_llm_unload_llm").value === "Unload LLM", "Loader reload cleanup must reset Unload LLM button value after ComfyUI shifts saved model text into it");
             assert(api.getWidget(clonedClipboardShiftNode, "deno_local_llm_system_prompt_button").value === "System Prompt", "Loader reload cleanup must reset System Prompt button value after ComfyUI restore");
             function makeCopiedLoaderNode(id) {{
+                const promptElement = {{ style: {{ minHeight: "460px", height: "460px" }} }};
+                const promptWidget = {{
+                    name: "prompt",
+                    label: "Prompt",
+                    type: "text",
+                    value: "",
+                    options: {{}},
+                    element: promptElement,
+                    computeSize() {{ return [560, 460]; }},
+                    computeLayoutSize() {{
+                        return {{
+                            minHeight: this.options.getMinHeight?.() ?? 50,
+                            maxHeight: this.options.getMaxHeight?.(),
+                            minWidth: 0,
+                        }};
+                    }},
+                }};
                 const node = {{
                     id,
                     type: "DenoLocalLLMRefiner",
@@ -596,7 +613,7 @@ def test_reviewer_graph_transform_submit_modes(tmp_path):
                         {{ name: "model_memory", label: "Model After Run", type: "combo", value: "Unload after run", options: {{ values: ["Unload after run", "Keep loaded"] }} }},
                         {{ name: "keep_minutes", label: "Keep Minutes", type: "number", value: 5 }},
                         {{ name: "comfy_vram_policy", label: "Unload ComfyUI Models Setting", type: "combo", value: "Auto: unload only before first LLM call", options: {{ values: ["Auto: unload only before first LLM call", "Always unload before each LLM call", "Never unload before LLM call"] }} }},
-                        {{ name: "prompt", label: "Prompt", type: "text", value: "" }},
+                        promptWidget,
                     ],
                     inputs: [],
                     outputs: [{{ name: "result", type: "STRING", links: [] }}],
@@ -639,6 +656,26 @@ def test_reviewer_graph_transform_submit_modes(tmp_path):
             assert(api.getWidget(copiedLoaderNode, "seed").value === 42, "Loader copy/paste setup must restore the saved seed");
             assert(api.getWidget(copiedLoaderNode, "prompt").value === "Prompt text", "Loader copy/paste setup must restore the saved prompt text");
             assert(api.getLocalLLMNodeState(copiedLoaderNode).thinking === "copied thinking", "Loader copy/paste setup must restore saved Thinking preview state");
+            const copiedPromptWidget = api.getWidget(copiedLoaderNode, "prompt");
+            assert(typeof copiedPromptWidget.computeSize === "undefined", "Modern ComfyUI prompt layout must not keep the current node height as a fixed computeSize minimum");
+            const compactPromptLayout = copiedPromptWidget.computeLayoutSize(copiedLoaderNode);
+            assert(compactPromptLayout.minHeight === 90 && compactPromptLayout.maxHeight === 460, "Prompt layout must keep a compact fixed minimum and remain growable");
+            assert(copiedPromptWidget.element.style.minHeight === "" && copiedPromptWidget.element.style.height === "100%", "Prompt textarea must follow the native allocated widget height");
+            copiedLoaderNode.size = [590, 760];
+            const grownPromptLayout = copiedPromptWidget.computeLayoutSize(copiedLoaderNode);
+            copiedLoaderNode.size = [590, 630];
+            const restoredPromptLayout = copiedPromptWidget.computeLayoutSize(copiedLoaderNode);
+            assert(grownPromptLayout.minHeight === 90 && restoredPromptLayout.minHeight === 90, "Growing a Loader must not ratchet its Prompt minimum and block shrinking back to the saved height");
+            api.setupNode(copiedLoaderNode);
+            assert(typeof copiedPromptWidget.computeSize === "undefined" && copiedPromptWidget.computeLayoutSize(copiedLoaderNode).minHeight === 90, "Repeated setup must preserve the non-ratcheting native Prompt layout");
+            const legacyPromptNode = makeCopiedLoaderNode(149);
+            const legacyPromptWidget = api.getWidget(legacyPromptNode, "prompt");
+            delete legacyPromptWidget.computeLayoutSize;
+            legacyPromptNode.size = [590, 900];
+            api.setupNode(legacyPromptNode);
+            assert(api.getWidget(legacyPromptNode, "prompt").computeSize(590)[1] === 90, "Legacy ComfyUI fallback must use a fixed compact Prompt minimum even when the saved node is tall");
+            legacyPromptNode.size = [590, 630];
+            assert(api.getWidget(legacyPromptNode, "prompt").computeSize(590)[1] === 90, "Legacy Prompt fallback must allow a grown Loader to shrink back to the saved height");
             const staleFirstRunNode = {{
                 widgets: [
                     {{ name: "provider", value: "Ollama", options: {{ values: ["Ollama", "LM Studio"] }} }},

--- a/web/js/deno_local_llm_refiner.js
+++ b/web/js/deno_local_llm_refiner.js
@@ -14,8 +14,7 @@ const OPENAI_MODEL_PICKER_NAME = `${GENERATED_PREFIX}model_picker`;
 const DEFAULT_WIDTH = 560;
 const GATE_DEFAULT_WIDTH = 420;
 const PREVIEW_HEIGHT = 150;
-const PROMPT_WIDGET_MIN_HEIGHT = 118;
-const PROMPT_WIDGET_DEFAULT_HEIGHT = 156;
+const PROMPT_WIDGET_MIN_HEIGHT = 90;
 const PROMPT_WIDGET_MAX_HEIGHT = 460;
 const PROMPT_WIDGET_SIDE_INSET = 0;
 const PREVIEW_TEXT_FONT = "10px monospace";
@@ -4486,15 +4485,21 @@ function configurePromptWidget(node, widget) {
     }
     widget.options = widget.options || {};
     widget.options.multiline = true;
+    if (typeof widget.computeLayoutSize === "function") {
+        delete widget.computeSize;
+        widget.options.getMinHeight = () => PROMPT_WIDGET_MIN_HEIGHT;
+        widget.options.getMaxHeight = () => PROMPT_WIDGET_MAX_HEIGHT;
+        stylePromptWidgetElement(widget);
+        return;
+    }
     widget.computeSize = (width) => {
-        const promptHeight = loaderPromptWidgetHeight(node);
-        stylePromptWidgetElement(widget, promptHeight);
-        return [Math.max(width || DEFAULT_WIDTH, DEFAULT_WIDTH), promptHeight];
+        stylePromptWidgetElement(widget);
+        return [Math.max(width || DEFAULT_WIDTH, DEFAULT_WIDTH), PROMPT_WIDGET_MIN_HEIGHT];
     };
-    stylePromptWidgetElement(widget, loaderPromptWidgetHeight(node));
+    stylePromptWidgetElement(widget);
 }
 
-function stylePromptWidgetElement(widget, height) {
+function stylePromptWidgetElement(widget) {
     const element = widget?.element || widget?.inputEl || null;
     if (!element?.style) {
         return;
@@ -4505,8 +4510,8 @@ function stylePromptWidgetElement(widget, height) {
     element.style.marginRight = `${PROMPT_WIDGET_SIDE_INSET}px`;
     element.style.width = `calc(100% - ${PROMPT_WIDGET_SIDE_INSET * 2}px)`;
     element.style.maxWidth = `calc(100% - ${PROMPT_WIDGET_SIDE_INSET * 2}px)`;
-    element.style.minHeight = `${Math.max(80, height - 8)}px`;
-    element.style.height = `${Math.max(80, height - 8)}px`;
+    element.style.minHeight = "";
+    element.style.height = "100%";
     element.style.resize = "none";
     element.style.overflow = "auto";
 }
@@ -5944,47 +5949,6 @@ function moveWidgetAfter(node, widget, anchor) {
     }
     const anchorIndex = node.widgets.indexOf(anchor);
     node.widgets.splice(anchorIndex >= 0 ? anchorIndex + 1 : node.widgets.length, 0, widget);
-}
-
-function loaderPromptWidgetHeight(node) {
-    const nodeHeight = Number(node?.size?.[1]) || 0;
-    if (!nodeHeight) {
-        return PROMPT_WIDGET_DEFAULT_HEIGHT;
-    }
-    const reserved = loaderNonPromptWidgetHeight(node);
-    return clampNumber(nodeHeight - reserved, PROMPT_WIDGET_MIN_HEIGHT, PROMPT_WIDGET_MAX_HEIGHT);
-}
-
-function loaderNonPromptWidgetHeight(node) {
-    const width = Number(node?.size?.[0]) || DEFAULT_WIDTH;
-    let total = 86;
-    for (const widget of node?.widgets || []) {
-        const name = String(widget?.name || "");
-        if (name === "prompt" || widget?.hidden) {
-            continue;
-        }
-        let height = LiteGraph.NODE_WIDGET_HEIGHT || 20;
-        if (typeof widget?.computeSize === "function") {
-            try {
-                const size = widget.computeSize(width);
-                if (Array.isArray(size)) {
-                    height = Number(size[1]) || height;
-                }
-            } catch {
-                // Keep the default row height for brittle third-party widget methods.
-            }
-        }
-        total += Math.max(0, height);
-    }
-    return total + 20;
-}
-
-function clampNumber(value, minimum, maximum) {
-    const number = Number(value);
-    if (!Number.isFinite(number)) {
-        return minimum;
-    }
-    return Math.min(maximum, Math.max(minimum, number));
 }
 
 function refreshNode(node) {


### PR DESCRIPTION
## Summary

- restore ComfyUI's native DOM layout path for the Local LLM prompt field
- keep a bounded, height-independent fallback for older frontends
- add modern, legacy, repeated-setup, grow/shrink, and saved-workflow regressions
- release the focused hotfix as v0.7.81

## Root cause

The prompt widget replaced the frontend's native layout method with a custom `computeSize` that derived its own minimum from the current outer node height. After the node grew, that larger height became the next minimum and prevented the node from shrinking again.

## User impact

`(Deno) Local LLM Loader` can now grow and shrink in both axes, the prompt field follows the available node area, and a compact saved node remains resizable after reopening. LLM execution, inputs, outputs, and serialized prompt values are unchanged.

## Validation

- focused Local LLM regressions: 59 passed
- full CI-equivalent suite: 446 passed
- JavaScript syntax and LTX frontend harness passed
- live ComfyUI canvas: empty and populated prompt, vertical and horizontal grow/shrink, save/reopen, and prompt preservation passed
- Registry package audit: version 0.7.81, 411 expected files, no tests/operator material, and packaged runtime JS matches the tested source bytes
