### PR TITLE
Enforce final-only local LLM responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This file intentionally stays short. Detailed engineering notes belong in privat
 
 ## Unreleased
 
+## 0.7.83 - 2026-08-09
+
+- Hardened `(Deno) Local LLM Loader` so Ollama and LM Studio return only the validated final answer while keeping reasoning and provider-added preambles out of the Result, without changing saved prompts, images, seed controls, or arbitrary multiline and Reviewer JSON outputs; LM Studio now applies the selected seed to generation requests.
+- Added one bounded finalization attempt for completed malformed or thinking-only replies, then fail closed instead of forwarding unvalidated model text; LM Studio generation now uses its official JSON Schema chat-completions path while retaining native model discovery and unload.
+
 ## 0.7.82 - 2026-08-09
 
 - Fixed `(Deno) Local LLM Loader` with Ollama Thinking enabled so a completed reasoning-only response automatically continues once to produce the final answer, while preserving the original prompt, images, seed, cancellation, and unload behavior.

--- a/deno_local_llm_refiner.py
+++ b/deno_local_llm_refiner.py
@@ -166,6 +166,22 @@ FINAL_PROMPT_MARKER_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 FINAL_PROMPT_LINE_RE = re.compile(r"DENO_FINAL_PROMPT\s*:\s*([^\r\n]+)", re.IGNORECASE)
+STRUCTURED_FINAL_ANSWER_FIELD = "deno_final_answer"
+STRUCTURED_FINAL_ANSWER_SYSTEM_INSTRUCTION = (
+    "Internal response contract: Return the requested downstream final answer in the "
+    "deno_final_answer field required by the transport JSON schema. The field value must "
+    "contain only the completed answer requested by the user. Never include private "
+    "chain-of-thought, hidden reasoning, scratch work, or internal deliberation, even if "
+    "requested. If the user asks for reasoning or an explanation, provide only a concise "
+    "answer-facing explanation. Exclude provider preambles, process commentary, transport "
+    "labels, and Markdown fences unless those visible answer elements are explicitly "
+    "requested. Never write anything outside the JSON object."
+)
+STRUCTURED_FINALIZATION_INSTRUCTION = (
+    "Finish the original request now. Return one valid response matching the required "
+    "transport JSON schema, with only the requested downstream final answer in "
+    "deno_final_answer and no text outside the JSON object."
+)
 REVIEWER_PREVIEW_SUBFOLDER = "deno_llm_reviewer"
 _WARM_LOCAL_LLM_KEYS: Dict[str, Optional[float]] = {}
 _ACTIVE_LOCAL_LLM_KEYS: Dict[str, int] = {}
@@ -1276,6 +1292,137 @@ def _raise_if_thinking_only_result(answer: str, thinking: str) -> None:
     raise RuntimeError(
         "The local model returned thinking text but no final result. "
         "Turn Thinking off, or ask the model to write a final answer after thinking."
+    )
+
+
+class _FinalAnswerEnvelopeError(RuntimeError):
+    """A provider response did not satisfy DENO's private transport contract."""
+
+
+def _final_answer_schema() -> Dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            STRUCTURED_FINAL_ANSWER_FIELD: {
+                "type": "string",
+                "description": (
+                    "Only the complete final answer requested by the original system and user "
+                    "messages. Never include private chain-of-thought, hidden reasoning, scratch "
+                    "work, or internal deliberation. Include an answer-facing explanation or "
+                    "requested visible formatting only when the original request requires it; "
+                    "exclude provider preambles, transport labels, and process commentary."
+                ),
+            },
+        },
+        "required": [STRUCTURED_FINAL_ANSWER_FIELD],
+        "additionalProperties": False,
+    }
+
+
+def _openai_final_answer_response_format() -> Dict[str, Any]:
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": STRUCTURED_FINAL_ANSWER_FIELD,
+            "strict": True,
+            "schema": _final_answer_schema(),
+        },
+    }
+
+
+def _unwrap_final_answer_envelope(content: str, provider: str) -> str:
+    provider_name = str(provider or "Local LLM").strip() or "Local LLM"
+    raw = str(content or "")
+    stripped = raw.strip()
+    if not stripped:
+        raise _FinalAnswerEnvelopeError(
+            f"{provider_name} returned no structured final-answer envelope."
+        )
+    try:
+        parsed = json.loads(stripped)
+    except (TypeError, ValueError) as exc:
+        raise _FinalAnswerEnvelopeError(
+            f"{provider_name} returned text outside or instead of the required structured final-answer envelope."
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise _FinalAnswerEnvelopeError(
+            f"{provider_name}'s structured final-answer envelope must be a JSON object."
+        )
+    if set(parsed) != {STRUCTURED_FINAL_ANSWER_FIELD}:
+        raise _FinalAnswerEnvelopeError(
+            f"{provider_name}'s structured final-answer envelope has missing or unexpected fields."
+        )
+    answer = parsed.get(STRUCTURED_FINAL_ANSWER_FIELD)
+    if not isinstance(answer, str):
+        raise _FinalAnswerEnvelopeError(
+            f"{provider_name}'s deno_final_answer field must be a string."
+        )
+    if not answer.strip():
+        raise _FinalAnswerEnvelopeError(
+            f"{provider_name}'s deno_final_answer field is blank."
+        )
+    return answer
+
+
+def _looks_like_unsupported_ollama_structured_output_error(detail: Any) -> bool:
+    lowered = str(detail or "").strip().lower()
+    if not lowered:
+        return False
+    format_markers = (
+        "structured output",
+        "json schema",
+        "schema",
+        "format",
+    )
+    unsupported_markers = (
+        "does not support",
+        "not supported",
+        "unsupported",
+        "unknown field",
+        "unrecognized field",
+        "invalid format",
+        "invalid schema",
+    )
+    return any(marker in lowered for marker in format_markers) and any(
+        marker in lowered for marker in unsupported_markers
+    )
+
+
+def _structured_output_compatibility_error(provider: str, detail: Any) -> RuntimeError:
+    provider_name = str(provider or "local LLM").strip() or "local LLM"
+    detail_text = str(detail or "").strip()
+    suffix = f" Server detail: {detail_text[:300]}" if detail_text else ""
+    return RuntimeError(
+        f"The selected {provider_name} model or server does not support the structured output required "
+        "to keep reasoning and extra commentary out of the node result. Update the local server or choose "
+        f"a model that supports JSON-schema output.{suffix}"
+    )
+
+
+def _looks_like_unsupported_lm_studio_structured_output_error(detail: Any) -> bool:
+    lowered = str(detail or "").strip().lower()
+    if not lowered:
+        return False
+    schema_markers = (
+        "structured output",
+        "json schema",
+        "json_schema",
+        "response_format",
+        "schema",
+    )
+    unsupported_markers = (
+        "does not support",
+        "not supported",
+        "unsupported",
+        "unknown field",
+        "unknown parameter",
+        "unrecognized field",
+        "unrecognized parameter",
+        "invalid response_format",
+        "invalid schema",
+    )
+    return any(marker in lowered for marker in schema_markers) and any(
+        marker in lowered for marker in unsupported_markers
     )
 
 
@@ -2943,17 +3090,17 @@ class DenoLocalLLMRefiner:
         memory_value = _normalize_model_memory(model_memory)
         keep_minutes_value = max(1, int(keep_minutes))
         messages = []
+        internal_system_prompt = STRUCTURED_FINAL_ANSWER_SYSTEM_INSTRUCTION
         if system_prompt.strip():
-            messages.append({"role": "system", "content": system_prompt})
+            internal_system_prompt = f"{system_prompt}\n\n{internal_system_prompt}"
+        messages.append({"role": "system", "content": internal_system_prompt})
         user_message: Dict[str, Any] = {"role": "user", "content": prompt}
         if image_attachments:
             user_message["images"] = [attachment["base64"] for attachment in image_attachments]
         messages.append(user_message)
 
         logical_keep_alive = _ollama_keep_alive(memory_value, keep_minutes_value, is_last)
-        hold_for_possible_continuation = bool(
-            thinking and _should_unload_after_run(memory_value, is_last)
-        )
+        hold_for_possible_continuation = _should_unload_after_run(memory_value, is_last)
         initial_keep_alive = (
             _ollama_keep_alive(memory_value, keep_minutes_value, False)
             if hold_for_possible_continuation
@@ -2964,16 +3111,21 @@ class DenoLocalLLMRefiner:
             "messages": messages,
             "stream": True,
             "think": thinking,
+            "format": _final_answer_schema(),
             "options": {"seed": int(seed)},
             "keep_alive": initial_keep_alive,
         }
-        answer_parts: List[str] = []
-        thinking_parts: List[str] = []
+        completed_thinking_parts: List[str] = []
         last_emit = 0.0
         cancel_key = _llm_state_key(PROVIDER_OLLAMA, base, model)
 
-        def stream_request(request_payload: Dict[str, Any], status: str) -> Dict[str, Any]:
+        def stream_request(
+            request_payload: Dict[str, Any],
+            status: str,
+        ) -> Tuple[str, str, Dict[str, Any]]:
             nonlocal last_emit
+            request_answer_parts: List[str] = []
+            request_thinking_parts: List[str] = []
             request_observed = False
             request_meta: Dict[str, Any] = {}
             for chunk in _http_stream_json_lines(f"{base}/api/chat", request_payload, cancel_key=cancel_key):
@@ -3003,9 +3155,9 @@ class DenoLocalLLMRefiner:
                     or ""
                 )
                 if content:
-                    answer_parts.append(content)
+                    request_answer_parts.append(content)
                 if thought:
-                    thinking_parts.append(thought)
+                    request_thinking_parts.append(thought)
                 if chunk.get("done"):
                     request_meta = {
                         key: chunk.get(key)
@@ -3023,6 +3175,14 @@ class DenoLocalLLMRefiner:
                 now = time.monotonic()
                 if now - last_emit > 0.12 or content or thought:
                     last_emit = now
+                    visible_thinking_parts = list(completed_thinking_parts) if thinking else []
+                    current_thinking = (
+                        "".join(request_thinking_parts).strip()
+                        if thinking
+                        else ""
+                    )
+                    if current_thinking:
+                        visible_thinking_parts.append(current_thinking)
                     _send_progress({
                         "node_id": node_id,
                         "status": status,
@@ -3030,22 +3190,47 @@ class DenoLocalLLMRefiner:
                         "model": model,
                         "index": index,
                         "total": total,
-                        "answer": "".join(answer_parts),
-                        "thinking": "".join(thinking_parts),
+                        # Do not expose an unvalidated envelope or provider chatter.
+                        "answer": "",
+                        "thinking": "\n".join(visible_thinking_parts).strip(),
                     })
-            return request_meta
+            if request_meta.get("done") is not True:
+                raise RuntimeError(
+                    "Ollama ended the response stream before confirming completion. "
+                    "Partial model text was discarded and no automatic finalization was attempted."
+                )
+            return (
+                "".join(request_answer_parts),
+                "".join(request_thinking_parts).strip(),
+                request_meta,
+            )
 
-        final_meta = stream_request(payload, "running")
+        try:
+            initial_content, initial_thinking, final_meta = stream_request(payload, "running")
+        except RuntimeError as exc:
+            if _looks_like_unsupported_ollama_structured_output_error(exc):
+                raise _structured_output_compatibility_error(PROVIDER_OLLAMA, exc) from exc
+            raise
 
-        answer = "".join(answer_parts).strip()
-        thought = "".join(thinking_parts).strip()
+        if thinking and initial_thinking:
+            completed_thinking_parts.append(initial_thinking)
+        thought = "\n".join(completed_thinking_parts).strip()
         recovery_meta: Optional[Dict[str, Any]] = None
-        if thinking and not answer and thought and final_meta.get("done") is True:
+        try:
+            answer = _unwrap_final_answer_envelope(initial_content, PROVIDER_OLLAMA)
+        except _FinalAnswerEnvelopeError as initial_envelope_error:
             _raise_if_local_llm_stopped(cancel_key)
             initial_meta = dict(final_meta)
             continuation_payload = dict(payload)
+            previous_assistant_message: Dict[str, Any] = {
+                "role": "assistant",
+                "content": initial_content,
+            }
+            if initial_thinking:
+                previous_assistant_message["thinking"] = initial_thinking
             continuation_payload["messages"] = list(messages) + [
-                {"role": "assistant", "content": "", "thinking": thought},
+                previous_assistant_message,
+                {"role": "user", "content": STRUCTURED_FINALIZATION_INSTRUCTION},
             ]
             continuation_payload["think"] = False
             continuation_payload["keep_alive"] = logical_keep_alive
@@ -3059,16 +3244,21 @@ class DenoLocalLLMRefiner:
                 "answer": "",
                 "thinking": thought,
             })
-            final_meta = stream_request(continuation_payload, "finishing final answer")
-            answer = "".join(answer_parts).strip()
-            thought = "".join(thinking_parts).strip()
-            recovery_meta = {
-                "attempted": True,
-                "succeeded": bool(answer),
-                "initial_meta": initial_meta,
-                "continuation_meta": dict(final_meta),
-            }
-            if not answer:
+            try:
+                final_content, finalization_thinking, final_meta = stream_request(
+                    continuation_payload,
+                    "finishing final answer",
+                )
+            except RuntimeError as exc:
+                if _looks_like_unsupported_ollama_structured_output_error(exc):
+                    raise _structured_output_compatibility_error(PROVIDER_OLLAMA, exc) from exc
+                raise
+            if thinking and finalization_thinking:
+                completed_thinking_parts.append(finalization_thinking)
+            thought = "\n".join(completed_thinking_parts).strip()
+            try:
+                answer = _unwrap_final_answer_envelope(final_content, PROVIDER_OLLAMA)
+            except _FinalAnswerEnvelopeError as final_envelope_error:
                 def meta_summary(meta: Dict[str, Any]) -> str:
                     values = [
                         f"done_reason={meta.get('done_reason', 'unknown')}",
@@ -3078,10 +3268,18 @@ class DenoLocalLLMRefiner:
                     return ", ".join(values)
 
                 raise RuntimeError(
-                    "Ollama returned thinking text but no final result after one automatic final-answer continuation. "
-                    f"Initial: {meta_summary(initial_meta)}. Continuation: {meta_summary(final_meta)}. "
-                    "Shorten the prompt or turn Thinking off."
-                )
+                    "Ollama did not return a valid structured final answer after one automatic "
+                    "finalization attempt. Raw model text was discarded. "
+                    f"Initial: {meta_summary(initial_meta)}. Finalization: {meta_summary(final_meta)}. "
+                    "Update Ollama, choose a model with reliable JSON-schema output, or simplify the request."
+                ) from final_envelope_error
+            recovery_meta = {
+                "attempted": True,
+                "succeeded": True,
+                "initial_error": str(initial_envelope_error),
+                "initial_meta": initial_meta,
+                "finalization_meta": dict(final_meta),
+            }
         post_run_unload: Dict[str, Any] = {"action": "none"}
         if hold_for_possible_continuation and recovery_meta is None and answer:
             if cleanup_state is not None:
@@ -3104,7 +3302,7 @@ class DenoLocalLLMRefiner:
         if initial_keep_alive != logical_keep_alive:
             raw["initial_keep_alive"] = initial_keep_alive
         if recovery_meta is not None:
-            raw["thinking_only_recovery"] = recovery_meta
+            raw["final_answer_recovery"] = recovery_meta
         raw["post_keepalive"] = _ensure_ollama_model_stays_loaded(
             base=base,
             model=model,
@@ -3297,116 +3495,164 @@ class DenoLocalLLMRefiner:
         openai_base = _normalize_lm_openai_url(server_url)
         memory_value = _normalize_model_memory(model_memory)
         keep_minutes_value = max(1, int(keep_minutes))
+        internal_system_prompt = STRUCTURED_FINAL_ANSWER_SYSTEM_INSTRUCTION
+        if system_prompt.strip():
+            internal_system_prompt = f"{system_prompt}\n\n{internal_system_prompt}"
+        messages: List[Dict[str, Any]] = [
+            {"role": "system", "content": internal_system_prompt},
+        ]
+        if image_attachments:
+            user_content: Any = [{"type": "text", "text": prompt}] + [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": attachment["data_url"]},
+                }
+                for attachment in image_attachments
+            ]
+        else:
+            user_content = prompt
+        messages.append({"role": "user", "content": user_content})
+
+        reasoning_effort = "high" if thinking else "none"
         payload: Dict[str, Any] = {
             "model": model,
+            "messages": messages,
             "stream": True,
-            "input": _lm_native_input(prompt, image_attachments),
-            "store": False,
+            "seed": int(seed),
+            "reasoning_effort": reasoning_effort,
+            "response_format": _openai_final_answer_response_format(),
         }
-        reasoning_requested = "on" if thinking else "off"
-        if thinking:
-            payload["reasoning"] = "on"
-        else:
-            reasoning_options = _lm_studio_reasoning_options(native_base, model)
-            # A missing or expired capability cache must not silently restore
-            # the model's default reasoning mode. Only a cached model that
-            # explicitly lacks `off` skips the field for compatibility.
-            if reasoning_options is None or "off" in reasoning_options:
-                payload["reasoning"] = "off"
-        if system_prompt.strip():
-            payload["system_prompt"] = system_prompt
 
-        # The active key still uses the OpenAI-style base saved in workflows,
-        # while the real request uses LM Studio's native chat endpoint.
         cancel_key = _llm_state_key(PROVIDER_LM_STUDIO, openai_base, model)
+        completed_thinking_parts: List[str] = []
+        last_emit = 0.0
 
-        reasoning_compat_fallback = False
-        reasoning_observed = False
-        try:
-            while True:
-                answer_parts: List[str] = []
-                thinking_parts: List[str] = []
-                final_meta: Dict[str, Any] = {}
-                last_emit = 0.0
-                received_generation_output = False
-                try:
-                    for event_name, chunk in _http_stream_sse(
-                        f"{native_base}/api/v1/chat",
-                        payload,
-                        cancel_key=cancel_key,
-                    ):
-                        if chunk.get("error"):
-                            error = chunk.get("error")
-                            if isinstance(error, dict):
-                                detail = str(error.get("message") or error)
-                                error_param = str(error.get("param") or "").strip()
-                                if error_param:
-                                    detail = f"{detail} (param: {error_param})"
-                            else:
-                                detail = str(error)
-                            if _looks_like_model_unavailable_error(detail):
-                                raise RuntimeError(_model_unavailable_message(model, detail))
-                            raise RuntimeError(detail)
-                        event_type = str(chunk.get("type") or event_name or "")
-                        content = str(chunk.get("content") or "") if event_type == "message.delta" else ""
-                        thought = str(chunk.get("content") or "") if event_type == "reasoning.delta" else ""
-                        if content:
-                            received_generation_output = True
-                            answer_parts.append(content)
-                        if thought:
-                            received_generation_output = True
-                            reasoning_observed = True
-                            if thinking:
-                                thinking_parts.append(thought)
-                        if event_type == "chat.end":
-                            final_meta = chunk
-                        now = time.monotonic()
-                        if now - last_emit > 0.12 or content or thought:
-                            last_emit = now
-                            _send_progress({
-                                "node_id": node_id,
-                                "status": "running",
-                                "provider": PROVIDER_LM_STUDIO,
-                                "model": model,
-                                "index": index,
-                                "total": total,
-                                "answer": "".join(answer_parts),
-                                "thinking": "".join(thinking_parts),
-                            })
-                    break
-                except RuntimeError as exc:
-                    can_retry_without_reasoning = (
-                        not thinking
-                        and payload.get("reasoning") == "off"
-                        and not reasoning_compat_fallback
-                        and not received_generation_output
-                        and not final_meta
-                        and _looks_like_unsupported_lm_studio_reasoning_error(str(exc))
+        def stream_request(
+            request_payload: Dict[str, Any],
+            status: str,
+        ) -> Tuple[str, str, Dict[str, Any]]:
+            nonlocal last_emit
+            request_answer_parts: List[str] = []
+            request_thinking_parts: List[str] = []
+            final_meta: Dict[str, Any] = {}
+            for _event_name, chunk in _http_stream_sse(
+                f"{openai_base}/chat/completions",
+                request_payload,
+                cancel_key=cancel_key,
+            ):
+                if chunk.get("error"):
+                    error = chunk.get("error")
+                    if isinstance(error, dict):
+                        detail = str(error.get("message") or error)
+                        error_param = str(error.get("param") or "").strip()
+                        if error_param:
+                            detail = f"{detail} (param: {error_param})"
+                    else:
+                        detail = str(error)
+                    if _looks_like_model_unavailable_error(detail):
+                        raise RuntimeError(_model_unavailable_message(model, detail))
+                    raise RuntimeError(detail)
+                content, thought = _extract_lm_delta(chunk)
+                if content:
+                    request_answer_parts.append(content)
+                if thought:
+                    request_thinking_parts.append(thought)
+                choices = chunk.get("choices")
+                if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+                    if choices[0].get("finish_reason") is not None:
+                        final_meta = dict(chunk)
+                now = time.monotonic()
+                if now - last_emit > 0.12 or content or thought:
+                    last_emit = now
+                    visible_thinking_parts = list(completed_thinking_parts) if thinking else []
+                    current_thinking = (
+                        "".join(request_thinking_parts).strip()
+                        if thinking
+                        else ""
                     )
-                    if not can_retry_without_reasoning:
-                        raise
-                    payload = dict(payload)
-                    payload.pop("reasoning", None)
-                    reasoning_compat_fallback = True
-
-            answer = "".join(answer_parts).strip()
-            thought = "".join(thinking_parts).strip()
-            if not answer and not thought and final_meta:
-                answer, thought = _extract_lm_native_final(final_meta, thinking)
-            if not answer and not thought:
-                _unused_answer, hidden_thought = _extract_lm_native_final(final_meta, True)
-                if not thinking and (reasoning_observed or hidden_thought):
-                    raise RuntimeError(
-                        "LM Studio returned reasoning without final text after Thinking was turned off. "
-                        "The model or server may have ignored reasoning='off'. Update LM Studio or choose "
-                        "a model that supports disabling reasoning."
-                    )
-                detail = (
-                    json.dumps(final_meta, ensure_ascii=False)[:800]
-                    if final_meta
-                    else "No final message was returned."
+                    if current_thinking:
+                        visible_thinking_parts.append(current_thinking)
+                    _send_progress({
+                        "node_id": node_id,
+                        "status": status,
+                        "provider": PROVIDER_LM_STUDIO,
+                        "model": model,
+                        "index": index,
+                        "total": total,
+                        # Never expose an unvalidated JSON envelope or provider chatter.
+                        "answer": "",
+                        "thinking": "\n".join(visible_thinking_parts).strip(),
+                    })
+            if not final_meta:
+                raise RuntimeError(
+                    "LM Studio ended the response stream before confirming completion. "
+                    "Partial model text was discarded and no automatic finalization was attempted."
                 )
-                raise RuntimeError(_lm_studio_empty_stream_error(detail))
+            return (
+                "".join(request_answer_parts),
+                "".join(request_thinking_parts).strip(),
+                final_meta,
+            )
+
+        recovery_meta: Optional[Dict[str, Any]] = None
+        try:
+            try:
+                initial_content, initial_thinking, final_meta = stream_request(payload, "running")
+            except RuntimeError as exc:
+                if _looks_like_unsupported_lm_studio_structured_output_error(exc):
+                    raise _structured_output_compatibility_error(PROVIDER_LM_STUDIO, exc) from exc
+                raise
+            if thinking and initial_thinking:
+                completed_thinking_parts.append(initial_thinking)
+            thought = "\n".join(completed_thinking_parts).strip()
+            try:
+                answer = _unwrap_final_answer_envelope(initial_content, PROVIDER_LM_STUDIO)
+            except _FinalAnswerEnvelopeError as initial_envelope_error:
+                _raise_if_local_llm_stopped(cancel_key)
+                initial_meta = dict(final_meta)
+                continuation_payload = dict(payload)
+                continuation_payload["messages"] = list(messages) + [
+                    {"role": "assistant", "content": initial_content},
+                    {"role": "user", "content": STRUCTURED_FINALIZATION_INSTRUCTION},
+                ]
+                continuation_payload["reasoning_effort"] = "none"
+                _send_progress({
+                    "node_id": node_id,
+                    "status": "finishing final answer",
+                    "provider": PROVIDER_LM_STUDIO,
+                    "model": model,
+                    "index": index,
+                    "total": total,
+                    "answer": "",
+                    "thinking": thought,
+                })
+                try:
+                    final_content, finalization_thinking, final_meta = stream_request(
+                        continuation_payload,
+                        "finishing final answer",
+                    )
+                except RuntimeError as exc:
+                    if _looks_like_unsupported_lm_studio_structured_output_error(exc):
+                        raise _structured_output_compatibility_error(PROVIDER_LM_STUDIO, exc) from exc
+                    raise
+                if thinking and finalization_thinking:
+                    completed_thinking_parts.append(finalization_thinking)
+                thought = "\n".join(completed_thinking_parts).strip()
+                try:
+                    answer = _unwrap_final_answer_envelope(final_content, PROVIDER_LM_STUDIO)
+                except _FinalAnswerEnvelopeError as final_envelope_error:
+                    raise RuntimeError(
+                        "LM Studio did not return a valid structured final answer after one automatic "
+                        "finalization attempt. Raw model text was discarded. Update LM Studio, choose "
+                        "a model with reliable JSON-schema output, or simplify the request."
+                    ) from final_envelope_error
+                recovery_meta = {
+                    "attempted": True,
+                    "succeeded": True,
+                    "initial_error": str(initial_envelope_error),
+                    "initial_meta": initial_meta,
+                    "finalization_meta": dict(final_meta),
+                }
         finally:
             if _should_unload_after_run(memory_value, is_last):
                 if cleanup_state is not None:
@@ -3419,12 +3665,13 @@ class DenoLocalLLMRefiner:
             "seed": seed,
             "model_memory": memory_value,
             "keep_minutes": keep_minutes_value,
-            "reasoning": payload.get("reasoning"),
-            "reasoning_requested": reasoning_requested,
-            "reasoning_compat_fallback": reasoning_compat_fallback,
-            "api": "LM Studio /api/v1/chat",
+            "reasoning_effort": payload.get("reasoning_effort"),
+            "reasoning_requested": reasoning_effort,
+            "api": "LM Studio /v1/chat/completions",
             "meta": final_meta,
         }
+        if recovery_meta is not None:
+            raw["final_answer_recovery"] = recovery_meta
         if image_attachments:
             raw["images"] = _image_attachment_metadata(image_attachments)
             raw["image"] = raw["images"][0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "deno-custom-nodes"
 description = "DENO RTX node pack for ComfyUI: MiniMax H3 multi-reference image and Reference to Video helpers, Ideogram Director visual JSON/bbox prompt builder, Local LLM Loader and Reviewer helpers, GPT/Gemini-ready Error Help reports, Prompt Only final prompt extraction, RTX Video Super Resolution, RTX Super Resolution, Video SR/VSR, NVIDIA VFX/nvvfx, RTX upscale helpers, LTX 2.3 workflows, LTX tiled second-pass refinement helpers, Bernini Prompt Guide, audio/image review gates, Bernini conditioning helpers, Wan 2.2 reference video edit workflows, image and video compare, video preview, Video to GIF/WebP tools, multi-image loading, resize tools, LoRA/model helpers, prompt guides, and visual workflow utilities."
-version = "0.7.82"
+version = "0.7.83"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = []

--- a/tests/test_image_resize_node.py
+++ b/tests/test_image_resize_node.py
@@ -4332,16 +4332,8 @@ def test_local_llm_refiner_lm_studio_keep_minutes_does_not_unload():
 
     def fake_stream(url, payload, **_kwargs):
         stream_payloads.append({"url": url, "payload": dict(payload)})
-        yield "reasoning.delta", {"type": "reasoning.delta", "content": "hidden thought"}
-        yield "message.delta", {"type": "message.delta", "content": "kept"}
-        yield "chat.end", {
-            "type": "chat.end",
-            "result": {
-                "model_instance_id": payload["model"],
-                "output": [{"type": "message", "content": "kept"}],
-                "stats": {"reasoning_output_tokens": 0},
-            },
-        }
+        yield "message", {"choices": [{"delta": {"content": json.dumps({"deno_final_answer": "kept"})}}]}
+        yield "message", {"choices": [{"delta": {}, "finish_reason": "stop"}]}
 
     node._lm_unload_best_effort = lambda native_base, model: unload_calls.append((native_base, model))
     module._http_stream_sse = fake_stream
@@ -4369,22 +4361,20 @@ def test_local_llm_refiner_lm_studio_keep_minutes_does_not_unload():
 
     assert answer == "kept"
     assert thought == ""
-    assert stream_payloads[0]["url"] == "http://127.0.0.1:1234/api/v1/chat"
-    assert stream_payloads[0]["payload"]["reasoning"] == "off"
-    assert stream_payloads[0]["payload"]["input"] == "hello"
-    assert stream_payloads[0]["payload"]["store"] is False
-    assert "ttl" not in stream_payloads[0]["payload"]
-    assert "seed" not in stream_payloads[0]["payload"]
-    assert raw["reasoning"] == "off"
-    assert raw["reasoning_requested"] == "off"
-    assert raw["reasoning_compat_fallback"] is False
+    assert stream_payloads[0]["url"] == "http://127.0.0.1:1234/v1/chat/completions"
+    assert stream_payloads[0]["payload"]["reasoning_effort"] == "none"
+    assert stream_payloads[0]["payload"]["messages"][1] == {"role": "user", "content": "hello"}
+    assert stream_payloads[0]["payload"]["seed"] == 7
+    assert stream_payloads[0]["payload"]["response_format"]["type"] == "json_schema"
+    assert raw["reasoning_effort"] == "none"
+    assert raw["reasoning_requested"] == "none"
     assert raw["model_memory"] == "Keep for minutes"
     assert raw["keep_minutes"] == 3
-    assert raw["api"] == "LM Studio /api/v1/chat"
+    assert raw["api"] == "LM Studio /v1/chat/completions"
     assert unload_calls == []
 
 
-def test_local_llm_refiner_lm_studio_sends_reasoning_off_when_model_supports_it():
+def test_local_llm_refiner_lm_studio_sends_reasoning_none_regardless_of_cached_capability():
     package = load_package()
     module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
     node = package.DenoLocalLLMRefiner()
@@ -4394,8 +4384,8 @@ def test_local_llm_refiner_lm_studio_sends_reasoning_off_when_model_supports_it(
 
     def fake_stream(url, payload, **_kwargs):
         stream_payloads.append({"url": url, "payload": dict(payload)})
-        yield "message.delta", {"type": "message.delta", "content": "kept"}
-        yield "chat.end", {"type": "chat.end", "result": {"output": [{"type": "message", "content": "kept"}]}}
+        yield "message", {"choices": [{"delta": {"content": json.dumps({"deno_final_answer": "kept"})}}]}
+        yield "message", {"choices": [{"delta": {}, "finish_reason": "stop"}]}
 
     module._http_stream_sse = fake_stream
     module._cache_lm_studio_models(
@@ -4424,13 +4414,12 @@ def test_local_llm_refiner_lm_studio_sends_reasoning_off_when_model_supports_it(
 
     assert answer == "kept"
     assert thought == ""
-    assert stream_payloads[0]["payload"]["reasoning"] == "off"
-    assert raw["reasoning"] == "off"
-    assert raw["reasoning_requested"] == "off"
-    assert raw["reasoning_compat_fallback"] is False
+    assert stream_payloads[0]["payload"]["reasoning_effort"] == "none"
+    assert raw["reasoning_effort"] == "none"
+    assert raw["reasoning_requested"] == "none"
 
 
-def test_local_llm_refiner_lm_studio_omits_reasoning_when_cached_model_does_not_support_it():
+def test_local_llm_refiner_lm_studio_sends_reasoning_none_when_cache_has_no_native_options():
     package = load_package()
     module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
     node = package.DenoLocalLLMRefiner()
@@ -4440,8 +4429,8 @@ def test_local_llm_refiner_lm_studio_omits_reasoning_when_cached_model_does_not_
 
     def fake_stream(url, payload, **_kwargs):
         stream_payloads.append({"url": url, "payload": dict(payload)})
-        yield "message.delta", {"type": "message.delta", "content": "kept"}
-        yield "chat.end", {"type": "chat.end", "result": {"output": [{"type": "message", "content": "kept"}]}}
+        yield "message", {"choices": [{"delta": {"content": json.dumps({"deno_final_answer": "kept"})}}]}
+        yield "message", {"choices": [{"delta": {}, "finish_reason": "stop"}]}
 
     module._http_stream_sse = fake_stream
     module._cache_lm_studio_models(
@@ -4470,10 +4459,9 @@ def test_local_llm_refiner_lm_studio_omits_reasoning_when_cached_model_does_not_
 
     assert answer == "kept"
     assert thought == ""
-    assert "reasoning" not in stream_payloads[0]["payload"]
-    assert raw["reasoning"] is None
-    assert raw["reasoning_requested"] == "off"
-    assert raw["reasoning_compat_fallback"] is False
+    assert stream_payloads[0]["payload"]["reasoning_effort"] == "none"
+    assert raw["reasoning_effort"] == "none"
+    assert raw["reasoning_requested"] == "none"
 
 
 def test_local_llm_refiner_lm_studio_sends_reasoning_only_when_thinking_enabled():
@@ -4486,9 +4474,9 @@ def test_local_llm_refiner_lm_studio_sends_reasoning_only_when_thinking_enabled(
 
     def fake_stream(url, payload, **_kwargs):
         stream_payloads.append({"url": url, "payload": dict(payload)})
-        yield "reasoning.delta", {"type": "reasoning.delta", "content": "visible thought"}
-        yield "message.delta", {"type": "message.delta", "content": "answer"}
-        yield "chat.end", {"type": "chat.end", "result": {"output": [{"type": "message", "content": "answer"}]}}
+        yield "message", {"choices": [{"delta": {"reasoning_content": "visible thought"}}]}
+        yield "message", {"choices": [{"delta": {"content": json.dumps({"deno_final_answer": "answer"})}}]}
+        yield "message", {"choices": [{"delta": {}, "finish_reason": "stop"}]}
 
     module._http_stream_sse = fake_stream
     try:
@@ -4512,10 +4500,9 @@ def test_local_llm_refiner_lm_studio_sends_reasoning_only_when_thinking_enabled(
 
     assert answer == "answer"
     assert thought == "visible thought"
-    assert stream_payloads[0]["payload"]["reasoning"] == "on"
-    assert raw["reasoning"] == "on"
-    assert raw["reasoning_requested"] == "on"
-    assert raw["reasoning_compat_fallback"] is False
+    assert stream_payloads[0]["payload"]["reasoning_effort"] == "high"
+    assert raw["reasoning_effort"] == "high"
+    assert raw["reasoning_requested"] == "high"
 
 
 def test_local_llm_refiner_lm_studio_native_extracts_top_level_output():
@@ -4552,8 +4539,7 @@ def test_local_llm_refiner_lm_studio_empty_stream_fails_without_duplicate_genera
 
     def fake_stream(_url, payload, **_kwargs):
         stream_payloads.append(dict(payload))
-        yield "chat.start", {"type": "chat.start", "model_instance_id": "google/gemma-4-12b"}
-        yield "chat.end", {"type": "chat.end", "result": {"output": []}}
+        yield "message", {"choices": [{"delta": {"content": "partial"}}]}
 
     def fake_http_json(url, _payload=None, method="GET", timeout=20.0):
         nonstream_calls.append((url, dict(_payload or {}), method, timeout))
@@ -4564,7 +4550,7 @@ def test_local_llm_refiner_lm_studio_empty_stream_fails_without_duplicate_genera
     module.list_local_llm_models = lambda _provider, _server_url: []
     node._lm_unload_best_effort = lambda native_base, model: unload_calls.append((native_base, model))
     try:
-        with pytest.raises(RuntimeError, match="ended the response stream without final text"):
+        with pytest.raises(RuntimeError, match="before confirming completion"):
             node._run_lm_studio(
                 server_url="http://127.0.0.1:1234/v1",
                 model="google/gemma-4-12b",
@@ -4587,53 +4573,53 @@ def test_local_llm_refiner_lm_studio_empty_stream_fails_without_duplicate_genera
         node._lm_unload_best_effort = original_unload
 
     assert len(stream_payloads) == 1
-    assert stream_payloads[0]["reasoning"] == "off"
+    assert stream_payloads[0]["reasoning_effort"] == "none"
     assert nonstream_calls == []
     assert unload_calls == [("http://127.0.0.1:1234", "google/gemma-4-12b")]
 
 
-def test_local_llm_refiner_lm_studio_reasoning_only_fails_fast_when_thinking_is_off(monkeypatch):
+def test_local_llm_refiner_lm_studio_reasoning_only_gets_one_finalization_when_thinking_is_off(monkeypatch):
     package = load_package()
     module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
     node = package.DenoLocalLLMRefiner()
     stream_payloads = []
+    progress = []
 
     def fake_stream(_url, payload, **_kwargs):
         stream_payloads.append(dict(payload))
-        yield "reasoning.delta", {"type": "reasoning.delta", "content": "hidden only"}
-        yield "chat.end", {
-            "type": "chat.end",
-            "result": {"output": [{"type": "reasoning", "content": "hidden only"}]},
-        }
+        if len(stream_payloads) == 1:
+            yield "message", {"choices": [{"delta": {"reasoning_content": "hidden only"}}]}
+            yield "message", {"choices": [{"delta": {}, "finish_reason": "stop"}]}
+            return
+        yield "message", {"choices": [{"delta": {"reasoning_content": "hidden finalization"}}]}
+        yield "message", {"choices": [{"delta": {"content": json.dumps({"deno_final_answer": "answer"})}}]}
+        yield "message", {"choices": [{"delta": {}, "finish_reason": "stop"}]}
 
     monkeypatch.setattr(module, "_http_stream_sse", fake_stream)
-    monkeypatch.setattr(
-        module,
-        "_http_json",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("reasoning-only output must not start a second generation request")
-        ),
+    monkeypatch.setattr(module, "_send_progress", lambda event: progress.append(dict(event)))
+    answer, thought, raw = node._run_lm_studio(
+        server_url="http://127.0.0.1:1234/v1",
+        model="google/gemma-4-12b",
+        system_prompt="",
+        prompt="hello",
+        thinking=False,
+        seed=7,
+        model_memory="Keep for minutes",
+        keep_minutes=3,
+        image_attachments=[],
+        is_last=True,
+        node_id="99",
+        index=1,
+        total=1,
     )
 
-    with pytest.raises(RuntimeError, match="reasoning without final text"):
-        node._run_lm_studio(
-            server_url="http://127.0.0.1:1234/v1",
-            model="google/gemma-4-12b",
-            system_prompt="",
-            prompt="hello",
-            thinking=False,
-            seed=7,
-            model_memory="Keep for minutes",
-            keep_minutes=3,
-            image_attachments=[],
-            is_last=True,
-            node_id="99",
-            index=1,
-            total=1,
-        )
-
-    assert len(stream_payloads) == 1
-    assert stream_payloads[0]["reasoning"] == "off"
+    assert answer == "answer"
+    assert thought == ""
+    assert len(stream_payloads) == 2
+    assert stream_payloads[0]["reasoning_effort"] == "none"
+    assert stream_payloads[1]["reasoning_effort"] == "none"
+    assert all(event["thinking"] == "" for event in progress)
+    assert raw["final_answer_recovery"]["succeeded"] is True
 
 
 def test_local_llm_refiner_sends_progress_error_before_raising(monkeypatch):
@@ -4678,7 +4664,7 @@ def test_local_llm_refiner_sends_progress_error_before_raising(monkeypatch):
     assert events[-1]["answer"] == ""
 
 
-def test_local_llm_refiner_lm_studio_native_image_input_uses_text_and_image_parts():
+def test_local_llm_refiner_lm_studio_chat_completions_uses_text_and_image_parts():
     package = load_package()
     module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
     node = package.DenoLocalLLMRefiner()
@@ -4688,8 +4674,8 @@ def test_local_llm_refiner_lm_studio_native_image_input_uses_text_and_image_part
 
     def fake_stream(url, payload, **_kwargs):
         stream_payloads.append({"url": url, "payload": dict(payload)})
-        yield "message.delta", {"type": "message.delta", "content": "image answer"}
-        yield "chat.end", {"type": "chat.end", "output": [{"type": "message", "content": "image answer"}]}
+        yield "message", {"choices": [{"delta": {"content": json.dumps({"deno_final_answer": "image answer"})}}]}
+        yield "message", {"choices": [{"delta": {}, "finish_reason": "stop"}]}
 
     module._http_stream_sse = fake_stream
     try:
@@ -4726,14 +4712,15 @@ def test_local_llm_refiner_lm_studio_native_image_input_uses_text_and_image_part
     finally:
         module._http_stream_sse = original_stream
 
-    input_parts = stream_payloads[0]["payload"]["input"]
+    input_parts = stream_payloads[0]["payload"]["messages"][1]["content"]
     assert answer == "image answer"
     assert thought == ""
     assert input_parts == [
-        {"type": "text", "content": "what is this image?"},
-        {"type": "image", "data_url": "data:image/jpeg;base64,abc"},
-        {"type": "image", "data_url": "data:image/jpeg;base64,def"},
+        {"type": "text", "text": "what is this image?"},
+        {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,abc"}},
+        {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,def"}},
     ]
+    assert stream_payloads[0]["url"] == "http://127.0.0.1:1234/v1/chat/completions"
     assert len(raw["images"]) == 2
     assert raw["image"]["width"] == 16
     assert raw["image"]["sent_height"] == 8
@@ -4749,7 +4736,7 @@ def test_local_llm_refiner_ollama_sends_every_image_as_images_array():
 
     def fake_stream(url, payload, timeout=600.0, cancel_key=None):
         stream_payloads.append({"url": url, "payload": dict(payload)})
-        yield {"message": {"content": "image answer"}, "done": False}
+        yield {"message": {"content": json.dumps({"deno_final_answer": "image answer"})}, "done": False}
         yield {"done": True, "done_reason": "stop"}
 
     module._http_stream_json_lines = fake_stream
@@ -4802,7 +4789,7 @@ def test_local_llm_refiner_ollama_recovers_completed_thinking_only_response_once
                 "eval_count": 64,
             }
             return
-        yield {"message": {"content": "complete final answer"}, "done": False}
+        yield {"message": {"content": json.dumps({"deno_final_answer": "complete final answer"})}, "done": False}
         yield {
             "done": True,
             "done_reason": "stop",
@@ -4858,23 +4845,26 @@ def test_local_llm_refiner_ollama_recovers_completed_thinking_only_response_once
     ) == 1
     assert continuation_payload["options"] == first_payload["options"] == {"seed": 7}
     assert continuation_payload["messages"][:2] == first_payload["messages"]
-    assert continuation_payload["messages"][-1] == {
+    assert continuation_payload["messages"][-2] == {
         "role": "assistant",
         "content": "",
         "thinking": "careful reasoning",
     }
+    assert continuation_payload["messages"][-1]["role"] == "user"
+    assert "deno_final_answer" in continuation_payload["messages"][-1]["content"]
     assert continuation_payload["messages"][1]["images"] == ["img-a"]
     assert raw["meta"]["done_reason"] == "stop"
-    assert raw["thinking_only_recovery"] == {
+    assert raw["final_answer_recovery"] == {
         "attempted": True,
         "succeeded": True,
+        "initial_error": "Ollama returned no structured final-answer envelope.",
         "initial_meta": {
             "done": True,
             "done_reason": initial_done_reason,
             "prompt_eval_count": 44,
             "eval_count": 64,
         },
-        "continuation_meta": {
+        "finalization_meta": {
             "done": True,
             "done_reason": "stop",
             "prompt_eval_count": 93,
@@ -4895,7 +4885,13 @@ def test_local_llm_refiner_ollama_normal_thinking_and_final_does_not_retry():
 
     def fake_stream(url, payload, timeout=600.0, cancel_key=None):
         stream_payloads.append(payload)
-        yield {"message": {"thinking": "reasoning", "content": "final answer"}, "done": False}
+        yield {
+            "message": {
+                "thinking": "reasoning",
+                "content": json.dumps({"deno_final_answer": "final answer"}),
+            },
+            "done": False,
+        }
         yield {"done": True, "done_reason": "stop", "prompt_eval_count": 10, "eval_count": 20}
 
     original_stream = module._http_stream_json_lines
@@ -4937,7 +4933,7 @@ def test_local_llm_refiner_ollama_normal_thinking_and_final_does_not_retry():
         payload["keep_alive"] in (0, "0", "0m", "0s")
         for payload in stream_payloads
     ) + len(unload_calls) == 1
-    assert "thinking_only_recovery" not in raw
+    assert "final_answer_recovery" not in raw
 
 
 def test_local_llm_refiner_ollama_failed_final_continuation_reports_both_terminal_reasons():
@@ -4981,9 +4977,9 @@ def test_local_llm_refiner_ollama_failed_final_continuation_reports_both_termina
 
     message = str(raised.value)
     assert call_count == 2
-    assert "after one automatic final-answer continuation" in message
+    assert "after one automatic finalization attempt" in message
     assert "Initial: done_reason=length, prompt_eval_count=101, eval_count=201" in message
-    assert "Continuation: done_reason=stop, prompt_eval_count=102, eval_count=202" in message
+    assert "Finalization: done_reason=stop, prompt_eval_count=102, eval_count=202" in message
 
 
 def test_local_llm_refiner_ollama_keep_alive_matches_ollama_node_duration_style():
@@ -5006,7 +5002,7 @@ def test_local_llm_refiner_ollama_keep_loaded_reloads_after_provider_eviction():
 
     def fake_stream(url, payload, timeout=600.0, cancel_key=None):
         calls.append(("stream", url, payload))
-        yield {"message": {"content": "done"}, "done": False}
+        yield {"message": {"content": json.dumps({"deno_final_answer": "done"})}, "done": False}
         yield {"done": True, "done_reason": "stop"}
 
     def fake_http_json(url, payload=None, method="GET", timeout=20.0):
@@ -5062,7 +5058,7 @@ def test_local_llm_refiner_ollama_keep_loaded_refreshes_even_when_provider_repor
 
     def fake_stream(url, payload, timeout=600.0, cancel_key=None):
         calls.append(("stream", url, payload))
-        yield {"message": {"content": "done"}, "done": False}
+        yield {"message": {"content": json.dumps({"deno_final_answer": "done"})}, "done": False}
         yield {"done": True, "done_reason": "stop"}
 
     def fake_http_json(url, payload=None, method="GET", timeout=20.0):

--- a/tests/test_local_llm_regressions.py
+++ b/tests/test_local_llm_regressions.py
@@ -32,6 +32,341 @@ def _refine_kwargs(prompts):
     }
 
 
+def _run_ollama_kwargs(**overrides):
+    kwargs = {
+        "server_url": "http://127.0.0.1:11434",
+        "model": "qwen3",
+        "system_prompt": "Keep the user's requested format.",
+        "prompt": "Write the final answer.",
+        "thinking": False,
+        "seed": 7,
+        "model_memory": "Keep loaded",
+        "keep_minutes": 5,
+        "image_attachments": [],
+        "is_last": True,
+        "node_id": "ollama-contract-node",
+        "index": 1,
+        "total": 1,
+        "cleanup_state": {"provider_cleanup_attempted": False},
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+def _ollama_envelope(answer):
+    return json.dumps({"deno_final_answer": answer}, ensure_ascii=False)
+
+
+def _run_lm_studio_kwargs(**overrides):
+    kwargs = {
+        "server_url": "http://127.0.0.1:1234/v1",
+        "model": "google/gemma",
+        "system_prompt": "Keep the user's requested format.",
+        "prompt": "Write the final answer.",
+        "thinking": False,
+        "seed": 7,
+        "model_memory": "Keep loaded",
+        "keep_minutes": 5,
+        "image_attachments": [],
+        "is_last": True,
+        "node_id": "lm-studio-contract-node",
+        "index": 1,
+        "total": 1,
+        "cleanup_state": {"provider_cleanup_attempted": False},
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+def _lm_studio_content_chunk(content="", reasoning="", finish_reason=None):
+    delta = {}
+    if content:
+        delta["content"] = content
+    if reasoning:
+        delta["reasoning_content"] = reasoning
+    return "message", {
+        "choices": [{"delta": delta, "finish_reason": finish_reason}],
+    }
+
+
+@pytest.mark.parametrize("thinking", [False, True])
+def test_local_llm_ollama_uses_structured_final_answer_contract(monkeypatch, thinking):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    payloads = []
+    progress = []
+
+    def fake_stream(_url, payload, **_kwargs):
+        payloads.append(payload)
+        message = {"content": _ollama_envelope("clean final answer")}
+        if thinking:
+            message["thinking"] = "private reasoning"
+        yield {"message": message, "done": False}
+        yield {"done": True, "done_reason": "stop"}
+
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(module, "_send_progress", lambda event: progress.append(dict(event)))
+    monkeypatch.setattr(module, "_ensure_ollama_model_stays_loaded", lambda **_kwargs: {"checked": False})
+
+    answer, thought, _raw = node._run_ollama(**_run_ollama_kwargs(thinking=thinking))
+
+    assert answer == "clean final answer"
+    assert thought == ("private reasoning" if thinking else "")
+    assert len(payloads) == 1
+    assert payloads[0]["think"] is thinking
+    assert payloads[0]["format"] == {
+        "type": "object",
+        "properties": {
+            "deno_final_answer": {
+                "type": "string",
+                "description": (
+                    "Only the complete final answer requested by the original system and user "
+                    "messages. Never include private chain-of-thought, hidden reasoning, scratch "
+                    "work, or internal deliberation. Include an answer-facing explanation or "
+                    "requested visible formatting only when the original request requires it; "
+                    "exclude provider preambles, transport labels, and process commentary."
+                ),
+            }
+        },
+        "required": ["deno_final_answer"],
+        "additionalProperties": False,
+    }
+    assert payloads[0]["messages"][0]["content"].startswith("Keep the user's requested format.")
+    contract = payloads[0]["messages"][0]["content"]
+    assert "only the completed answer requested by the user" in contract
+    assert "Never include private chain-of-thought" in contract
+    assert "even if requested" in contract
+    assert "answer-facing explanation" in contract
+    assert all(event["answer"] == "" for event in progress)
+
+
+@pytest.mark.parametrize(
+    "invalid_content",
+    [
+        'preamble {"deno_final_answer":"answer"}',
+        '{"wrong_field":"answer"}',
+        '{"deno_final_answer":"answer","extra":"not allowed"}',
+        '{"deno_final_answer":"   "}',
+        '{"deno_final_answer":7}',
+    ],
+)
+def test_local_llm_ollama_discards_invalid_envelopes_after_one_finalization(
+    monkeypatch,
+    invalid_content,
+):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    payloads = []
+
+    def fake_stream(_url, payload, **_kwargs):
+        payloads.append(payload)
+        yield {"message": {"content": invalid_content}, "done": False}
+        yield {"done": True, "done_reason": "stop", "eval_count": 3}
+
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(module, "_send_progress", lambda _event: None)
+    monkeypatch.setattr(module, "_ensure_ollama_model_stays_loaded", lambda **_kwargs: {"checked": False})
+
+    with pytest.raises(RuntimeError, match="one automatic finalization attempt|Raw model text was discarded"):
+        node._run_ollama(**_run_ollama_kwargs())
+
+    assert len(payloads) == 2
+    assert payloads[0]["think"] is False
+    assert payloads[1]["think"] is False
+    assert payloads[0]["options"] == payloads[1]["options"] == {"seed": 7}
+
+
+@pytest.mark.parametrize(
+    "final_answer",
+    [
+        "first line\nsecond line\n\nlast line",
+        '{"verdict":"PASS","reason":"정확한 JSON 리뷰"}',
+    ],
+)
+def test_local_llm_ollama_preserves_multiline_and_reviewer_json_strings(monkeypatch, final_answer):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+
+    def fake_stream(_url, _payload, **_kwargs):
+        encoded = _ollama_envelope(final_answer)
+        split = max(1, len(encoded) // 2)
+        yield {"message": {"content": encoded[:split]}, "done": False}
+        yield {"message": {"content": encoded[split:]}, "done": False}
+        yield {"done": True, "done_reason": "stop"}
+
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(module, "_send_progress", lambda _event: None)
+    monkeypatch.setattr(module, "_ensure_ollama_model_stays_loaded", lambda **_kwargs: {"checked": False})
+
+    answer, thought, _raw = node._run_ollama(**_run_ollama_kwargs())
+
+    assert answer == final_answer
+    assert thought == ""
+
+
+def test_local_llm_ollama_envelope_is_unwrapped_before_prompt_only_extraction():
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    wrapped = _ollama_envelope(
+        "This preamble must not reach downstream.\n"
+        "DENO_FINAL_PROMPT: a clean cinematic final prompt"
+    )
+
+    answer = module._unwrap_final_answer_envelope(wrapped, module.PROVIDER_OLLAMA)
+
+    assert module._extract_final_prompt_block(answer, require=True) == (
+        "a clean cinematic final prompt"
+    )
+
+
+def test_local_llm_ollama_malformed_first_response_uses_isolated_bounded_finalization(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    payloads = []
+    image_attachments = [{
+        "base64": "image-data",
+        "width": 1,
+        "height": 1,
+        "sent_width": 1,
+        "sent_height": 1,
+    }]
+
+    def fake_stream(_url, payload, **_kwargs):
+        payloads.append(payload)
+        if len(payloads) == 1:
+            yield {"message": {"content": "unwanted preamble"}, "done": False}
+        else:
+            yield {"message": {"content": _ollama_envelope("corrected final")}, "done": False}
+        yield {"done": True, "done_reason": "stop"}
+
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(module, "_send_progress", lambda _event: None)
+    monkeypatch.setattr(module, "_ensure_ollama_model_stays_loaded", lambda **_kwargs: {"checked": False})
+
+    answer, thought, raw = node._run_ollama(
+        **_run_ollama_kwargs(
+            thinking=True,
+            image_attachments=image_attachments,
+        )
+    )
+
+    assert answer == "corrected final"
+    assert thought == ""
+    assert len(payloads) == 2
+    assert payloads[1]["think"] is False
+    assert payloads[1]["options"] == payloads[0]["options"] == {"seed": 7}
+    assert payloads[0]["messages"][1]["images"] == ["image-data"]
+    assert payloads[1]["messages"][:2] == payloads[0]["messages"]
+    assert payloads[1]["messages"][-2]["content"] == "unwanted preamble"
+    assert raw["final_answer_recovery"]["attempted"] is True
+
+
+def test_local_llm_ollama_thinking_only_finalization_keeps_reasoning_separate(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    payloads = []
+
+    def fake_stream(_url, payload, **_kwargs):
+        payloads.append(payload)
+        if len(payloads) == 1:
+            yield {"message": {"thinking": "private chain"}, "done": False}
+            yield {"done": True, "done_reason": "length"}
+            return
+        yield {"message": {"content": _ollama_envelope("final after thought")}, "done": False}
+        yield {"done": True, "done_reason": "stop"}
+
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(module, "_send_progress", lambda _event: None)
+    monkeypatch.setattr(module, "_ensure_ollama_model_stays_loaded", lambda **_kwargs: {"checked": False})
+
+    answer, thought, _raw = node._run_ollama(**_run_ollama_kwargs(thinking=True))
+
+    assert answer == "final after thought"
+    assert thought == "private chain"
+    assert [payload["think"] for payload in payloads] == [True, False]
+
+
+def test_local_llm_ollama_thinking_off_hides_unexpected_reasoning_during_recovery(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    payloads = []
+    progress = []
+
+    def fake_stream(_url, payload, **_kwargs):
+        payloads.append(payload)
+        if len(payloads) == 1:
+            yield {"message": {"thinking": "unexpected initial reasoning"}, "done": False}
+            yield {"done": True, "done_reason": "stop"}
+            return
+        yield {
+            "message": {
+                "thinking": "unexpected finalization reasoning",
+                "content": _ollama_envelope("recovered final"),
+            },
+            "done": False,
+        }
+        yield {"done": True, "done_reason": "stop"}
+
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(module, "_send_progress", lambda event: progress.append(dict(event)))
+    monkeypatch.setattr(module, "_ensure_ollama_model_stays_loaded", lambda **_kwargs: {"checked": False})
+
+    answer, thought, raw = node._run_ollama(**_run_ollama_kwargs(thinking=False))
+
+    assert answer == "recovered final"
+    assert thought == ""
+    assert [payload["think"] for payload in payloads] == [False, False]
+    assert all(event["thinking"] == "" for event in progress)
+    assert raw["final_answer_recovery"]["succeeded"] is True
+
+
+def test_local_llm_ollama_reports_structured_output_compatibility_error(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+
+    def fake_stream(_url, _payload, **_kwargs):
+        raise RuntimeError("invalid format: JSON schema is not supported")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(module, "_send_progress", lambda _event: None)
+
+    with pytest.raises(RuntimeError, match="does not support the structured output"):
+        node._run_ollama(**_run_ollama_kwargs())
+
+
+def test_local_llm_ollama_does_not_finalize_an_unconfirmed_partial_stream(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    payloads = []
+
+    def fake_stream(_url, payload, **_kwargs):
+        payloads.append(payload)
+        yield {
+            "message": {
+                "thinking": "unfinished private reasoning",
+                "content": '{"deno_final_answer":"partial answer',
+            },
+            "done": False,
+        }
+
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(module, "_send_progress", lambda _event: None)
+
+    with pytest.raises(RuntimeError, match="before confirming completion"):
+        node._run_ollama(**_run_ollama_kwargs(thinking=True))
+
+    assert len(payloads) == 1
+
+
 @pytest.mark.parametrize(
     "error_message",
     [
@@ -329,7 +664,7 @@ def test_local_llm_ollama_continuation_preserves_batch_order_and_one_terminal_un
         yield {
             "message": {
                 "thinking": "" if payload["think"] is False else f"reasoning {prompt_index}",
-                "content": f"final {prompt_index}",
+                "content": _ollama_envelope(f"final {prompt_index}"),
             },
             "done": False,
         }
@@ -595,145 +930,203 @@ def test_llama_swap_terminal_request_cleanup_occurs_exactly_once(
     assert cleanup_state["provider_cleanup_attempted"] is bool(expected_unloads)
 
 
-def test_lm_studio_keep_loaded_runs_do_not_query_model_list_during_generation(monkeypatch):
+@pytest.mark.parametrize(("thinking", "effort"), [(False, "none"), (True, "high")])
+def test_lm_studio_uses_chat_completions_structured_contract(monkeypatch, thinking, effort):
     package = load_package()
     module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
     node = package.DenoLocalLLMRefiner()
-    model_list_calls = []
-    stream_payloads = []
+    calls = []
+    progress = []
 
-    with module._LM_STUDIO_MODELS_CACHE_LOCK:
-        module._LM_STUDIO_MODELS_CACHE.clear()
-
-    def fake_http_json(url, *_args, **_kwargs):
-        if url.endswith("/api/v1/models"):
-            model_list_calls.append(url)
-            raise AssertionError("generation must not synchronously query LM Studio's model list")
-        raise AssertionError(f"unexpected non-stream request: {url}")
-
-    def fake_stream(_url, payload, **_kwargs):
-        stream_payloads.append(dict(payload))
-        yield "message.delta", {"type": "message.delta", "content": "ready"}
-        yield "chat.end", {"type": "chat.end"}
-
-    monkeypatch.setattr(module, "_http_json", fake_http_json)
-    monkeypatch.setattr(module, "_http_stream_sse", fake_stream)
-
-    for _ in range(2):
-        answer, _thinking, raw = node._run_lm_studio(
-            server_url="http://127.0.0.1:1234/v1",
-            model="google/gemma",
-            system_prompt="",
-            prompt="hello",
-            thinking=False,
-            seed=7,
-            model_memory="Keep loaded",
-            keep_minutes=5,
-            image_attachments=[],
-            is_last=True,
-            node_id="lm-studio-no-list-preflight",
-            index=1,
-            total=1,
-        )
-        assert answer == "ready"
-        assert raw["reasoning"] == "off"
-        assert raw["reasoning_requested"] == "off"
-        assert raw["reasoning_compat_fallback"] is False
-
-    assert model_list_calls == []
-    assert [payload["reasoning"] for payload in stream_payloads] == ["off", "off"]
-
-
-def test_lm_studio_retries_once_without_reasoning_only_when_off_is_explicitly_unsupported(monkeypatch):
-    package = load_package()
-    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
-    node = package.DenoLocalLLMRefiner()
-    stream_payloads = []
-
-    with module._LM_STUDIO_MODELS_CACHE_LOCK:
-        module._LM_STUDIO_MODELS_CACHE.clear()
-
-    def fake_stream(_url, payload, **_kwargs):
-        stream_payloads.append(dict(payload))
-        if len(stream_payloads) == 1:
-            raise RuntimeError("This model does not support the reasoning setting 'off'.")
-        yield "message.delta", {"type": "message.delta", "content": "ready"}
-        yield "chat.end", {"type": "chat.end"}
+    def fake_stream(url, payload, **kwargs):
+        calls.append((url, payload, kwargs))
+        if thinking:
+            yield _lm_studio_content_chunk(reasoning="private reasoning")
+        yield _lm_studio_content_chunk(content=_ollama_envelope("clean final answer"))
+        yield _lm_studio_content_chunk(finish_reason="stop")
 
     monkeypatch.setattr(module, "_http_stream_sse", fake_stream)
+    monkeypatch.setattr(module, "_send_progress", lambda event: progress.append(dict(event)))
 
     answer, thought, raw = node._run_lm_studio(
-        server_url="http://127.0.0.1:1234/v1",
-        model="local/non-reasoning-model",
-        system_prompt="",
-        prompt="hello",
-        thinking=False,
-        seed=7,
-        model_memory="Keep loaded",
-        keep_minutes=5,
-        image_attachments=[],
-        is_last=True,
-        node_id="lm-studio-reasoning-compat",
-        index=1,
-        total=1,
+        **_run_lm_studio_kwargs(thinking=thinking)
     )
 
-    assert answer == "ready"
-    assert thought == ""
-    assert stream_payloads[0]["reasoning"] == "off"
-    assert "reasoning" not in stream_payloads[1]
-    assert raw["reasoning"] is None
-    assert raw["reasoning_requested"] == "off"
-    assert raw["reasoning_compat_fallback"] is True
+    assert answer == "clean final answer"
+    assert thought == ("private reasoning" if thinking else "")
+    assert len(calls) == 1
+    url, payload, kwargs = calls[0]
+    assert url == "http://127.0.0.1:1234/v1/chat/completions"
+    assert kwargs["cancel_key"].startswith("LM Studio|")
+    assert payload["reasoning_effort"] == effort
+    assert payload["seed"] == 7
+    assert payload["response_format"] == module._openai_final_answer_response_format()
+    assert payload["messages"][0]["content"].startswith("Keep the user's requested format.")
+    assert raw["reasoning_effort"] == effort
+    assert raw["api"] == "LM Studio /v1/chat/completions"
+    assert all(event["answer"] == "" for event in progress)
 
 
 @pytest.mark.parametrize(
-    ("partial_output", "error_message"),
+    "final_answer",
     [
-        (False, "LM Studio connection failed"),
-        (True, "This model does not support the reasoning setting 'off'."),
+        "first line\nsecond line\n\nlast line",
+        '{"verdict":"PASS","reason":"exact reviewer JSON"}',
+        "DENO_FINAL_PROMPT: exact prompt-only result",
     ],
 )
-def test_lm_studio_does_not_retry_unrelated_or_partial_output_failures(
+def test_lm_studio_preserves_final_answer_strings_after_unwrap(monkeypatch, final_answer):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+
+    def fake_stream(_url, _payload, **_kwargs):
+        yield _lm_studio_content_chunk(content=_ollama_envelope(final_answer))
+        yield _lm_studio_content_chunk(finish_reason="stop")
+
+    monkeypatch.setattr(module, "_http_stream_sse", fake_stream)
+    answer, thought, _raw = node._run_lm_studio(**_run_lm_studio_kwargs())
+
+    assert answer == final_answer
+    assert thought == ""
+    if final_answer.startswith("DENO_FINAL_PROMPT:"):
+        assert module._extract_final_prompt_block(answer, require=True) == "exact prompt-only result"
+
+
+@pytest.mark.parametrize(
+    "invalid_content",
+    [
+        'preamble {"deno_final_answer":"answer"}',
+        '{"wrong_field":"answer"}',
+        '{"deno_final_answer":"answer","extra":"not allowed"}',
+        '{"deno_final_answer":"   "}',
+    ],
+)
+def test_lm_studio_invalid_envelope_gets_one_bounded_finalization_then_fails(
     monkeypatch,
-    partial_output,
-    error_message,
+    invalid_content,
 ):
     package = load_package()
     module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
     node = package.DenoLocalLLMRefiner()
-    stream_payloads = []
-
-    with module._LM_STUDIO_MODELS_CACHE_LOCK:
-        module._LM_STUDIO_MODELS_CACHE.clear()
+    payloads = []
 
     def fake_stream(_url, payload, **_kwargs):
-        stream_payloads.append(dict(payload))
-        if partial_output:
-            yield "message.delta", {"type": "message.delta", "content": "partial"}
-        raise RuntimeError(error_message)
+        payloads.append(payload)
+        yield _lm_studio_content_chunk(content=invalid_content)
+        yield _lm_studio_content_chunk(finish_reason="stop")
 
     monkeypatch.setattr(module, "_http_stream_sse", fake_stream)
 
-    with pytest.raises(RuntimeError, match="reasoning setting|connection failed"):
-        node._run_lm_studio(
-            server_url="http://127.0.0.1:1234/v1",
-            model="google/gemma",
-            system_prompt="",
-            prompt="hello",
-            thinking=False,
-            seed=7,
-            model_memory="Keep loaded",
-            keep_minutes=5,
-            image_attachments=[],
-            is_last=True,
-            node_id="lm-studio-no-retry",
-            index=1,
-            total=1,
-        )
+    with pytest.raises(RuntimeError, match="one automatic finalization attempt|Raw model text was discarded"):
+        node._run_lm_studio(**_run_lm_studio_kwargs())
 
-    assert len(stream_payloads) == 1
-    assert stream_payloads[0]["reasoning"] == "off"
+    assert len(payloads) == 2
+    assert [payload["reasoning_effort"] for payload in payloads] == ["none", "none"]
+
+
+def test_lm_studio_malformed_first_response_retries_once_with_same_context_and_unloads(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    payloads = []
+    unloads = []
+    cleanup_state = {"provider_cleanup_attempted": False}
+    images = [{
+        "data_url": "data:image/jpeg;base64,image-data",
+        "base64": "image-data",
+        "width": 1,
+        "height": 1,
+        "sent_width": 1,
+        "sent_height": 1,
+    }]
+
+    def fake_stream(_url, payload, **_kwargs):
+        payloads.append(payload)
+        if len(payloads) == 1:
+            yield _lm_studio_content_chunk(content="unwanted preamble", reasoning="private chain")
+        else:
+            yield _lm_studio_content_chunk(content=_ollama_envelope("corrected final"))
+        yield _lm_studio_content_chunk(finish_reason="stop")
+
+    monkeypatch.setattr(module, "_http_stream_sse", fake_stream)
+    monkeypatch.setattr(node, "_lm_unload_best_effort", lambda base, model: unloads.append((base, model)))
+
+    answer, thought, raw = node._run_lm_studio(
+        **_run_lm_studio_kwargs(
+            thinking=True,
+            model_memory="Unload after run",
+            image_attachments=images,
+            cleanup_state=cleanup_state,
+        )
+    )
+
+    assert answer == "corrected final"
+    assert thought == "private chain"
+    assert len(payloads) == 2
+    assert [payload["reasoning_effort"] for payload in payloads] == ["high", "none"]
+    assert payloads[0]["seed"] == payloads[1]["seed"] == 7
+    assert payloads[1]["messages"][:2] == payloads[0]["messages"]
+    assert payloads[0]["messages"][1]["content"][1]["image_url"]["url"].endswith("image-data")
+    assert raw["final_answer_recovery"]["attempted"] is True
+    assert unloads == [("http://127.0.0.1:1234", "google/gemma")]
+    assert cleanup_state["provider_cleanup_attempted"] is True
+
+
+def test_lm_studio_does_not_retry_unconfirmed_partial_stream(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    payloads = []
+
+    def fake_stream(_url, payload, **_kwargs):
+        payloads.append(payload)
+        yield _lm_studio_content_chunk(content='{"deno_final_answer":"partial')
+
+    monkeypatch.setattr(module, "_http_stream_sse", fake_stream)
+
+    with pytest.raises(RuntimeError, match="before confirming completion"):
+        node._run_lm_studio(**_run_lm_studio_kwargs(thinking=True))
+
+    assert len(payloads) == 1
+
+
+def test_lm_studio_reports_unsupported_schema_without_plaintext_fallback(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    payloads = []
+
+    def fake_stream(_url, payload, **_kwargs):
+        payloads.append(payload)
+        raise RuntimeError("response_format json_schema is not supported")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(module, "_http_stream_sse", fake_stream)
+
+    with pytest.raises(RuntimeError, match="does not support the structured output"):
+        node._run_lm_studio(**_run_lm_studio_kwargs())
+
+    assert len(payloads) == 1
+
+
+def test_lm_studio_generation_does_not_query_native_model_list(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+
+    def fake_http_json(url, *_args, **_kwargs):
+        raise AssertionError(f"generation must not query native model API: {url}")
+
+    def fake_stream(_url, _payload, **_kwargs):
+        yield _lm_studio_content_chunk(content=_ollama_envelope("ready"))
+        yield _lm_studio_content_chunk(finish_reason="stop")
+
+    monkeypatch.setattr(module, "_http_json", fake_http_json)
+    monkeypatch.setattr(module, "_http_stream_sse", fake_stream)
+
+    answer, _thought, _raw = node._run_lm_studio(**_run_lm_studio_kwargs())
+    assert answer == "ready"
 
 
 def test_local_llm_input_types_never_queries_lm_studio_during_prompt_validation(monkeypatch):


### PR DESCRIPTION
## Summary

- Enforce a strict structured final-answer envelope for Ollama and LM Studio so provider preambles and raw transport text never reach the Result output.
- Keep reasoning separate from Result, including when a provider ignores Thinking Off; allow one bounded finalization for completed malformed or thinking-only replies, then fail closed.
- Use LM Studio's official JSON Schema chat-completions path for generation while preserving native model discovery/unload and applying the selected seed.
- Preserve node IDs, sockets, widget order, saved prompts, images, arbitrary multiline output, Reviewer JSON, cancellation, and model cleanup behavior.

## Verification

- Full suite: `478 passed`
- Local LLM focused regression matrix: passed
- Node syntax, LTX JavaScript harness, Python compile, and `git diff --check`: passed
- Live candidate runs:
  - Ollama `qwen3.6:35b-a3b`: Thinking Off and On
  - Ollama `gemma4:31b-it-qat`: Thinking Off
  - LM Studio `qwen/qwen3.5-9b`: Thinking Off and On
  - LM Studio `google/gemma-4-12b-qat`: Thinking Off
- Every live run returned only the exact final answer; Thinking Off leaked no reasoning, Thinking On kept reasoning in the separate channel, and both providers ended with zero loaded models.
- Registry package audit: 411 files, no private/operator files, local paths, credentials, or experimental Audio/A2V files.

## Scope

This release contains only the Local LLM final-answer contract, its regression coverage, version `0.7.83`, and release notes. The separate Audio-to-Video and audio-analysis work is intentionally excluded.