### PR TITLE
Persist Local LLM results in saved metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file intentionally stays short. Detailed engineering notes belong in privat
 
 ## Unreleased
 
+## 0.7.85 - 2026-08-11
+
+- Fixed `(Deno) Local LLM Loader` so, whenever the node executes, its final Result is embedded in that output's workflow metadata and restored inside the node when a saved PNG or workflow is reopened, without persisting Thinking/reasoning content.
+
 ## 0.7.84 - 2026-08-11
 
 - Added `(Deno) Audio Transcript` for optional local Whisper transcription with user-supplied wording priority, segment timing, confidence context, official checkpoint caching, audio passthrough, and post-run model unload.

--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ Main features:
 - connect prompt batches through one node run so the local model can stay loaded until the batch finishes
 - optionally attach an IMAGE to a vision-capable local model call
 - preview Thinking and Result text directly on the node
+- embed the node's final Result in saved PNG/workflow metadata whenever the Local LLM node executes, so reopening the file restores it inside the node; Thinking/reasoning remains preview-only and is not persisted
 - keep named System Prompt presets in ComfyUI user data so they survive browser-profile cleanup; existing browser presets can be imported once while the browser copy stays untouched as a backup
 - see the actually applied System Prompt preset name on the node and in the editor; edited unmatched text is shown as `Custom`
 - connect a positive FLOAT to `video seconds` to append a sentence such as `This is an 8-second video.` to each LLM user prompt without changing the saved Prompt text

--- a/deno_local_llm_refiner.py
+++ b/deno_local_llm_refiner.py
@@ -77,6 +77,9 @@ LEGACY_CUSTOM_SERVER_DEFAULT = CUSTOM_SERVER_DEFAULT
 LOCAL_LLM_IMAGE_MAX_SIDE = 2048
 LOCAL_LLM_IMAGE_MAX_PIXELS = 2 * 1024 * 1024
 LOCAL_LLM_IMAGE_JPEG_QUALITY = 92
+LOCAL_LLM_STATE_PROPERTY = "deno_local_llm_state"
+LOCAL_LLM_STATE_SCHEMA = 1
+LOCAL_LLM_STATE_TEXT_LIMIT = 120000
 
 MEMORY_UNLOAD_AFTER_RUN = "Unload after run"
 LEGACY_MEMORY_FREE_AFTER_BATCH = "Free VRAM after batch"
@@ -738,6 +741,57 @@ def _extract_scalar(value: Any, default: Any = None) -> Any:
     return default if value is None else value
 
 
+def _persist_local_llm_answer_in_workflow_metadata(
+    extra_pnginfo: Any,
+    node_id: Any,
+    *,
+    provider: str,
+    model: str,
+    answer: str,
+    status: str = "done",
+    index: int = 1,
+    total: int = 1,
+) -> bool:
+    """Store this node execution's final Result in the embedded workflow snapshot."""
+    metadata = _extract_scalar(extra_pnginfo, None)
+    if not isinstance(metadata, dict):
+        return False
+    workflow = metadata.get("workflow")
+    if not isinstance(workflow, dict):
+        return False
+    nodes = workflow.get("nodes")
+    if not isinstance(nodes, list):
+        return False
+
+    target_id = str(_extract_scalar(node_id, "") or "").strip()
+    if not target_id:
+        return False
+
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        if str(node.get("id", "")) != target_id or node.get("type") != "DenoLocalLLMRefiner":
+            continue
+        properties = node.get("properties")
+        if not isinstance(properties, dict):
+            properties = {}
+            node["properties"] = properties
+        properties[LOCAL_LLM_STATE_PROPERTY] = {
+            "schema": LOCAL_LLM_STATE_SCHEMA,
+            "status": str(status or "done")[:200],
+            "provider": str(provider or "")[:80],
+            "model": str(model or "")[:500],
+            "answer": str(answer or "")[:LOCAL_LLM_STATE_TEXT_LIMIT],
+            "thinking": "",
+            "error": "",
+            "index": max(0, int(index)),
+            "total": max(0, int(total)),
+            "updatedAt": int(time.time() * 1000),
+        }
+        return True
+    return False
+
+
 def _extract_media(value: Any) -> Any:
     if isinstance(value, list):
         for item in value:
@@ -812,7 +866,7 @@ def _local_llm_cache_key(kwargs: Dict[str, Any]) -> str:
     payload = {
         key: _cache_stable_value(value)
         for key, value in sorted(kwargs.items())
-        if key != "unique_id"
+        if key not in {"unique_id", "extra_pnginfo"}
     }
     payload["seed_mode"] = seed_mode
     encoded = json.dumps(payload, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
@@ -2709,6 +2763,9 @@ class DenoLocalLLMRefiner:
         "adds a short English duration sentence to each user prompt. Optional audio_context STRING "
         "data can carry upstream transcript and acoustic evidence without replacing the user prompt; "
         "only explicitly labeled user-supplied wording is authoritative.\n\n"
+        "When this node executes, its final Result is stored in the embedded workflow state so "
+        "reopening a saved PNG or workflow restores it. Thinking and reasoning stay preview-only "
+        "and are not persisted in that state.\n\n"
         "Designed for prompt-batcher workflows: use the in-node Prompt field or connect STRING into Prompt, "
         "and this node processes the whole prompt batch in one execution so the local LLM can stay "
         "loaded until the batch is complete.\n\n"
@@ -2783,6 +2840,7 @@ class DenoLocalLLMRefiner:
             },
             "hidden": {
                 "unique_id": "UNIQUE_ID",
+                "extra_pnginfo": "EXTRA_PNGINFO",
             },
         }
 
@@ -2866,6 +2924,7 @@ class DenoLocalLLMRefiner:
         video_seconds=None,
         audio_context=None,
         unique_id=None,
+        extra_pnginfo=None,
     ):
         provider_value = _normalize_provider(str(_extract_scalar(provider, PROVIDER_OLLAMA)))
         ollama_model_value = str(_extract_scalar(ollama_model, "")).strip()
@@ -3023,9 +3082,21 @@ class DenoLocalLLMRefiner:
             if thinking_results:
                 thinking_results[-1] = final_thinking
 
+        final_status = "done, unload warning" if post_run_unload_warnings else "done"
+        _persist_local_llm_answer_in_workflow_metadata(
+            extra_pnginfo,
+            node_id,
+            provider=provider_value,
+            model=model_value,
+            answer=results[-1] if results else "",
+            status=final_status,
+            index=total,
+            total=total,
+        )
+
         _send_progress({
             "node_id": node_id,
-            "status": "done, unload warning" if post_run_unload_warnings else "done",
+            "status": final_status,
             "provider": provider_value,
             "model": model_value,
             "index": total,

--- a/deno_node_metadata.py
+++ b/deno_node_metadata.py
@@ -384,7 +384,7 @@ NODE_OUTPUT_TOOLTIPS = {
         "Drawn board boxes as downstream BBOX data.",
     ),
     "DenoLocalLLMRefiner": (
-        "Local LLM answer or extracted final prompt. Batched prompts return a STRING list.",
+        "Final Result returned by the Local LLM node. When the node executes, its latest Result is embedded in saved workflow metadata; Thinking/reasoning is not persisted. Batched prompts return a STRING list.",
     ),
     "DenoAIReviewGate": (
         "Original image passed through only when the review approves it.",

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -236,7 +236,7 @@ Negative preset은 출력 모드가 아니라 아래 negative prompt 칸을 자�
 
 내 PC에서 실행 중인 로컬 LLM을 ComfyUI 안에서 호출하고, LLM이 만든 review text로 저장 전 결과를 통과하거나 막는 노드입니다.
 
-주요 기능: Ollama, LM Studio, llama.cpp, vLLM, Custom OpenAI-compatible 서버 또는 llama-swap 로컬 모델 호출, `127.0.0.1`/`localhost` 전용 안전 제한, provider별 모델 새로고침, 실행 중인 로컬 LLM 요청 중단, llama-swap 실행 상태 확인과 수동/실행 후 unload, prompt batch를 한 번의 노드 실행으로 순차 처리, vision 모델용 IMAGE 첨부, Thinking/Result 프리뷰, Save 노드 앞 IMAGE/AUDIO gate, 현재 리뷰 결과 1회 승인, reviewer 앞 경로만 다시 실행. llama-swap에 설정된 서버 timeout은 자동 unload 시점을 계속 관리합니다.
+주요 기능: Ollama, LM Studio, llama.cpp, vLLM, Custom OpenAI-compatible 서버 또는 llama-swap 로컬 모델 호출, `127.0.0.1`/`localhost` 전용 안전 제한, provider별 모델 새로고침, 실행 중인 로컬 LLM 요청 중단, llama-swap 실행 상태 확인과 수동/실행 후 unload, prompt batch를 한 번의 노드 실행으로 순차 처리, vision 모델용 IMAGE 첨부, Thinking/Result 프리뷰, Save 노드 앞 IMAGE/AUDIO gate, 현재 리뷰 결과 1회 승인, reviewer 앞 경로만 다시 실행. Local LLM 노드가 실행되어 반환한 최종 Result는 PNG/워크플로 메타데이터에 저장되어 파일을 다시 열면 노드 안에서 복원되며, Thinking/reasoning 내용은 저장하지 않습니다. llama-swap에 설정된 서버 timeout은 자동 unload 시점을 계속 관리합니다.
 
 오디오 참고: Local LLM Loader는 원본 AUDIO를 로컬 모델에 직접 보내지 않습니다. 선택형 `audio_context` STRING 입력으로 상위 노드의 받아쓰기와 음향 보고서를 사용자 prompt를 바꾸지 않는 참고 데이터로 받을 수 있습니다. ComfyUI 기본 또는 다른 audio-capable text generation 노드가 review text를 만들면, Local LLM Reviewer가 그 review text 기준으로 AUDIO도 함께 통과하거나 차단할 수 있습니다.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "deno-custom-nodes"
 description = "DENO RTX node pack for ComfyUI: MiniMax H3 multi-reference image and Reference to Video helpers, local audio transcription and analysis helpers, Ideogram Director visual JSON/bbox prompt builder, Local LLM Loader and Reviewer helpers, GPT/Gemini-ready Error Help reports, Prompt Only final prompt extraction, RTX Video Super Resolution, RTX Super Resolution, Video SR/VSR, NVIDIA VFX/nvvfx, RTX upscale helpers, LTX 2.3 workflows, LTX tiled second-pass refinement helpers, Bernini Prompt Guide, audio/image review gates, Bernini conditioning helpers, Wan 2.2 reference video edit workflows, image and video compare, video preview, Video to GIF/WebP tools, multi-image loading, resize tools, LoRA/model helpers, prompt guides, and visual workflow utilities."
-version = "0.7.84"
+version = "0.7.85"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = ["openai-whisper>=20250625"]

--- a/tests/test_image_resize_node.py
+++ b/tests/test_image_resize_node.py
@@ -3733,8 +3733,12 @@ def test_local_llm_refiner_declares_batch_prompt_contract_and_frontend_preview()
     assert optional["audio_context"][1]["multiline"] is True
     assert "user_prompt" not in optional
     assert "audio" not in optional
-    assert list(hidden) == ["unique_id"]
+    assert list(hidden) == ["unique_id", "extra_pnginfo"]
+    assert hidden["extra_pnginfo"] == "EXTRA_PNGINFO"
     assert "reviewer_state" not in hidden
+    assert node_cls.OUTPUT_TOOLTIPS == (
+        "Final Result returned by the Local LLM node. When the node executes, its latest Result is embedded in saved workflow metadata; Thinking/reasoning is not persisted. Batched prompts return a STRING list.",
+    )
 
     script = (REPO_ROOT / "web" / "js" / "deno_local_llm_refiner.js").read_text(encoding="utf-8")
     assert 'const NODE_NAME = "DenoLocalLLMRefiner";' in script

--- a/tests/test_local_llm_regressions.py
+++ b/tests/test_local_llm_regressions.py
@@ -187,6 +187,252 @@ def test_local_llm_refine_preserves_system_and_user_prompts_when_adding_duration
     )
 
 
+def test_local_llm_metadata_helper_updates_only_the_matching_workflow_node(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    stale_state = {"schema": 1, "answer": "stale", "thinking": "private reasoning"}
+    untouched_state = {"schema": 1, "answer": "keep this"}
+    extra_pnginfo = [{
+        "workflow": {
+            "nodes": [
+                {
+                    "id": 143,
+                    "type": "DenoLocalLLMRefiner",
+                    "properties": {"deno_local_llm_state": stale_state},
+                },
+                {
+                    "id": 144,
+                    "type": "DenoLocalLLMRefiner",
+                    "properties": {"deno_local_llm_state": untouched_state},
+                },
+                {"id": 145, "type": "SaveImage", "properties": {"keep": True}},
+            ]
+        }
+    }]
+    monkeypatch.setattr(module.time, "time", lambda: 1234.567)
+
+    assert module._persist_local_llm_answer_in_workflow_metadata(
+        extra_pnginfo,
+        ["143"],
+        provider="Custom",
+        model="koboldcpp-model",
+        answer="the exact final prompt",
+        index=2,
+        total=2,
+    ) is True
+
+    target = extra_pnginfo[0]["workflow"]["nodes"][0]["properties"]["deno_local_llm_state"]
+    assert target == {
+        "schema": 1,
+        "status": "done",
+        "provider": "Custom",
+        "model": "koboldcpp-model",
+        "answer": "the exact final prompt",
+        "thinking": "",
+        "error": "",
+        "index": 2,
+        "total": 2,
+        "updatedAt": 1234567,
+    }
+    assert extra_pnginfo[0]["workflow"]["nodes"][1]["properties"]["deno_local_llm_state"] == untouched_state
+    assert extra_pnginfo[0]["workflow"]["nodes"][2]["properties"] == {"keep": True}
+
+
+def test_local_llm_metadata_helper_is_json_round_trip_safe_and_bounds_answer_text(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    extra_pnginfo = {
+        "workflow": {
+            "nodes": [
+                {"id": 143, "type": "DenoLocalLLMRefiner", "properties": {}},
+            ]
+        }
+    }
+    monkeypatch.setattr(module.time, "time", lambda: 1.0)
+    oversized = "한글\n" + ("x" * (module.LOCAL_LLM_STATE_TEXT_LIMIT + 20))
+
+    assert module._persist_local_llm_answer_in_workflow_metadata(
+        extra_pnginfo,
+        143,
+        provider="LM Studio",
+        model="google/gemma",
+        answer=oversized,
+    ) is True
+
+    round_tripped = json.loads(json.dumps(extra_pnginfo, ensure_ascii=False))
+    state = round_tripped["workflow"]["nodes"][0]["properties"]["deno_local_llm_state"]
+    assert len(state["answer"]) == module.LOCAL_LLM_STATE_TEXT_LIMIT
+    assert state["answer"].startswith("한글\n")
+    assert state["thinking"] == ""
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected_model"),
+    [
+        ("Ollama", "qwen3"),
+        ("LM Studio", "google/gemma"),
+        ("llama.cpp", "custom-model"),
+        ("vLLM", "custom-model"),
+        ("Custom", "custom-model"),
+        ("llama-swap", "custom-model"),
+    ],
+)
+def test_local_llm_refine_embeds_same_run_final_answer_for_every_provider(
+    monkeypatch,
+    provider,
+    expected_model,
+):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    extra_pnginfo = [{
+        "workflow": {
+            "nodes": [
+                {
+                    "id": 143,
+                    "type": "DenoLocalLLMRefiner",
+                    "properties": {
+                        "deno_local_llm_state": {
+                            "schema": 1,
+                            "status": "ready",
+                            "answer": "previous run",
+                            "thinking": "previous private reasoning",
+                        }
+                    },
+                }
+            ]
+        }
+    }]
+    calls = []
+
+    monkeypatch.setattr(module, "_send_progress", lambda payload: calls.append(payload))
+    monkeypatch.setattr(module, "_unload_other_warm_local_llms", lambda **_kwargs: {})
+    monkeypatch.setattr(module, "_prepare_comfy_vram_before_llm", lambda **_kwargs: {})
+    monkeypatch.setattr(module.time, "time", lambda: 2000.0)
+
+    def run_single(**kwargs):
+        kwargs["cleanup_state"]["provider_cleanup_attempted"] = True
+        return "same-run final answer", "private chain of thought", {}
+
+    monkeypatch.setattr(node, "_run_single", run_single)
+    kwargs = _refine_kwargs(["Direct the scene."])
+    kwargs.update({
+        "provider": provider,
+        "unique_id": ["143"],
+        "extra_pnginfo": extra_pnginfo,
+    })
+
+    output = node.refine(**kwargs)
+
+    assert output["result"] == (["same-run final answer"],)
+    state = extra_pnginfo[0]["workflow"]["nodes"][0]["properties"]["deno_local_llm_state"]
+    assert state["answer"] == "same-run final answer"
+    assert state["thinking"] == ""
+    assert state["error"] == ""
+    assert state["provider"] == provider
+    assert state["model"] == expected_model
+    assert state["updatedAt"] == 2000000
+    assert calls[-1]["answer"] == "same-run final answer"
+
+
+def test_local_llm_refine_embeds_the_last_answer_from_a_prompt_batch(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    extra_pnginfo = {
+        "workflow": {
+            "nodes": [
+                {"id": 143, "type": "DenoLocalLLMRefiner", "properties": {}},
+            ]
+        }
+    }
+    generated = iter([
+        ("first final answer", "first private thought", {}),
+        ("second final answer", "second private thought", {}),
+    ])
+
+    monkeypatch.setattr(module, "_send_progress", lambda _payload: None)
+    monkeypatch.setattr(module, "_unload_other_warm_local_llms", lambda **_kwargs: {})
+    monkeypatch.setattr(module, "_prepare_comfy_vram_before_llm", lambda **_kwargs: {})
+
+    def run_single(**kwargs):
+        kwargs["cleanup_state"]["provider_cleanup_attempted"] = True
+        return next(generated)
+
+    monkeypatch.setattr(node, "_run_single", run_single)
+    kwargs = _refine_kwargs(["First direction.", "Second direction."])
+    kwargs.update({"unique_id": "143", "extra_pnginfo": extra_pnginfo})
+
+    output = node.refine(**kwargs)
+
+    assert output["result"] == (["first final answer", "second final answer"],)
+    state = extra_pnginfo["workflow"]["nodes"][0]["properties"]["deno_local_llm_state"]
+    assert state["answer"] == "second final answer"
+    assert state["index"] == 2
+    assert state["total"] == 2
+    assert state["thinking"] == ""
+
+
+def test_local_llm_cache_key_ignores_runtime_workflow_metadata():
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    base = {
+        "provider": "Ollama",
+        "prompt": ["Direct the scene."],
+        "seed": 7,
+        "seed_mode": "fixed",
+        "unique_id": "143",
+    }
+    first = {
+        **base,
+        "extra_pnginfo": {
+            "workflow": {
+                "nodes": [
+                    {
+                        "id": 143,
+                        "type": "DenoLocalLLMRefiner",
+                        "properties": {"deno_local_llm_state": {"answer": "first", "thinking": "private"}},
+                    }
+                ]
+            }
+        },
+    }
+    second = {
+        **base,
+        "unique_id": "999",
+        "extra_pnginfo": {
+            "workflow": {
+                "nodes": [
+                    {
+                        "id": 999,
+                        "type": "DenoLocalLLMRefiner",
+                        "properties": {"deno_local_llm_state": {"answer": "second", "thinking": "other"}},
+                    }
+                ]
+            }
+        },
+    }
+
+    assert module._local_llm_cache_key(first) == module._local_llm_cache_key(second)
+
+
+@pytest.mark.parametrize(
+    "extra_pnginfo",
+    [None, [], {}, {"workflow": None}, {"workflow": {}}, {"workflow": {"nodes": []}}],
+)
+def test_local_llm_metadata_helper_is_a_safe_noop_without_a_matching_workflow(extra_pnginfo):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+
+    assert module._persist_local_llm_answer_in_workflow_metadata(
+        extra_pnginfo,
+        "143",
+        provider="Ollama",
+        model="qwen3",
+        answer="final",
+    ) is False
+
+
 def _run_ollama_kwargs(**overrides):
     kwargs = {
         "server_url": "http://127.0.0.1:11434",

--- a/tests/test_local_llm_reviewer_graph_transform.py
+++ b/tests/test_local_llm_reviewer_graph_transform.py
@@ -218,13 +218,33 @@ def test_reviewer_graph_transform_submit_modes(tmp_path):
                 updatedAt: 1234,
             }});
             assert(savedState.answer === "saved answer", "Loader state setter must return the saved answer");
+            assert(savedState.thinking === "saved thinking", "Loader live preview state may keep current-run Thinking in memory");
             assert(stateNode.properties.deno_local_llm_state.answer === "saved answer", "Loader state must persist into node.properties");
-            const restoredStateNode = {{ id: 45, properties: {{ deno_local_llm_state: stateNode.properties.deno_local_llm_state }} }};
+            assert(stateNode.properties.deno_local_llm_state.thinking === "", "Loader properties must never persist current-run Thinking");
+            const restoredStateNode = {{
+                id: 45,
+                properties: {{
+                    deno_local_llm_state: {{
+                        ...stateNode.properties.deno_local_llm_state,
+                        thinking: "legacy saved thinking",
+                    }},
+                }},
+            }};
             const restoredState = api.restoreLocalLLMStateFromProperties(restoredStateNode);
             assert(restoredState.answer === "saved answer", "Loader state must restore from workflow properties");
-            assert(restoredStateNode.__denoLocalLLMState.thinking === "saved thinking", "Restored Loader state must hydrate the visible node state");
-            const lazyRestoredStateNode = {{ id: 145, properties: {{ deno_local_llm_state: stateNode.properties.deno_local_llm_state }} }};
-            assert(api.getLocalLLMNodeState(lazyRestoredStateNode).thinking === "saved thinking", "Loader preview state must lazily restore Thinking from workflow properties");
+            assert(restoredStateNode.__denoLocalLLMState.thinking === "", "Restoring older Loader state must not hydrate private Thinking");
+            assert(restoredStateNode.properties.deno_local_llm_state.thinking === "", "Restoring older Loader state must scrub private Thinking from properties");
+            const lazyRestoredStateNode = {{
+                id: 145,
+                properties: {{
+                    deno_local_llm_state: {{
+                        ...stateNode.properties.deno_local_llm_state,
+                        thinking: "legacy lazy thinking",
+                    }},
+                }},
+            }};
+            assert(api.getLocalLLMNodeState(lazyRestoredStateNode).thinking === "", "Loader preview state must not lazily restore Thinking from workflow properties");
+            assert(lazyRestoredStateNode.properties.deno_local_llm_state.thinking === "", "Lazy restore must scrub private Thinking from workflow properties");
             const progressStateNode = {{ id: 146, properties: {{}}, setDirtyCanvas() {{}} }};
             api.setLocalLLMNodeState(progressStateNode, {{
                 status: "done",
@@ -240,6 +260,7 @@ def test_reviewer_graph_transform_submit_modes(tmp_path):
                 answer: "kept answer",
             }}));
             assert(api.getLocalLLMNodeState(progressStateNode).thinking === "kept thinking", "Progress updates without Thinking must not wipe the saved Thinking preview");
+            assert(progressStateNode.properties.deno_local_llm_state.thinking === "", "Live progress Thinking must remain absent from Loader properties");
             api.setLocalLLMNodeState(progressStateNode, api.localLLMProgressStatePatch(progressStateNode, {{
                 status: "running",
                 provider: "vLLM",
@@ -357,15 +378,26 @@ def test_reviewer_graph_transform_submit_modes(tmp_path):
             }};
             assert(configuredLoader.configure(configureInfo) === "configured", "Loader configure wrapper must preserve the original configure result");
             assert(configuredLoader.__denoLocalLLMState.answer === "workflow answer", "Loader configure must restore saved result state from properties");
+            assert(configuredLoader.__denoLocalLLMState.thinking === "", "Loader configure must not restore saved private Thinking");
+            assert(configureInfo.properties.deno_local_llm_state.thinking === "", "Loader configure must scrub private Thinking before base restore");
             const sameIdOtherWorkflowNode = {{ id: 46, type: "DenoLocalLLMRefiner", properties: {{}} }};
             assert(
                 api.getLocalLLMNodeState(sameIdOtherWorkflowNode).answer !== "workflow answer",
                 "Loader state must be scoped to the actual node object, not a node id reused by another workflow"
             );
+            api.setLocalLLMNodeState(configuredLoader, {{ thinking: "current run thinking", updatedAt: 3333 }});
+            assert(configuredLoader.__denoLocalLLMState.thinking === "current run thinking", "Current-run Thinking must remain visible in the in-memory Loader preview");
+            assert(configuredLoader.properties.deno_local_llm_state.thinking === "", "Current-run Thinking must not leak into live workflow properties");
             const serializedInfo = {{ widgets_values: [...savedLoaderValues], properties: {{}} }};
             assert(configuredLoader.onSerialize(serializedInfo) === "serialized", "Loader serialize wrapper must preserve the original serialize result");
             assert(serializedInfo.widgets_values.length === 13, "Loader serialize must remove generated buttons and keep canonical widget count");
             assert(serializedInfo.properties.deno_local_llm_state.answer === "workflow answer", "Loader serialize must include saved result state in properties");
+            assert(serializedInfo.properties.deno_local_llm_state.thinking === "", "Loader serialize must never include current-run Thinking");
+            assert(configuredLoader.properties.deno_local_llm_state.thinking === "", "Loader serialize must keep node.properties free of Thinking");
+            assert(configuredLoader.__denoLocalLLMState.thinking === "current run thinking", "Loader serialize must not erase the current in-memory Thinking preview");
+            const serializedReloadNode = {{ id: 246, properties: serializedInfo.properties }};
+            assert(api.restoreLocalLLMStateFromProperties(serializedReloadNode).answer === "workflow answer", "Serialized Loader state must retain the final answer on reload");
+            assert(serializedReloadNode.__denoLocalLLMState.thinking === "", "Serialized Loader state must reload without private Thinking");
             const legacyInputNode = {{
                 id: 146,
                 inputs: [
@@ -684,7 +716,8 @@ def test_reviewer_graph_transform_submit_modes(tmp_path):
             assert(api.getWidget(copiedLoaderNode, "thinking").value === true, "Loader copy/paste setup must restore Thinking On");
             assert(api.getWidget(copiedLoaderNode, "seed").value === 42, "Loader copy/paste setup must restore the saved seed");
             assert(api.getWidget(copiedLoaderNode, "prompt").value === "Prompt text", "Loader copy/paste setup must restore the saved prompt text");
-            assert(api.getLocalLLMNodeState(copiedLoaderNode).thinking === "copied thinking", "Loader copy/paste setup must restore saved Thinking preview state");
+            assert(api.getLocalLLMNodeState(copiedLoaderNode).thinking === "", "Loader copy/paste setup must not restore saved private Thinking");
+            assert(copiedLoaderNode.properties.deno_local_llm_state.thinking === "", "Loader copy/paste setup must scrub private Thinking from properties");
             assert(copiedLoaderNode.inputs.filter((input) => input.name === "audio_context").length === 1, "Fresh setup must add one audio analysis socket");
             const copiedPromptWidget = api.getWidget(copiedLoaderNode, "prompt");
             assert(typeof copiedPromptWidget.computeSize === "undefined", "Modern ComfyUI prompt layout must not keep the current node height as a fixed computeSize minimum");

--- a/web/js/deno_local_llm_refiner.js
+++ b/web/js/deno_local_llm_refiner.js
@@ -704,11 +704,23 @@ function sanitizeLocalLLMState(raw) {
     };
 }
 
+function sanitizeLocalLLMPersistedState(raw) {
+    const clean = sanitizeLocalLLMState(raw);
+    if (!clean) {
+        return null;
+    }
+    // Thinking is a live preview only; workflow/PNG metadata keeps the final answer, never private reasoning.
+    return {
+        ...clean,
+        thinking: "",
+    };
+}
+
 function persistLocalLLMStateToProperties(node, state) {
     if (!node) {
         return null;
     }
-    const clean = sanitizeLocalLLMState(state);
+    const clean = sanitizeLocalLLMPersistedState(state);
     if (!clean) {
         return null;
     }
@@ -718,10 +730,12 @@ function persistLocalLLMStateToProperties(node, state) {
 }
 
 function restoreLocalLLMStateFromProperties(node) {
-    const restored = sanitizeLocalLLMState(node?.properties?.[LOADER_STATE_PROPERTY]);
+    const restored = sanitizeLocalLLMPersistedState(node?.properties?.[LOADER_STATE_PROPERTY]);
     if (!node || !restored) {
         return null;
     }
+    node.properties = node.properties || {};
+    node.properties[LOADER_STATE_PROPERTY] = restored;
     node.__denoLocalLLMState = restored;
     const key = localLLMNodeStateKey(node);
     if (key) {
@@ -1057,7 +1071,7 @@ app.registerExtension({
         const configure = nodeType.prototype.configure;
         nodeType.prototype.configure = function (info) {
             const normalizedValues = normalizeLocalLLMLoaderWidgetValues(info);
-            const restoredState = sanitizeLocalLLMState(info?.properties?.[LOADER_STATE_PROPERTY]);
+            const restoredState = sanitizeLocalLLMPersistedState(info?.properties?.[LOADER_STATE_PROPERTY]);
             if (restoredState) {
                 info.properties = info.properties || {};
                 info.properties[LOADER_STATE_PROPERTY] = restoredState;
@@ -1097,7 +1111,7 @@ app.registerExtension({
                     || normalizeLocalLLMLoaderSerializedValues(info.widgets_values)
                     || info.widgets_values.slice(0, LOADER_SERIALIZED_WIDGET_COUNT);
             }
-            const state = sanitizeLocalLLMState(this.__denoLocalLLMState || restoreLocalLLMStateFromProperties(this));
+            const state = sanitizeLocalLLMPersistedState(this.__denoLocalLLMState || restoreLocalLLMStateFromProperties(this));
             if (state && info) {
                 info.properties = info.properties || {};
                 info.properties[LOADER_STATE_PROPERTY] = state;
@@ -2141,6 +2155,7 @@ if (typeof globalThis !== "undefined" && typeof globalThis.__DENO_LOCAL_LLM_REVI
         persistLocalLLMStateToProperties,
         restoreLocalLLMStateFromProperties,
         sanitizeLocalLLMState,
+        sanitizeLocalLLMPersistedState,
         getLocalLLMNodeState,
         localLLMProgressStatePatch,
         setLocalLLMNodeState,


### PR DESCRIPTION
## Summary
- embed the Local LLM node's final Result into the same execution's workflow metadata before downstream save nodes run
- restore the Result when a saved PNG or workflow is reopened while keeping Thinking/reasoning preview-only and scrubbing legacy persisted Thinking
- preserve existing node IDs, sockets, widgets, batch output behavior, and cache inputs; bump the package to v0.7.85

## Verification
- 585 Python tests passed with the CI-equivalent command
- frontend syntax checks and the LTX harness passed
- isolated CPU ComfyUI execution saved a real PNG whose workflow metadata contained the same-run Result and no Thinking content
- Registry package audit: 418 files, no experimental MiniMax H3 A2V node, no private runtime artifacts