### PR TITLE
Fix Ollama thinking-only completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file intentionally stays short. Detailed engineering notes belong in privat
 
 ## Unreleased
 
+## 0.7.82 - 2026-08-09
+
+- Fixed `(Deno) Local LLM Loader` with Ollama Thinking enabled so a completed reasoning-only response automatically continues once to produce the final answer, while preserving the original prompt, images, seed, cancellation, and unload behavior.
+
 ## 0.7.81 - 2026-08-08
 
 - Fixed `(Deno) Local LLM Loader` so a vertically enlarged prompt area can shrink again, follows ComfyUI's native DOM layout, and keeps its compact size after saving and reopening a workflow.

--- a/deno_local_llm_refiner.py
+++ b/deno_local_llm_refiner.py
@@ -2950,83 +2950,165 @@ class DenoLocalLLMRefiner:
             user_message["images"] = [attachment["base64"] for attachment in image_attachments]
         messages.append(user_message)
 
+        logical_keep_alive = _ollama_keep_alive(memory_value, keep_minutes_value, is_last)
+        hold_for_possible_continuation = bool(
+            thinking and _should_unload_after_run(memory_value, is_last)
+        )
+        initial_keep_alive = (
+            _ollama_keep_alive(memory_value, keep_minutes_value, False)
+            if hold_for_possible_continuation
+            else logical_keep_alive
+        )
         payload = {
             "model": model,
             "messages": messages,
             "stream": True,
             "think": thinking,
             "options": {"seed": int(seed)},
-            "keep_alive": _ollama_keep_alive(memory_value, keep_minutes_value, is_last),
+            "keep_alive": initial_keep_alive,
         }
         answer_parts: List[str] = []
         thinking_parts: List[str] = []
-        final_meta: Dict[str, Any] = {}
         last_emit = 0.0
         cancel_key = _llm_state_key(PROVIDER_OLLAMA, base, model)
 
-        request_observed = False
-        for chunk in _http_stream_json_lines(f"{base}/api/chat", payload, cancel_key=cancel_key):
-            if not request_observed:
-                request_observed = True
-                if _should_unload_after_run(memory_value, is_last) and cleanup_state is not None:
-                    # A provider response proves that the terminal Ollama request carrying
-                    # keep_alive=0m was accepted. Post-processing must not issue a second
-                    # unload request for that same completed provider-owned cleanup.
-                    cleanup_state["provider_cleanup_attempted"] = True
-            if chunk.get("error"):
-                detail = str(chunk.get("error"))
-                if _looks_like_model_unavailable_error(detail):
-                    raise RuntimeError(_model_unavailable_message(model, detail))
-                raise RuntimeError(detail)
-            message = chunk.get("message") or {}
-            content = str(message.get("content") or "")
-            thought = str(message.get("thinking") or "")
-            if content:
-                answer_parts.append(content)
-            if thought:
-                thinking_parts.append(thought)
-            if chunk.get("done"):
-                final_meta = {
-                    key: chunk.get(key)
-                    for key in (
-                        "model",
-                        "done_reason",
-                        "total_duration",
-                        "load_duration",
-                        "prompt_eval_count",
-                        "eval_count",
-                    )
-                    if key in chunk
-                }
-            now = time.monotonic()
-            if now - last_emit > 0.12 or content or thought:
-                last_emit = now
-                _send_progress({
-                    "node_id": node_id,
-                    "status": "running",
-                    "provider": PROVIDER_OLLAMA,
-                    "model": model,
-                    "index": index,
-                    "total": total,
-                    "answer": "".join(answer_parts),
-                    "thinking": "".join(thinking_parts),
-                })
+        def stream_request(request_payload: Dict[str, Any], status: str) -> Dict[str, Any]:
+            nonlocal last_emit
+            request_observed = False
+            request_meta: Dict[str, Any] = {}
+            for chunk in _http_stream_json_lines(f"{base}/api/chat", request_payload, cancel_key=cancel_key):
+                if not request_observed:
+                    request_observed = True
+                    unload_requested = str(request_payload.get("keep_alive", "")).strip().lower() in {
+                        "0",
+                        "0m",
+                        "0s",
+                    }
+                    if unload_requested and cleanup_state is not None:
+                        # A provider response proves that the terminal Ollama request carrying
+                        # keep_alive=0m was accepted. Post-processing must not issue a second
+                        # unload request for that same completed provider-owned cleanup.
+                        cleanup_state["provider_cleanup_attempted"] = True
+                if chunk.get("error"):
+                    detail = str(chunk.get("error"))
+                    if _looks_like_model_unavailable_error(detail):
+                        raise RuntimeError(_model_unavailable_message(model, detail))
+                    raise RuntimeError(detail)
+                message = chunk.get("message") or {}
+                content = str(message.get("content") or "")
+                thought = str(
+                    message.get("thinking")
+                    or message.get("reasoning")
+                    or message.get("reasoning_content")
+                    or ""
+                )
+                if content:
+                    answer_parts.append(content)
+                if thought:
+                    thinking_parts.append(thought)
+                if chunk.get("done"):
+                    request_meta = {
+                        key: chunk.get(key)
+                        for key in (
+                            "done",
+                            "model",
+                            "done_reason",
+                            "total_duration",
+                            "load_duration",
+                            "prompt_eval_count",
+                            "eval_count",
+                        )
+                        if key in chunk
+                    }
+                now = time.monotonic()
+                if now - last_emit > 0.12 or content or thought:
+                    last_emit = now
+                    _send_progress({
+                        "node_id": node_id,
+                        "status": status,
+                        "provider": PROVIDER_OLLAMA,
+                        "model": model,
+                        "index": index,
+                        "total": total,
+                        "answer": "".join(answer_parts),
+                        "thinking": "".join(thinking_parts),
+                    })
+            return request_meta
+
+        final_meta = stream_request(payload, "running")
 
         answer = "".join(answer_parts).strip()
         thought = "".join(thinking_parts).strip()
+        recovery_meta: Optional[Dict[str, Any]] = None
+        if thinking and not answer and thought and final_meta.get("done") is True:
+            _raise_if_local_llm_stopped(cancel_key)
+            initial_meta = dict(final_meta)
+            continuation_payload = dict(payload)
+            continuation_payload["messages"] = list(messages) + [
+                {"role": "assistant", "content": "", "thinking": thought},
+            ]
+            continuation_payload["think"] = False
+            continuation_payload["keep_alive"] = logical_keep_alive
+            _send_progress({
+                "node_id": node_id,
+                "status": "finishing final answer",
+                "provider": PROVIDER_OLLAMA,
+                "model": model,
+                "index": index,
+                "total": total,
+                "answer": "",
+                "thinking": thought,
+            })
+            final_meta = stream_request(continuation_payload, "finishing final answer")
+            answer = "".join(answer_parts).strip()
+            thought = "".join(thinking_parts).strip()
+            recovery_meta = {
+                "attempted": True,
+                "succeeded": bool(answer),
+                "initial_meta": initial_meta,
+                "continuation_meta": dict(final_meta),
+            }
+            if not answer:
+                def meta_summary(meta: Dict[str, Any]) -> str:
+                    values = [
+                        f"done_reason={meta.get('done_reason', 'unknown')}",
+                        f"prompt_eval_count={meta.get('prompt_eval_count', 'unknown')}",
+                        f"eval_count={meta.get('eval_count', 'unknown')}",
+                    ]
+                    return ", ".join(values)
+
+                raise RuntimeError(
+                    "Ollama returned thinking text but no final result after one automatic final-answer continuation. "
+                    f"Initial: {meta_summary(initial_meta)}. Continuation: {meta_summary(final_meta)}. "
+                    "Shorten the prompt or turn Thinking off."
+                )
+        post_run_unload: Dict[str, Any] = {"action": "none"}
+        if hold_for_possible_continuation and recovery_meta is None and answer:
+            if cleanup_state is not None:
+                cleanup_state["provider_cleanup_attempted"] = True
+            try:
+                _ollama_unload_best_effort(base, model)
+                post_run_unload = {"action": "unloaded"}
+            except Exception as exc:
+                post_run_unload = {"action": "failed", "message": str(exc)}
         raw = {
             "provider": PROVIDER_OLLAMA,
             "model": model,
             "seed": seed,
             "model_memory": memory_value,
             "keep_minutes": keep_minutes_value,
-            "keep_alive": payload["keep_alive"],
+            "keep_alive": logical_keep_alive,
             "meta": final_meta,
+            "post_run_unload": post_run_unload,
         }
+        if initial_keep_alive != logical_keep_alive:
+            raw["initial_keep_alive"] = initial_keep_alive
+        if recovery_meta is not None:
+            raw["thinking_only_recovery"] = recovery_meta
         raw["post_keepalive"] = _ensure_ollama_model_stays_loaded(
             base=base,
             model=model,
-            keep_alive=payload["keep_alive"],
+            keep_alive=logical_keep_alive,
             node_id=node_id,
             index=index,
             total=total,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "deno-custom-nodes"
 description = "DENO RTX node pack for ComfyUI: MiniMax H3 multi-reference image and Reference to Video helpers, Ideogram Director visual JSON/bbox prompt builder, Local LLM Loader and Reviewer helpers, GPT/Gemini-ready Error Help reports, Prompt Only final prompt extraction, RTX Video Super Resolution, RTX Super Resolution, Video SR/VSR, NVIDIA VFX/nvvfx, RTX upscale helpers, LTX 2.3 workflows, LTX tiled second-pass refinement helpers, Bernini Prompt Guide, audio/image review gates, Bernini conditioning helpers, Wan 2.2 reference video edit workflows, image and video compare, video preview, Video to GIF/WebP tools, multi-image loading, resize tools, LoRA/model helpers, prompt guides, and visual workflow utilities."
-version = "0.7.81"
+version = "0.7.82"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = []

--- a/tests/test_image_resize_node.py
+++ b/tests/test_image_resize_node.py
@@ -4782,6 +4782,210 @@ def test_local_llm_refiner_ollama_sends_every_image_as_images_array():
     assert raw["image"]["width"] == 8
 
 
+@pytest.mark.parametrize("initial_done_reason", ["length", "stop"])
+def test_local_llm_refiner_ollama_recovers_completed_thinking_only_response_once(initial_done_reason):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    stream_payloads = []
+    progress_events = []
+    cleanup_state = {"provider_cleanup_attempted": False}
+
+    def fake_stream(url, payload, timeout=600.0, cancel_key=None):
+        stream_payloads.append({"url": url, "payload": payload, "cancel_key": cancel_key})
+        if len(stream_payloads) == 1:
+            yield {"message": {"thinking": "careful reasoning"}, "done": False}
+            yield {
+                "done": True,
+                "done_reason": initial_done_reason,
+                "prompt_eval_count": 44,
+                "eval_count": 64,
+            }
+            return
+        yield {"message": {"content": "complete final answer"}, "done": False}
+        yield {
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": 93,
+            "eval_count": 12,
+        }
+
+    original_stream = module._http_stream_json_lines
+    original_progress = module._send_progress
+    module._http_stream_json_lines = fake_stream
+    module._send_progress = lambda payload: progress_events.append(payload)
+    try:
+        answer, thought, raw = node._run_ollama(
+            server_url="http://127.0.0.1:11434",
+            model="qwen3.6",
+            system_prompt="Return a polished final prompt.",
+            prompt="direct the supplied image",
+            thinking=True,
+            seed=7,
+            model_memory="Unload after run",
+            keep_minutes=5,
+            image_attachments=[
+                {
+                    "base64": "img-a",
+                    "data_url": "data:image/jpeg;base64,img-a",
+                    "width": 8,
+                    "height": 8,
+                    "sent_width": 8,
+                    "sent_height": 8,
+                }
+            ],
+            is_last=True,
+            node_id="node",
+            index=1,
+            total=1,
+            cleanup_state=cleanup_state,
+        )
+    finally:
+        module._http_stream_json_lines = original_stream
+        module._send_progress = original_progress
+
+    assert answer == "complete final answer"
+    assert thought == "careful reasoning"
+    assert len(stream_payloads) == 2
+    first_payload = stream_payloads[0]["payload"]
+    continuation_payload = stream_payloads[1]["payload"]
+    assert first_payload["think"] is True
+    assert continuation_payload["think"] is False
+    assert [payload["payload"]["keep_alive"] for payload in stream_payloads] == ["5m", "0m"]
+    assert sum(
+        payload["payload"]["keep_alive"] in (0, "0", "0m", "0s")
+        for payload in stream_payloads
+    ) == 1
+    assert continuation_payload["options"] == first_payload["options"] == {"seed": 7}
+    assert continuation_payload["messages"][:2] == first_payload["messages"]
+    assert continuation_payload["messages"][-1] == {
+        "role": "assistant",
+        "content": "",
+        "thinking": "careful reasoning",
+    }
+    assert continuation_payload["messages"][1]["images"] == ["img-a"]
+    assert raw["meta"]["done_reason"] == "stop"
+    assert raw["thinking_only_recovery"] == {
+        "attempted": True,
+        "succeeded": True,
+        "initial_meta": {
+            "done": True,
+            "done_reason": initial_done_reason,
+            "prompt_eval_count": 44,
+            "eval_count": 64,
+        },
+        "continuation_meta": {
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": 93,
+            "eval_count": 12,
+        },
+    }
+    assert cleanup_state["provider_cleanup_attempted"] is True
+    assert any(event["status"] == "finishing final answer" for event in progress_events)
+
+
+def test_local_llm_refiner_ollama_normal_thinking_and_final_does_not_retry():
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    stream_payloads = []
+    unload_calls = []
+    cleanup_state = {"provider_cleanup_attempted": False}
+
+    def fake_stream(url, payload, timeout=600.0, cancel_key=None):
+        stream_payloads.append(payload)
+        yield {"message": {"thinking": "reasoning", "content": "final answer"}, "done": False}
+        yield {"done": True, "done_reason": "stop", "prompt_eval_count": 10, "eval_count": 20}
+
+    original_stream = module._http_stream_json_lines
+    original_unload = module._ollama_unload_best_effort
+    module._http_stream_json_lines = fake_stream
+    module._ollama_unload_best_effort = lambda base, model: unload_calls.append((base, model))
+    try:
+        answer, thought, raw = node._run_ollama(
+            server_url="http://127.0.0.1:11434",
+            model="gemma4",
+            system_prompt="",
+            prompt="hello",
+            thinking=True,
+            seed=1,
+            model_memory="Unload after run",
+            keep_minutes=5,
+            image_attachments=[],
+            is_last=True,
+            node_id="node",
+            index=1,
+            total=1,
+            cleanup_state=cleanup_state,
+        )
+    finally:
+        module._http_stream_json_lines = original_stream
+        module._ollama_unload_best_effort = original_unload
+
+    assert answer == "final answer"
+    assert thought == "reasoning"
+    assert len(stream_payloads) == 1
+    assert stream_payloads[0]["think"] is True
+    assert stream_payloads[0]["keep_alive"] == "5m"
+    assert raw["keep_alive"] == "0m"
+    assert raw["initial_keep_alive"] == "5m"
+    assert raw["post_run_unload"] == {"action": "unloaded"}
+    assert unload_calls == [("http://127.0.0.1:11434", "gemma4")]
+    assert cleanup_state["provider_cleanup_attempted"] is True
+    assert sum(
+        payload["keep_alive"] in (0, "0", "0m", "0s")
+        for payload in stream_payloads
+    ) + len(unload_calls) == 1
+    assert "thinking_only_recovery" not in raw
+
+
+def test_local_llm_refiner_ollama_failed_final_continuation_reports_both_terminal_reasons():
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    call_count = 0
+
+    def fake_stream(url, payload, timeout=600.0, cancel_key=None):
+        nonlocal call_count
+        call_count += 1
+        yield {"message": {"thinking": f"reasoning {call_count}"}, "done": False}
+        yield {
+            "done": True,
+            "done_reason": "length" if call_count == 1 else "stop",
+            "prompt_eval_count": 100 + call_count,
+            "eval_count": 200 + call_count,
+        }
+
+    original_stream = module._http_stream_json_lines
+    module._http_stream_json_lines = fake_stream
+    try:
+        with pytest.raises(RuntimeError) as raised:
+            node._run_ollama(
+                server_url="http://127.0.0.1:11434",
+                model="qwen3.6",
+                system_prompt="",
+                prompt="hello",
+                thinking=True,
+                seed=1,
+                model_memory="Unload after run",
+                keep_minutes=5,
+                image_attachments=[],
+                is_last=True,
+                node_id="node",
+                index=1,
+                total=1,
+            )
+    finally:
+        module._http_stream_json_lines = original_stream
+
+    message = str(raised.value)
+    assert call_count == 2
+    assert "after one automatic final-answer continuation" in message
+    assert "Initial: done_reason=length, prompt_eval_count=101, eval_count=201" in message
+    assert "Continuation: done_reason=stop, prompt_eval_count=102, eval_count=202" in message
+
+
 def test_local_llm_refiner_ollama_keep_alive_matches_ollama_node_duration_style():
     package = load_package()
     module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]

--- a/tests/test_local_llm_regressions.py
+++ b/tests/test_local_llm_regressions.py
@@ -229,6 +229,145 @@ def test_local_llm_ollama_completed_terminal_request_does_not_unload_twice_on_po
     assert unload_calls == []
 
 
+def test_local_llm_ollama_continuation_failure_before_response_runs_explicit_cleanup_once(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    unload_calls = []
+    stream_calls = 0
+    original_error = RuntimeError("continuation connection failed")
+
+    def fake_stream(url, payload, timeout=600.0, cancel_key=None):
+        nonlocal stream_calls
+        stream_calls += 1
+        if stream_calls == 1:
+            yield {"message": {"thinking": "unfinished reasoning"}, "done": False}
+            yield {"done": True, "done_reason": "length", "prompt_eval_count": 10, "eval_count": 20}
+            return
+        raise original_error
+        yield  # pragma: no cover - keep this function a generator
+
+    monkeypatch.setattr(module, "_send_progress", lambda _payload: None)
+    monkeypatch.setattr(module, "_unload_other_warm_local_llms", lambda **_kwargs: {})
+    monkeypatch.setattr(module, "_prepare_comfy_vram_before_llm", lambda **_kwargs: {})
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(
+        module,
+        "unload_local_llm_model",
+        lambda *args: unload_calls.append(args) or {"ok": True},
+    )
+
+    kwargs = _refine_kwargs(["only prompt"])
+    kwargs["thinking"] = True
+    with pytest.raises(RuntimeError) as raised:
+        node.refine(**kwargs)
+
+    assert raised.value is original_error
+    assert stream_calls == 2
+    assert unload_calls == [("Ollama", "http://127.0.0.1:11434", "qwen3")]
+
+
+def test_local_llm_ollama_stop_between_thinking_and_continuation_does_not_start_retry(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    unload_calls = []
+    stream_calls = 0
+
+    def fake_stream(url, payload, timeout=600.0, cancel_key=None):
+        nonlocal stream_calls
+        stream_calls += 1
+        yield {"message": {"thinking": "unfinished reasoning"}, "done": False}
+        yield {"done": True, "done_reason": "length", "prompt_eval_count": 10, "eval_count": 20}
+        module._CANCEL_LOCAL_LLM_KEYS.add(cancel_key)
+
+    monkeypatch.setattr(module, "_send_progress", lambda _payload: None)
+    monkeypatch.setattr(module, "_unload_other_warm_local_llms", lambda **_kwargs: {})
+    monkeypatch.setattr(module, "_prepare_comfy_vram_before_llm", lambda **_kwargs: {})
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(
+        module,
+        "unload_local_llm_model",
+        lambda *args: unload_calls.append(args) or {"ok": True},
+    )
+
+    kwargs = _refine_kwargs(["only prompt"])
+    kwargs["thinking"] = True
+    with pytest.raises(Exception, match="Local LLM generation stopped"):
+        node.refine(**kwargs)
+
+    assert stream_calls == 1
+    assert unload_calls == [("Ollama", "http://127.0.0.1:11434", "qwen3")]
+
+
+@pytest.mark.parametrize("recover_prompt_index", [0, 1])
+def test_local_llm_ollama_continuation_preserves_batch_order_and_one_terminal_unload(
+    monkeypatch,
+    recover_prompt_index,
+):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    stream_payloads = []
+    explicit_unload_calls = []
+    fallback_unload_calls = []
+    prompt_attempts = {"first prompt": 0, "second prompt": 0}
+
+    def fake_stream(url, payload, timeout=600.0, cancel_key=None):
+        stream_payloads.append(payload)
+        original_prompt = next(
+            message["content"]
+            for message in payload["messages"]
+            if message.get("role") == "user"
+        )
+        prompt_attempts[original_prompt] += 1
+        prompt_index = 0 if original_prompt == "first prompt" else 1
+        if prompt_index == recover_prompt_index and payload["think"] is True:
+            yield {"message": {"thinking": f"reasoning {prompt_index}"}, "done": False}
+            yield {"done": True, "done_reason": "length", "prompt_eval_count": 10, "eval_count": 20}
+            return
+        yield {
+            "message": {
+                "thinking": "" if payload["think"] is False else f"reasoning {prompt_index}",
+                "content": f"final {prompt_index}",
+            },
+            "done": False,
+        }
+        yield {"done": True, "done_reason": "stop", "prompt_eval_count": 11, "eval_count": 12}
+
+    monkeypatch.setattr(module, "_send_progress", lambda _payload: None)
+    monkeypatch.setattr(module, "_unload_other_warm_local_llms", lambda **_kwargs: {})
+    monkeypatch.setattr(module, "_prepare_comfy_vram_before_llm", lambda **_kwargs: {})
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(module, "_ensure_ollama_model_stays_loaded", lambda **_kwargs: {"checked": False})
+    monkeypatch.setattr(
+        module,
+        "_ollama_unload_best_effort",
+        lambda base, model: explicit_unload_calls.append((base, model)),
+    )
+    monkeypatch.setattr(
+        module,
+        "unload_local_llm_model",
+        lambda *args: fallback_unload_calls.append(args) or {"ok": True},
+    )
+
+    kwargs = _refine_kwargs(["first prompt", "second prompt"])
+    kwargs["thinking"] = True
+    result = node.refine(**kwargs)
+
+    assert result["result"][0] == ["final 0", "final 1"]
+    assert prompt_attempts == {
+        "first prompt": 2 if recover_prompt_index == 0 else 1,
+        "second prompt": 2 if recover_prompt_index == 1 else 1,
+    }
+    terminal_keep_alive_count = sum(
+        payload["keep_alive"] in (0, "0", "0m", "0s")
+        for payload in stream_payloads
+    )
+    assert terminal_keep_alive_count + len(explicit_unload_calls) == 1
+    assert fallback_unload_calls == []
+
+
 def test_llama_swap_running_parser_matches_official_management_shape():
     package = load_package()
     module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]


### PR DESCRIPTION
## Summary
- recover an Ollama response that finishes its reasoning stream without final content by continuing exactly once with Thinking disabled
- preserve the original system/user messages, images, seed, cancellation, progress, and exact-once unload behavior
- release the isolated backend hotfix as v0.7.82

## Scope
- includes only the Local LLM Ollama backend, focused regression tests, version, and changelog
- excludes all Audio Transcript, audio_context, and MiniMax H3 Audio-to-Video work

## Verification
- `454 passed` in the full Python CI-equivalent suite
- JavaScript syntax check and LTX input-slot harness passed
- focused continuation matrix passed for length/stop, normal final, failed continuation, cancellation, connection failure, batching, image preservation, and unload finality
- Registry manifest remains 411 files with no Audio/A2V paths
- live isolated Ollama reproduction recovered a real reasoning-only `done_reason=length` response and returned final text