### PR TITLE
Add LTX 2.5 setup and Nodes 2.0 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This file intentionally stays short. Detailed engineering notes belong in privat
 
 ## Unreleased
 
+## 0.7.86 - 2026-08-12
+
+- Added the complete official LTX 2.5 Distilled INT8 model set to `(Deno) Easy Model Download Helper`, including the two-stage x2 spatial upscaler, while preserving saved custom and legacy LTX 2.3 presets and keeping all gated downloads in the user's browser.
+- Updated `(Deno) LTX Sequencer` to request its image input lazily when guides are active and to follow current ComfyUI LTX guide metadata without changing its saved input or output schema.
+- Fixed the DENO input-folder browsers to skip external symlinks and junctions that ComfyUI cannot safely serve, with a clear route to `(Deno) Advanced Image Source Loader` for external folders. Fixes #71.
+- Fixed image-loader compatibility with Nodes 2.0 by keeping serialized path widgets hidden, making the Advanced loader gallery follow the available node height, and keeping disabled sources readable without rebuilding the whole gallery. Fixes #72.
+
 ## 0.7.85 - 2026-08-11
 
 - Fixed `(Deno) Local LLM Loader` so, whenever the node executes, its final Result is embedded in that output's workflow metadata and restored inside the node when a saved PNG or workflow is reopened, without persisting Thinking/reasoning content.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Main features:
 - `Input Folder` browser for reusing existing ComfyUI `input` images
 - input subfolder browsing with folder tiles, double-click navigation, and a `Parent` button
 - nested input images can be added while preserving their ComfyUI subfolder paths
+- external symlinks or junctions that leave ComfyUI's `input` folder are skipped for security; use `(Deno) Advanced Image Source Loader`'s External Folder mode for those sources
 - newest-first input image sorting based on file modified time
 - responsive input-folder thumbnails for smoother browsing with many images
 - `Keep Input Ratio`, `Preset Ratio`, or `Manual Input` size mode
@@ -169,8 +170,9 @@ Main features:
 - supports upload, drag-and-drop, paste, and browser folder upload where the browser allows it
 - includes a visible `Paste` button plus normal Ctrl+V image paste
 - click thumbnails to disable/enable sources without deleting them
+- disabled sources stay readable and remain saved with the workflow until re-enabled or removed
 - drag thumbnail cards to reorder output sequence
-- the gallery expands vertically when the ComfyUI node is resized
+- the gallery follows the node's available height in both the classic canvas and Nodes 2.0
 - thumbnails use a masonry-style flow so mixed portrait/landscape references are easier to scan
 - `Load Path` reads an external folder directly without first importing it into ComfyUI `input`
 - `Upload Folder...` is an optional browser upload/import helper, not required for external path loading
@@ -369,19 +371,22 @@ The full audio latent is passed to every video tile as context, while the return
 
 ### `(Deno) Easy Model Download Helper`
 
-Preset-based setup helper for recommended model file sets. The first built-in preset is the LTX 2.3 8GB VRAM GGUF starter set.
+Preset-based setup helper for recommended model file sets. The built-in presets cover the LTX 2.3 8GB VRAM GGUF starter set and the official LTX 2.5 Distilled INT8 two-stage model set.
 
 ![Deno Easy Model Download Helper](docs/images/easy-model-download-helper.png)
 
 Main features:
 
 - opens official model links in the browser instead of downloading files in Python
+- includes the LTX 2.5 diffusion model, projected Gemma 4 text encoder, video and audio VAEs, and x2 spatial upscaler required by the two-stage workflow
 - shows detected ComfyUI model roots and lets users copy the selected root
 - supports saved creator presets inside the workflow and restores them from browser storage after a page reload
 - supports Hugging Face direct links and Civitai page/download links without Python-side network requests
 - checks ComfyUI-registered model folders, including custom folder names from `extra_model_paths`
 - checks each preset's exact target path inside those registered model folders without scanning unrelated nested project folders
 - shows target ComfyUI model subfolders so viewers know exactly where files should go
+
+The LTX 2.5 repository requires a Hugging Face account and **Agree and Access** before its files can be downloaded. The helper does not bypass that gate or download files automatically. Review the [LTX-2 Community License](https://github.com/Lightricks/LTX-2/blob/main/LICENSE.md), request access on the [official LTX 2.5 repository](https://huggingface.co/Lightricks/LTX-2.5), then use the helper's browser links and move each downloaded file into the displayed ComfyUI model folder.
 
 Creator preset link guide:
 

--- a/deno_advanced_image_source_loader.py
+++ b/deno_advanced_image_source_loader.py
@@ -492,7 +492,7 @@ class DenoAdvancedImageSourceLoader:
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "image_paths": ("STRING", {"default": "", "multiline": True}),
+                "image_paths": ("STRING", {"default": "", "multiline": True, "hidden": True}),
                 "mode": (["Keep Input Ratio", "Preset Ratio", "Manual Input"], {"default": "Keep Input Ratio"}),
                 "ratio_preset": (COMMON_RATIOS, {"default": "16:9"}),
                 "megapixels": ("FLOAT", {"default": 1.0, "min": 0.01, "max": 10.0, "step": 0.01}),
@@ -503,7 +503,7 @@ class DenoAdvancedImageSourceLoader:
                 "resize_method": (ADVANCED_RESIZE_METHODS, {"default": "Center Crop (Fill)"}),
                 "recursive_folders": ("BOOLEAN", {"default": False}),
                 "list_output_mode": (["Original Size", "Match Batch Size"], {"default": "Original Size"}),
-                "disabled_image_paths": ("STRING", {"default": "", "multiline": True}),
+                "disabled_image_paths": ("STRING", {"default": "", "multiline": True, "hidden": True}),
             },
             "optional": {
                 "images": ("IMAGE",),

--- a/deno_ltx_model_downloader.py
+++ b/deno_ltx_model_downloader.py
@@ -74,6 +74,55 @@ MODEL_FILES = [
 ]
 
 
+LTX25_MODEL_FILES = [
+    {
+        "id": "diffusion_model",
+        "label": "LTX 2.5 distilled INT8 model",
+        "repo": "Lightricks/LTX-2.5",
+        "repo_path": "diffusion_models/ltx-2.5-22b-distilled-transformer-comfy-int8-convrot.safetensors",
+        "target_subdir": "diffusion_models",
+        "filename": "ltx-2.5-22b-distilled-transformer-comfy-int8-convrot.safetensors",
+        "size": 21_504_034_224,
+    },
+    {
+        "id": "text_encoder",
+        "label": "Gemma 4 text encoder with LTX 2.5 projection",
+        "repo": "Lightricks/LTX-2.5",
+        "repo_path": "text_encoders/gemma4-12b-with-proj-ltx-2.5-comfy-int8-convrot.safetensors",
+        "target_subdir": "text_encoders",
+        "filename": "gemma4-12b-with-proj-ltx-2.5-comfy-int8-convrot.safetensors",
+        "size": 15_372_971_786,
+    },
+    {
+        "id": "video_vae",
+        "label": "LTX 2.5 video VAE",
+        "repo": "Lightricks/LTX-2.5",
+        "repo_path": "vae/ltx-2.5-video-vae-bf16.safetensors",
+        "target_subdir": "vae",
+        "filename": "ltx-2.5-video-vae-bf16.safetensors",
+        "size": 1_472_223_346,
+    },
+    {
+        "id": "audio_vae",
+        "label": "LTX 2.5 audio VAE",
+        "repo": "Lightricks/LTX-2.5",
+        "repo_path": "vae/ltx-2.5-audio-vae-bf16.safetensors",
+        "target_subdir": "vae",
+        "filename": "ltx-2.5-audio-vae-bf16.safetensors",
+        "size": 364_866_540,
+    },
+    {
+        "id": "spatial_upscaler",
+        "label": "LTX 2.5 spatial upscaler x2",
+        "repo": "Lightricks/LTX-2.5",
+        "repo_path": "latent_upscale_models/ltx-2.5-latent-spatial-upscaler-x2-bf16-1.0.safetensors",
+        "target_subdir": "latent_upscale_models",
+        "filename": "ltx-2.5-latent-spatial-upscaler-x2-bf16-1.0.safetensors",
+        "size": 995_778_752,
+    },
+]
+
+
 MODEL_ROOT_SUBDIRS = {
     "unet",
     "diffusion_models",
@@ -232,10 +281,28 @@ def _default_package() -> Dict:
     }
 
 
+def _ltx25_package() -> Dict:
+    return {
+        "id": "ltx_25_distilled_int8",
+        "title": "LTX 2.5 Distilled INT8",
+        "description": (
+            "Official LTX 2.5 distilled INT8 model set, including the projected Gemma 4 text encoder, "
+            "video/audio VAEs, and x2 spatial upscaler. Sign in to Hugging Face and complete "
+            "Agree and Access before opening the download links. Files are provided under the "
+            "LTX-2 Community License."
+        ),
+        "files": [_model_file_to_package_file(item) for item in LTX25_MODEL_FILES],
+    }
+
+
+def _builtin_packages() -> List[Dict]:
+    return [_default_package(), _ltx25_package()]
+
+
 def _default_presets_state() -> Dict:
     return {
         "active_preset_id": "ltx_23_8gb_vram",
-        "presets": [_default_package()],
+        "presets": _builtin_packages(),
     }
 
 
@@ -510,13 +577,14 @@ def _parse_presets_state(value) -> Dict:
     if not isinstance(presets, list):
         presets = []
 
-    default_package = _default_package()
+    builtin_packages = _builtin_packages()
+    builtin_ids = {package["id"] for package in builtin_packages}
     normalized = [
         _normalize_package(item)
         for item in presets
-        if isinstance(item, dict) and str(item.get("id") or "") != default_package["id"]
+        if isinstance(item, dict) and str(item.get("id") or "") not in builtin_ids
     ]
-    normalized = [default_package, *normalized]
+    normalized = [*builtin_packages, *normalized]
 
     active_id = str(value.get("active_preset_id") or normalized[0]["id"])
     if not any(item["id"] == active_id for item in normalized):
@@ -534,6 +602,15 @@ def _active_package_from_state(state_value) -> Dict:
         if package["id"] == state["active_preset_id"]:
             return package
     return state["presets"][0]
+
+
+def _canonicalize_builtin_package(package: Dict) -> Dict:
+    """Replace stale saved copies of built-ins while preserving custom packages."""
+    package_id = str(package.get("id") or "")
+    for builtin in _builtin_packages():
+        if builtin["id"] == package_id:
+            return builtin
+    return package
 
 
 def _model_subdirs(models_root: str) -> List[str]:
@@ -624,7 +701,11 @@ def _public_package_files(models_root: str, package: Dict) -> List[Dict]:
 def _build_payload(root_id: str | None, state_value=None, package_value=None, model_root: str | None = None) -> Dict:
     selected, roots, selection_mode, selection_reason = _select_root(root_id)
     state = _parse_presets_state(state_value)
-    package = _normalize_package(package_value) if package_value is not None else _active_package_from_state(state)
+    package = (
+        _canonicalize_builtin_package(_normalize_package(package_value))
+        if package_value is not None
+        else _active_package_from_state(state)
+    )
     roots = [
         {
             **root,
@@ -701,9 +782,10 @@ async def ltx_model_downloader_check(request):
 class DenoLTXModelDownloader:
     DESCRIPTION = (
         "Preset-based easy model download helper.\n"
-        "The first preset is the LTX 2.3 8GB VRAM GGUF starter set. "
-        "Shows official Hugging Face links, target ComfyUI model paths, "
-        "and local install status without running automatic downloads."
+        "Includes the LTX 2.3 8GB VRAM GGUF starter set and the official LTX 2.5 Distilled INT8 set. "
+        "Shows Hugging Face links, target ComfyUI model paths, and local install status without "
+        "running automatic downloads. LTX 2.5 requires Hugging Face Agree and Access and is "
+        "provided under the LTX-2 Community License."
     )
     RETURN_TYPES = ()
     FUNCTION = "run"

--- a/deno_ltx_sequencer_plus.py
+++ b/deno_ltx_sequencer_plus.py
@@ -1,3 +1,5 @@
+import inspect
+
 from comfy_extras.nodes_lt import LTXVAddGuide
 import torch
 
@@ -10,6 +12,51 @@ except ImportError:
         if isinstance(latent, dict):
             return latent.get("noise_mask")
         return None
+
+try:
+    from comfy_extras.nodes_lt import _append_guide_attention_entry
+except ImportError:
+    # ComfyUI versions from before per-guide attention metadata remain supported.
+    _append_guide_attention_entry = None
+
+
+def _get_latent_index(conditioning, latent_length, guide_length, frame_idx, scale_factors, latent_shape):
+    """Use the current Comfy signature without dropping compatibility with older cores."""
+    try:
+        parameters = inspect.signature(LTXVAddGuide.get_latent_index).parameters
+    except (TypeError, ValueError):
+        parameters = {}
+    if "latent_shape" in parameters:
+        return LTXVAddGuide.get_latent_index(
+            conditioning,
+            latent_length,
+            guide_length,
+            frame_idx,
+            scale_factors,
+            latent_shape=latent_shape,
+        )
+    return LTXVAddGuide.get_latent_index(
+        conditioning,
+        latent_length,
+        guide_length,
+        frame_idx,
+        scale_factors,
+    )
+
+
+def _append_attention_entry(positive, negative, encoded_latent, strength):
+    if _append_guide_attention_entry is None:
+        return positive, negative
+    latent_shape = list(encoded_latent.shape[2:])
+    pre_filter_count = encoded_latent.shape[2] * encoded_latent.shape[3] * encoded_latent.shape[4]
+    return _append_guide_attention_entry(
+        positive,
+        negative,
+        pre_filter_count,
+        latent_shape,
+        strength=strength,
+        attention_mask=None,
+    )
 
 
 class DenoLTXSequencer:
@@ -30,7 +77,7 @@ class DenoLTXSequencer:
             "negative": ("CONDITIONING",),
             "vae": ("VAE",),
             "latent": ("LATENT",),
-            "multi_input": ("IMAGE",),
+            "multi_input": ("IMAGE", {"lazy": True}),
             "num_images": ("INT", {"default": 1, "min": 0, "max": 50, "step": 1}),
             "insert_mode": (["frames", "seconds"], {"default": "frames"}),
             "frame_rate": ("INT", {"default": 24, "min": 1, "max": 120, "step": 1}),
@@ -45,6 +92,13 @@ class DenoLTXSequencer:
             optional[f"strength_{index}"] = ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01})
 
         return {"required": required, "optional": optional}
+
+    @classmethod
+    def check_lazy_status(cls, bypass, num_images, multi_input=None, **kwargs):
+        if not bypass and int(num_images) > 0 and multi_input is None:
+            return ["multi_input"]
+        return []
+
     @classmethod
     def execute(
         cls,
@@ -63,8 +117,14 @@ class DenoLTXSequencer:
         if bypass:
             return (positive, negative, latent)
 
-        batch_size = int(multi_input.shape[0]) if multi_input is not None else 0
-        effective_count = max(0, min(int(num_images), batch_size))
+        requested_count = max(0, int(num_images))
+        if requested_count <= 0:
+            return (positive, negative, latent)
+        if multi_input is None:
+            raise ValueError("multi_input is required when LTX Sequencer guides are active.")
+
+        batch_size = int(multi_input.shape[0])
+        effective_count = min(requested_count, batch_size)
         if effective_count <= 0:
             return (positive, negative, latent)
 
@@ -75,7 +135,7 @@ class DenoLTXSequencer:
         latent_image = latent["samples"]
         noise_mask = get_noise_mask(latent)
 
-        _, _, latent_length, latent_height, latent_width = latent_image.shape
+        _, _, _, latent_height, latent_width = latent_image.shape
         applied_count = 0
 
         for index in range(1, effective_count + 1):
@@ -111,15 +171,21 @@ class DenoLTXSequencer:
                 strength = 1.0
 
             encoded_image, encoded_latent = LTXVAddGuide.encode(vae, latent_width, latent_height, image, scale_factors)
-            conditioning_frame_idx, latent_idx = LTXVAddGuide.get_latent_index(
-                positive, latent_length, len(encoded_image), frame_index, scale_factors
+            current_latent_length = latent_image.shape[2]
+            conditioning_frame_idx, latent_idx = _get_latent_index(
+                positive,
+                current_latent_length,
+                len(encoded_image),
+                frame_index,
+                scale_factors,
+                latent_image.shape,
             )
-            if latent_idx + encoded_latent.shape[2] > latent_length:
+            if latent_idx + encoded_latent.shape[2] > current_latent_length:
                 raise ValueError(
                     "Conditioning frames exceed latent length: "
                     f"latent_idx={latent_idx}, "
                     f"encoded_len={encoded_latent.shape[2]}, "
-                    f"latent_len={latent_length}."
+                    f"latent_len={current_latent_length}."
                 )
 
             positive, negative, latent_image, noise_mask = LTXVAddGuide.append_keyframe(
@@ -131,6 +197,12 @@ class DenoLTXSequencer:
                 encoded_latent,
                 strength,
                 scale_factors,
+            )
+            positive, negative = _append_attention_entry(
+                positive,
+                negative,
+                encoded_latent,
+                strength,
             )
             applied_count += 1
 

--- a/deno_minimax_h3_reference.py
+++ b/deno_minimax_h3_reference.py
@@ -79,7 +79,7 @@ class DenoMiniMaxH3ReferenceImageLoader:
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "image_paths": ("STRING", {"default": "", "multiline": True}),
+                "image_paths": ("STRING", {"default": "", "multiline": True, "hidden": True}),
             }
         }
 

--- a/deno_multi_image_board.py
+++ b/deno_multi_image_board.py
@@ -56,16 +56,27 @@ def _normalize_input_browser_path(relative_path: str | None) -> str | None:
     return normalized
 
 
+def _path_is_within_root(root_path: str, candidate_path: str) -> bool:
+    root_real_path = os.path.realpath(root_path)
+    candidate_real_path = os.path.realpath(candidate_path)
+    try:
+        common_path = os.path.commonpath([
+            os.path.normcase(root_real_path),
+            os.path.normcase(candidate_real_path),
+        ])
+    except ValueError:
+        return False
+    return common_path == os.path.normcase(root_real_path)
+
+
+def _input_browser_path_is_contained(input_dir: str, relative_path: str) -> bool:
+    return _path_is_within_root(input_dir, os.path.join(input_dir, relative_path))
+
+
 def _resolve_input_browser_dir(input_dir: str, relative_path: str) -> str | None:
     base_dir = os.path.realpath(input_dir)
     candidate_dir = os.path.realpath(os.path.join(base_dir, relative_path))
-
-    try:
-        common_path = os.path.commonpath([os.path.normcase(base_dir), os.path.normcase(candidate_dir)])
-    except ValueError:
-        return None
-
-    if common_path != os.path.normcase(base_dir):
+    if not _path_is_within_root(base_dir, candidate_dir):
         return None
     return candidate_dir if os.path.isdir(candidate_dir) else None
 
@@ -77,13 +88,6 @@ def _resolve_input_image_copy_path(path: str | None) -> str | None:
     return _resolve_input_path(raw_path)
 
 
-def _to_input_relative_path(input_dir: str, full_path: str) -> str:
-    relative = os.path.relpath(full_path, input_dir)
-    if relative == ".":
-        return ""
-    return relative.replace("\\", "/")
-
-
 def _get_input_browser_parent(relative_path: str) -> str:
     if not relative_path:
         return ""
@@ -91,12 +95,25 @@ def _get_input_browser_parent(relative_path: str) -> str:
     return "" if parent == "." else parent
 
 
-def _empty_input_folder_listing(relative_path: str = ""):
+def _blocked_input_items_notice(blocked_count: int) -> str:
+    count = max(0, int(blocked_count or 0))
+    if count <= 0:
+        return ""
+    noun = "item" if count == 1 else "items"
+    return (
+        f"{count} linked {noun} skipped because the target is outside "
+        "the ComfyUI input folder. Use Advanced Image Source Loader for external folders."
+    )
+
+
+def _empty_input_folder_listing(relative_path: str = "", blocked_count: int = 0):
     return {
         "path": relative_path,
         "parent": _get_input_browser_parent(relative_path),
         "folders": [],
         "files": [],
+        "blocked_count": max(0, int(blocked_count or 0)),
+        "notice": _blocked_input_items_notice(blocked_count),
     }
 
 
@@ -116,33 +133,45 @@ def _list_input_folder_entries(relative_path: str | None = ""):
 
     folders = []
     files = []
+    blocked_count = 0
     try:
-        for name in os.listdir(current_dir):
-            full_path = os.path.join(current_dir, name)
+        names = os.listdir(current_dir)
+    except Exception as exc:
+        print(f"[DenoMultiImageLoader] Failed to list input folder images: {exc}")
+        return _empty_input_folder_listing(browser_path)
+
+    for name in names:
+        full_path = os.path.join(current_dir, name)
+        if not _path_is_within_root(input_dir, full_path):
+            blocked_count += 1
+            continue
+        try:
             stat = os.stat(full_path)
+            entry_path = "/".join(part for part in (browser_path, name) if part)
             if os.path.isdir(full_path):
                 folders.append({
                     "name": name,
-                    "path": _to_input_relative_path(input_dir, full_path),
+                    "path": entry_path,
                     "mtime": stat.st_mtime,
                 })
                 continue
             if os.path.isfile(full_path) and os.path.splitext(name)[1].lower() in INPUT_BROWSER_IMAGE_EXTENSIONS:
                 files.append({
-                    "name": _to_input_relative_path(input_dir, full_path),
+                    "name": entry_path,
                     "display_name": name,
                     "mtime": stat.st_mtime,
                     "size": stat.st_size,
                 })
-    except Exception as exc:
-        print(f"[DenoMultiImageLoader] Failed to list input folder images: {exc}")
-        return _empty_input_folder_listing(browser_path)
+        except OSError:
+            continue
 
     return {
         "path": browser_path,
         "parent": _get_input_browser_parent(browser_path),
         "folders": sorted(folders, key=lambda item: str(item["name"]).lower()),
         "files": sorted(files, key=lambda item: (-float(item["mtime"]), str(item["name"]).lower())),
+        "blocked_count": blocked_count,
+        "notice": _blocked_input_items_notice(blocked_count),
     }
 
 
@@ -156,6 +185,15 @@ async def deno_input_folder_images(request):
     browser_path = _normalize_input_browser_path(requested_path)
     if browser_path is None:
         return web.json_response({"error": "Invalid input folder path."}, status=400)
+    folder_paths = _get_folder_paths()
+    if (
+        folder_paths is not None
+        and hasattr(folder_paths, "get_input_directory")
+        and not _input_browser_path_is_contained(folder_paths.get_input_directory(), browser_path)
+    ):
+        return web.json_response({
+            "error": "This input folder path is blocked because it resolves outside the ComfyUI input folder."
+        }, status=403)
     return web.json_response(_list_input_folder_entries(browser_path))
 
 
@@ -167,6 +205,15 @@ async def deno_input_image_path(request):
     browser_path = _normalize_input_browser_path(requested_path)
     if browser_path is None:
         return web.json_response({"error": "Invalid input image path."}, status=400)
+    folder_paths = _get_folder_paths()
+    if (
+        folder_paths is not None
+        and hasattr(folder_paths, "get_input_directory")
+        and not _input_browser_path_is_contained(folder_paths.get_input_directory(), browser_path)
+    ):
+        return web.json_response({
+            "error": "This input image path is blocked because it resolves outside the ComfyUI input folder."
+        }, status=403)
     resolved_path = _resolve_input_image_copy_path(requested_path)
     return web.json_response({
         "path": browser_path if resolved_path else "",
@@ -446,7 +493,7 @@ class DenoMultiImageLoader:
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "image_paths": ("STRING", {"default": "", "multiline": True}),
+                "image_paths": ("STRING", {"default": "", "multiline": True, "hidden": True}),
                 "mode": (["Keep Input Ratio", "Preset Ratio", "Manual Input"], {"default": "Keep Input Ratio"}),
                 "ratio_preset": (COMMON_RATIOS, {"default": "16:9"}),
                 "megapixels": ("FLOAT", {"default": 1.0, "min": 0.01, "max": 10.0, "step": 0.01}),

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -73,7 +73,7 @@ ComfyUI용 해상도 도우미와 이미지 리사이즈 노드입니다.
 
 ![Deno Multi Image Loader](images/multi-image-loader.jpg)
 
-주요 기능: 고정 높이 갤러리, 드래그 정렬, 업로드, 드래그 앤 드롭, 이미지 붙여넣기, ComfyUI `input` 폴더 탐색, 중첩 폴더 이미지 추가, 최신순 정렬, 비율 유지/프리셋/직접 입력 리사이즈, `multi_output`, `width`, `height` 출력.
+주요 기능: 고정 높이 갤러리, 드래그 정렬, 업로드, 드래그 앤 드롭, 이미지 붙여넣기, ComfyUI `input` 폴더 탐색, 중첩 폴더 이미지 추가, 최신순 정렬, 비율 유지/프리셋/직접 입력 리사이즈, `multi_output`, `width`, `height` 출력. 보안을 위해 `input` 폴더 밖으로 나가는 외부 심볼릭 링크·정션은 건너뛰며, 이런 소스는 `(Deno) Advanced Image Source Loader`의 External Folder를 사용합니다.
 
 ### `(Deno) MiniMax H3 Multi Reference Image Loader`
 
@@ -109,7 +109,7 @@ ComfyUI 순정 MiniMax H3 Reference to Video용 한 줄 연결 다중 참조 이
 
 ![Deno Advanced Image Source Loader](images/advanced-image-source-loader.png)
 
-주요 기능: ComfyUI `input` 폴더와 외부 로컬 폴더 지원, URL/Path 입력, 업로드와 붙여넣기, 썸네일 enable/disable, 드래그 정렬, masonry 스타일 갤러리, 재귀 폴더 로드, 배치 텐서와 `image_list` 출력.
+주요 기능: ComfyUI `input` 폴더와 외부 로컬 폴더 지원, URL/Path 입력, 업로드와 붙여넣기, 썸네일 enable/disable, 드래그 정렬, masonry 스타일 갤러리, 재귀 폴더 로드, 배치 텐서와 `image_list` 출력. 비활성 이미지는 삭제하지 않은 채 알아볼 수 있는 밝기로 유지되고, 갤러리는 기존 캔버스와 Nodes 2.0에서 노드 높이에 맞춰 유동적으로 배치됩니다.
 
 ### `(Deno) Image Compare`
 
@@ -189,11 +189,13 @@ LTX AV refinement 패스를 위한 샘플러입니다. 하나의 global sampler 
 
 ### `(Deno) Easy Model Download Helper`
 
-권장 모델 파일 세트를 안내하는 프리셋 기반 설치 도우미입니다.
+권장 모델 파일 세트를 안내하는 프리셋 기반 설치 도우미입니다. 내장 프리셋은 기존 LTX 2.3 8GB VRAM GGUF 세트와 공식 LTX 2.5 Distilled INT8 2단계 모델 세트를 함께 제공합니다.
 
 ![Deno Easy Model Download Helper](images/easy-model-download-helper.png)
 
-주요 기능: Python에서 직접 다운로드하지 않고 공식 모델 링크를 브라우저로 열기, ComfyUI 모델 루트 표시, workflow 안 creator preset 저장, Hugging Face와 Civitai 링크 지원, 파일이 올바른 모델 폴더에 있는지 확인.
+주요 기능: Python에서 직접 다운로드하지 않고 공식 모델 링크를 브라우저로 열기, ComfyUI 모델 루트 표시, workflow 안 creator preset 저장, Hugging Face와 Civitai 링크 지원, 파일이 올바른 모델 폴더에 있는지 확인. LTX 2.5 프리셋에는 diffusion model, projection이 포함된 Gemma 4 text encoder, video/audio VAE, 2단계 처리용 x2 spatial upscaler가 모두 포함됩니다.
+
+LTX 2.5 파일은 Hugging Face 로그인 후 **Agree and Access** 승인이 필요합니다. 이 도우미는 접근 제한을 우회하거나 모델을 자동 다운로드하지 않습니다. 먼저 [LTX-2 Community License](https://github.com/Lightricks/LTX-2/blob/main/LICENSE.md)를 확인하고 [공식 LTX 2.5 저장소](https://huggingface.co/Lightricks/LTX-2.5)에서 접근 권한을 받은 뒤, 노드가 여는 브라우저 링크로 파일을 내려받아 화면에 표시된 ComfyUI 모델 폴더에 옮기세요.
 
 ![Hugging Face link guide](images/easy-model-download-helper-huggingface-link.png)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "deno-custom-nodes"
-description = "DENO RTX node pack for ComfyUI: MiniMax H3 multi-reference image and Reference to Video helpers, local audio transcription and analysis helpers, Ideogram Director visual JSON/bbox prompt builder, Local LLM Loader and Reviewer helpers, GPT/Gemini-ready Error Help reports, Prompt Only final prompt extraction, RTX Video Super Resolution, RTX Super Resolution, Video SR/VSR, NVIDIA VFX/nvvfx, RTX upscale helpers, LTX 2.3 workflows, LTX tiled second-pass refinement helpers, Bernini Prompt Guide, audio/image review gates, Bernini conditioning helpers, Wan 2.2 reference video edit workflows, image and video compare, video preview, Video to GIF/WebP tools, multi-image loading, resize tools, LoRA/model helpers, prompt guides, and visual workflow utilities."
-version = "0.7.85"
+description = "DENO RTX node pack for ComfyUI: MiniMax H3 multi-reference image and Reference to Video helpers, local audio transcription and analysis helpers, Ideogram Director visual JSON/bbox prompt builder, Local LLM Loader and Reviewer helpers, GPT/Gemini-ready Error Help reports, Prompt Only final prompt extraction, RTX Video Super Resolution, RTX Super Resolution, Video SR/VSR, NVIDIA VFX/nvvfx, RTX upscale helpers, LTX 2.3 and LTX 2.5 model/workflow helpers, LTX tiled second-pass refinement helpers, Bernini Prompt Guide, audio/image review gates, Bernini conditioning helpers, Wan 2.2 reference video edit workflows, image and video compare, video preview, Video to GIF/WebP tools, multi-image loading, resize tools, LoRA/model helpers, prompt guides, and visual workflow utilities."
+version = "0.7.86"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = ["openai-whisper>=20250625"]
@@ -21,6 +21,7 @@ keywords = [
   "nvvfx",
   "ltx-video",
   "ltx-2.3",
+  "ltx-2.5",
   "ltx-tiled",
   "ltx-tiled-sampler",
   "ltx-av-tiled",

--- a/tests/js/advanced_image_source_loader_harness.mjs
+++ b/tests/js/advanced_image_source_loader_harness.mjs
@@ -49,6 +49,8 @@ class FakeMouseEvent {
   }
 }
 
+class FakeWheelEvent extends FakeMouseEvent {}
+
 function pointerEvent(overrides = {}) {
   return {
     type: "mousedown",
@@ -77,6 +79,7 @@ windowTarget.__DENO_ADVANCED_IMAGE_SOURCE_TEST_HOOK__ = (registered) => {
 const context = {
   console,
   MouseEvent: FakeMouseEvent,
+  WheelEvent: FakeWheelEvent,
   URLSearchParams,
   app: {
     canvas: { canvas: canvasTarget },
@@ -116,33 +119,123 @@ assert.equal(
 );
 assert.match(hooks.getPreviewUrl("folder/a.png"), /^\/api\/view\?/);
 
+assert.deepEqual(Array.from(hooks.resolveAdvancedNodeSize([300, 400])), [520, 620]);
+assert.deepEqual(Array.from(hooks.resolveAdvancedNodeSize([840, 900])), [840, 900]);
+assert.equal(hooks.shouldApplyAdvancedNodeSize([520, 620], [520, 620]), false);
+assert.equal(hooks.shouldApplyAdvancedNodeSize([500, 620], [520, 620]), true);
+
+const hiddenCallback = () => "preserved";
+const hiddenWidget = {
+  name: "image_paths",
+  value: "one.png\ntwo.png",
+  callback: hiddenCallback,
+  computeSize: () => [320, 80],
+};
+const widgetOrder = [{ name: "before" }, hiddenWidget, { name: "after" }];
+hooks.hideWidget(hiddenWidget);
+assert.equal(widgetOrder[1], hiddenWidget, "the serialized widget must stay in its original array slot");
+assert.equal(hiddenWidget.value, "one.png\ntwo.png");
+assert.equal(hiddenWidget.callback, hiddenCallback);
+assert.equal(hiddenWidget.options.hidden, true);
+assert.equal(hiddenWidget.hidden, true);
+assert.equal(hiddenWidget.type, "hidden");
+
+const conditionalWidget = {
+  type: "number",
+  hidden: false,
+  options: {},
+  computeSize: () => [320, 24],
+};
+hooks.toggleWidgetVisibility(conditionalWidget, false);
+assert.equal(conditionalWidget.type, "hidden");
+assert.equal(conditionalWidget.options.hidden, true);
+hooks.toggleWidgetVisibility(conditionalWidget, true);
+assert.equal(conditionalWidget.type, "number");
+assert.equal(conditionalWidget.options.hidden, false);
+assert.deepEqual(Array.from(conditionalWidget.computeSize()), [320, 24]);
+
 const root = new FakeEventTarget();
-const cleanup = hooks.installMiddleMouseCanvasPan(root);
-assert.equal(root.listenerCount("mousedown"), 1);
-assert.equal(root.listenerCount("mousemove"), 1);
+const galleryChild = {};
+root.contains = (target) => target === root || target === galleryChild;
+const gallery = {
+  scrollTop: 10,
+  clientHeight: 100,
+  scrollHeight: 300,
+  contains(target) {
+    return target === galleryChild;
+  },
+};
+const cleanup = hooks.installMiddleMouseCanvasPan(root, gallery);
+assert.equal(root.listenerCount("wheel"), 0);
+assert.equal(root.listenerCount("mousedown"), 0);
+assert.equal(root.listenerCount("mousemove"), 0);
 assert.equal(root.listenerCount("auxclick"), 1);
+assert.equal(windowTarget.listenerCount("wheel"), 1);
+assert.equal(windowTarget.listenerCount("mousedown"), 1);
 assert.equal(windowTarget.listenerCount("mousemove"), 1);
 assert.equal(windowTarget.listenerCount("mouseup"), 1);
 
+const localWheel = pointerEvent({
+  type: "wheel",
+  target: galleryChild,
+  deltaX: 0,
+  deltaY: 120,
+  deltaZ: 0,
+  deltaMode: 0,
+});
+windowTarget.emit("wheel", localWheel);
+assert.equal(canvasTarget.dispatched.length, 0, "wheel over the visible gallery remains local scrolling");
+assert.equal(gallery.scrollTop, 130);
+assert.equal(localWheel.preventDefaultCalls, 1);
+assert.equal(localWheel.stopPropagationCalls, 1);
+
+gallery.scrollTop = 200;
+const boundaryWheel = pointerEvent({
+  type: "wheel",
+  target: galleryChild,
+  deltaX: 0,
+  deltaY: 120,
+  deltaZ: 0,
+  deltaMode: 0,
+});
+windowTarget.emit("wheel", boundaryWheel);
+assert.equal(canvasTarget.dispatched.length, 1, "wheel at the gallery boundary reaches the ComfyUI canvas");
+assert.equal(boundaryWheel.preventDefaultCalls, 1);
+
+const canvasWheel = pointerEvent({
+  type: "wheel",
+  target: root,
+  deltaX: 0,
+  deltaY: -120,
+  deltaZ: 0,
+  deltaMode: 0,
+});
+windowTarget.emit("wheel", canvasWheel);
+assert.equal(canvasTarget.dispatched.length, 2, "wheel outside the gallery reaches the ComfyUI canvas");
+assert.equal(canvasTarget.dispatched[1].type, "wheel");
+assert.equal(canvasWheel.preventDefaultCalls, 1);
+assert.equal(canvasWheel.stopPropagationCalls, 1);
+
 const down = pointerEvent();
-root.emit("mousedown", down);
-assert.equal(canvasTarget.dispatched.length, 1);
+down.target = root;
+windowTarget.emit("mousedown", down);
+assert.equal(canvasTarget.dispatched.length, 3);
 assert.equal(down.preventDefaultCalls, 1);
 assert.equal(down.stopPropagationCalls, 1);
 
 const move = pointerEvent({ type: "mousemove" });
 windowTarget.emit("mousemove", move);
-assert.equal(canvasTarget.dispatched.length, 2);
+assert.equal(canvasTarget.dispatched.length, 4);
 
 cleanup();
 cleanup();
-assert.equal(root.listenerCount("mousedown"), 0);
-assert.equal(root.listenerCount("mousemove"), 0);
+assert.equal(windowTarget.listenerCount("mousedown"), 0);
+assert.equal(windowTarget.listenerCount("wheel"), 0);
 assert.equal(root.listenerCount("auxclick"), 0);
 assert.equal(windowTarget.listenerCount("mousemove"), 0);
 assert.equal(windowTarget.listenerCount("mouseup"), 0);
 root.emit("mousedown", pointerEvent());
-assert.equal(canvasTarget.dispatched.length, 2);
+assert.equal(canvasTarget.dispatched.length, 4);
 
 const node = { __denoAdvancedLastExternalRoot: "C:\\Previous" };
 await hooks.fetchExternalFolderImagesAndRemember(node, "  /home/user/images  ", "child");

--- a/tests/js/ltx_model_downloader_presets_harness.mjs
+++ b/tests/js/ltx_model_downloader_presets_harness.mjs
@@ -1,0 +1,127 @@
+import fs from "node:fs";
+import vm from "node:vm";
+
+const sourcePath = process.argv[2];
+if (!sourcePath) {
+    throw new Error("Expected deno_ltx_model_downloader.js path.");
+}
+
+const storage = new Map();
+let helpers = null;
+const context = {
+    app: { registerExtension() {} },
+    api: {},
+    window: {
+        __DENO_LTX_MODEL_DOWNLOADER_TEST_HOOK__(value) {
+            helpers = value;
+        },
+    },
+    localStorage: {
+        getItem(key) {
+            return storage.has(key) ? storage.get(key) : null;
+        },
+        setItem(key, value) {
+            storage.set(key, String(value));
+        },
+    },
+    AbortController,
+    URL,
+    console,
+};
+
+const source = fs.readFileSync(sourcePath, "utf8").replace(/^import .*;\r?\n/gm, "");
+vm.runInNewContext(source, context, { filename: sourcePath });
+
+if (!helpers) {
+    throw new Error("LTX downloader test hook was not installed.");
+}
+
+function check(condition, message) {
+    if (!condition) {
+        throw new Error(message);
+    }
+}
+
+function ids(state) {
+    return state.presets.map((item) => item.id);
+}
+
+const builtinIds = ["ltx_23_8gb_vram", "ltx_25_distilled_int8"];
+const fresh = helpers.normalizePresetsState({});
+check(JSON.stringify(ids(fresh)) === JSON.stringify(builtinIds), "fresh state must contain both built-ins");
+check(fresh.active_preset_id === "ltx_23_8gb_vram", "fresh state must keep the LTX 2.3 default");
+check(!helpers.hasCustomPresets(fresh), "built-in LTX 2.5 must not be mistaken for a custom preset");
+
+const legacyOnly = helpers.normalizePresetsState({
+    active_preset_id: "ltx_23_8gb_vram",
+    presets: [{ id: "ltx_23_8gb_vram", title: "stale", files: [] }],
+});
+check(JSON.stringify(ids(legacyOnly)) === JSON.stringify(builtinIds), "LTX 2.3-only state must gain LTX 2.5");
+check(legacyOnly.presets[0].files.length === helpers.DEFAULT_PACKAGE.files.length, "stale LTX 2.3 must be canonicalized");
+check(legacyOnly.presets[1].files.length === 5, "LTX 2.5 must include the spatial upscaler");
+const expectedLtx25Files = [
+    ["diffusion_models", "ltx-2.5-22b-distilled-transformer-comfy-int8-convrot.safetensors", 21504034224],
+    ["text_encoders", "gemma4-12b-with-proj-ltx-2.5-comfy-int8-convrot.safetensors", 15372971786],
+    ["vae", "ltx-2.5-video-vae-bf16.safetensors", 1472223346],
+    ["vae", "ltx-2.5-audio-vae-bf16.safetensors", 364866540],
+    ["latent_upscale_models", "ltx-2.5-latent-spatial-upscaler-x2-bf16-1.0.safetensors", 995778752],
+];
+const actualLtx25Files = legacyOnly.presets[1].files.map((item) => [item.target_subdir, item.filename, item.size]);
+check(JSON.stringify(actualLtx25Files) === JSON.stringify(expectedLtx25Files), "LTX 2.5 browser preset must match backend files and sizes");
+
+const customPackage = {
+    id: "my_unknown_pack",
+    title: "My Unknown Pack",
+    description: "preserve me",
+    files: [{ id: "one", url: "https://example.com/one.safetensors", target_subdir: "checkpoints", filename: "one.safetensors", size: 1 }],
+};
+const customActive = helpers.normalizePresetsState({
+    active_preset_id: customPackage.id,
+    presets: [customPackage],
+});
+check(customActive.active_preset_id === customPackage.id, "custom active ID must be preserved");
+check(ids(customActive).includes(customPackage.id), "unknown custom preset must be preserved");
+check(customActive.presets.find((item) => item.id === customPackage.id).description === "preserve me", "custom fields must survive migration");
+
+const staleLtx25 = helpers.normalizePresetsState({
+    active_preset_id: "ltx_25_distilled_int8",
+    presets: [{ id: "ltx_25_distilled_int8", title: "old", files: [] }],
+});
+check(staleLtx25.active_preset_id === "ltx_25_distilled_int8", "known LTX 2.5 active ID must be preserved");
+check(staleLtx25.presets[1].files.length === 5, "stale LTX 2.5 must be replaced by the canonical package");
+
+storage.clear();
+let widgetCallbackCount = 0;
+const legacyWidget = {
+    value: JSON.stringify({
+        active_preset_id: "ltx_23_8gb_vram",
+        presets: [{ id: "ltx_23_8gb_vram", title: "old", files: [] }],
+    }),
+    callback() {
+        widgetCallbackCount += 1;
+    },
+};
+const migratedWidget = helpers.readPresetsState(legacyWidget);
+check(ids(migratedWidget).includes("ltx_25_distilled_int8"), "saved workflow widget must gain LTX 2.5");
+check(JSON.parse(legacyWidget.value).presets[1].files.length === 5, "saved workflow widget must persist canonical LTX 2.5 files");
+check(widgetCallbackCount === 1, "saved workflow widget migration must notify ComfyUI once");
+
+const merged = helpers.mergePresetLibrary(staleLtx25, customActive);
+check(merged.active_preset_id === "ltx_25_distilled_int8", "workflow active preset must remain authoritative");
+check(ids(merged).includes(customPackage.id), "browser custom preset must merge without replacing workflow state");
+
+helpers.writeStoredPresetsState(customActive);
+const reread = helpers.readStoredPresetsState();
+check(reread.active_preset_id === customPackage.id, "browser storage must preserve its active preset ID");
+check(ids(reread).includes(customPackage.id), "browser storage must preserve custom presets");
+
+storage.clear();
+storage.set("deno_ltx_model_downloader_presets_v1", JSON.stringify(customActive));
+const migratedLegacyStorage = helpers.readStoredPresetsState();
+check(migratedLegacyStorage.active_preset_id === customPackage.id, "legacy browser storage active ID must migrate");
+check(ids(migratedLegacyStorage).includes("ltx_25_distilled_int8"), "legacy browser storage must gain LTX 2.5");
+
+const fromBackend = helpers.normalizedPresetsStateFromPayload({ presets_state: customActive });
+check(fromBackend.active_preset_id === customPackage.id, "backend normalized active ID must be consumed");
+check(helpers.presetsStateEqual(fromBackend, customActive), "backend normalized state comparison must be stable");
+check(helpers.normalizedPresetsStateFromPayload({}) === null, "missing backend state must not overwrite frontend state");

--- a/tests/test_advanced_image_source_loader_frontend.py
+++ b/tests/test_advanced_image_source_loader_frontend.py
@@ -35,3 +35,40 @@ def test_external_root_memory_is_runtime_only() -> None:
     assert "node.properties.__denoAdvancedLastExternalRoot" not in source
     assert "localStorage" not in source
     assert "sessionStorage" not in source
+
+
+def test_advanced_panel_uses_nodes2_fluid_dom_layout() -> None:
+    source = SCRIPT_PATH.read_text(encoding="utf-8")
+
+    assert 'container.dataset.denoAdvancedLayout = "fluid-v1"' in source
+    assert "height: calc(100% + ${PANEL_WRAPPER_COMPENSATION}px)" in source
+    assert "getMinHeight: () => PANEL_MIN_HEIGHT + PANEL_WIDGET_EXTRA_HEIGHT" in source
+    assert "flex: 1 1 0px" in source
+    assert "height: 0" in source
+    assert 'const widget = node.addDOMWidget("advanced_source_panel"' not in source
+    assert "function panelHeight()" not in source
+    assert "refreshPanelHeight" not in source
+    assert "PANEL_RESERVED_NODE_HEIGHT" not in source
+    assert "panelResizeObserver?.observe(container)" in source
+    assert "panelResizeObserver?.observe(grid)" in source
+
+
+def test_advanced_gallery_keeps_disabled_cards_readable_without_full_toggle_render() -> None:
+    source = SCRIPT_PATH.read_text(encoding="utf-8")
+
+    assert 'image.style.opacity = isDisabled ? "0.78" : "1"' in source
+    assert 'disabledPill.style.display = isDisabled ? "block" : "none"' in source
+    assert "syncDisabledCardStates(currentPaths, new Set(cleaned))" in source
+    assert "cards.forEach((card) => applyCardDisabledState" in source
+    assert "scheduleMasonryRefresh();" in source
+
+
+def test_advanced_panel_preserves_local_gallery_scroll_and_canvas_navigation() -> None:
+    source = SCRIPT_PATH.read_text(encoding="utf-8")
+
+    assert "installMiddleMouseCanvasPan(container, grid)" in source
+    assert 'window.addEventListener("wheel", onWheel' in source
+    assert "localScrollSurface.contains?.(target)" in source
+    assert "localScrollSurface.scrollTop += event.deltaY * deltaScale" in source
+    assert 'canvas.dispatchEvent(new WheelEvent("wheel"' in source
+    assert 'window.addEventListener("mousedown", onMouseDown, true)' in source

--- a/tests/test_image_resize_node.py
+++ b/tests/test_image_resize_node.py
@@ -1840,6 +1840,7 @@ def test_multi_image_loader_returns_batch_and_int_dimensions():
     input_types = node_cls.INPUT_TYPES()
 
     assert input_types["required"]["image_paths"][0] == "STRING"
+    assert input_types["required"]["image_paths"][1]["hidden"] is True
     assert input_types["required"]["mode"][0] == ["Keep Input Ratio", "Preset Ratio", "Manual Input"]
     assert input_types["required"]["mode"][1]["default"] == "Keep Input Ratio"
     assert "16:9" in input_types["required"]["ratio_preset"][0]
@@ -1900,6 +1901,9 @@ def test_minimax_h3_reference_loader_rejects_empty_and_more_than_nine_images():
     package = load_package()
     loader_cls = package.NODE_CLASS_MAPPINGS["DenoMiniMaxH3ReferenceImageLoader"]
 
+    input_types = loader_cls.INPUT_TYPES()
+    assert list(input_types["required"]) == ["image_paths"]
+    assert input_types["required"]["image_paths"][1]["hidden"] is True
     assert "No images are selected" in loader_cls.VALIDATE_INPUTS("")
     ten_paths = "\n".join(f"image-{index}.png" for index in range(10))
     validation = loader_cls.VALIDATE_INPUTS(ten_paths)
@@ -2092,6 +2096,17 @@ def test_multi_image_loader_dom_panel_tracks_manual_node_resize():
     assert "node.__denoSyncLoaderPanelGeometry" not in script
 
 
+def test_multi_image_loader_keeps_serialized_path_widget_hidden_without_reordering():
+    script = (REPO_ROOT / "web" / "js" / "deno_extra_nodes.js").read_text(encoding="utf-8")
+
+    assert "hideSerializedWidget(pathsWidget)" in script
+    assert "widget.options.hidden = true" in script
+    assert "const preservedValue = widget.value" in script
+    assert "const preservedCallback = widget.callback" in script
+    assert "widget.value = preservedValue" in script
+    assert "widget.callback = preservedCallback" in script
+
+
 def test_multi_image_loader_frontend_supports_copy_image_context_menu():
     script = (REPO_ROOT / "web" / "js" / "deno_extra_nodes.js").read_text(encoding="utf-8")
 
@@ -2260,8 +2275,10 @@ def test_advanced_image_source_loader_declares_external_outputs():
     input_types = node_cls.INPUT_TYPES()
 
     assert input_types["required"]["image_paths"][0] == "STRING"
+    assert input_types["required"]["image_paths"][1]["hidden"] is True
     assert input_types["required"]["mode"][0] == ["Keep Input Ratio", "Preset Ratio", "Manual Input"]
     assert input_types["required"]["disabled_image_paths"][0] == "STRING"
+    assert input_types["required"]["disabled_image_paths"][1]["hidden"] is True
     assert input_types["required"]["resize_method"][0] == [
         "Center Crop (Fill)",
         "Fit (Letterbox/Pillarbox)",
@@ -2477,6 +2494,160 @@ def test_multi_image_loader_copy_path_route_never_returns_absolute_filesystem_pa
     assert temp_dir not in json.dumps(absolute_response)
 
 
+def test_input_folder_browser_omits_external_links_but_allows_internal_links(monkeypatch, tmp_path):
+    import asyncio
+
+    load_package()
+    board = sys.modules["comfyui_deno_custom_nodes.deno_multi_image_board"]
+    folder_paths = sys.modules["folder_paths"]
+    input_dir = tmp_path / "input"
+    inside_target = input_dir / "inside-target"
+    outside_target = tmp_path / "outside-target"
+    input_dir.mkdir()
+    inside_target.mkdir()
+    outside_target.mkdir()
+    Image.new("RGB", (3, 2), color=(12, 34, 56)).save(inside_target / "inside.png")
+    Image.new("RGB", (3, 2), color=(65, 43, 21)).save(outside_target / "outside.png")
+
+    internal_link = input_dir / "internal-link"
+    external_link = input_dir / "external-link"
+
+    def create_directory_link(link_path: Path, target_path: Path) -> None:
+        try:
+            link_path.symlink_to(target_path, target_is_directory=True)
+            return
+        except OSError as symlink_error:
+            if os.name != "nt":
+                pytest.skip(f"directory symlinks are unavailable in this environment: {symlink_error}")
+        result = subprocess.run(
+            ["cmd.exe", "/d", "/c", "mklink", "/J", str(link_path), str(target_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            pytest.skip(f"directory links are unavailable in this environment: {result.stderr or result.stdout}")
+
+    create_directory_link(internal_link, inside_target)
+    create_directory_link(external_link, outside_target)
+
+    monkeypatch.setattr(folder_paths, "get_input_directory", lambda: str(input_dir))
+
+    root_listing = board._list_input_folder_entries("")
+    root_folders = {entry["path"] for entry in root_listing["folders"]}
+    assert "internal-link" in root_folders
+    assert "external-link" not in root_folders
+    assert root_listing["blocked_count"] == 1
+    assert "1 linked item skipped" in root_listing["notice"]
+    assert "external-link" not in json.dumps(root_listing)
+    assert str(outside_target) not in json.dumps(root_listing)
+
+    internal_response = asyncio.run(
+        board.deno_input_folder_images(types.SimpleNamespace(query={"path": "internal-link"}))
+    )
+    assert internal_response["status"] == 200
+    assert [entry["name"] for entry in internal_response["payload"]["files"]] == [
+        "internal-link/inside.png"
+    ]
+
+    blocked_folder_response = asyncio.run(
+        board.deno_input_folder_images(types.SimpleNamespace(query={"path": "external-link"}))
+    )
+    blocked_image_response = asyncio.run(
+        board.deno_input_image_path(
+            types.SimpleNamespace(query={"path": "external-link/outside.png"})
+        )
+    )
+    assert blocked_folder_response["status"] == 403
+    assert blocked_image_response["status"] == 403
+    blocked_payloads = json.dumps([blocked_folder_response, blocked_image_response])
+    assert "outside the ComfyUI input folder" in blocked_payloads
+    assert "external-link" not in blocked_payloads
+    assert str(outside_target) not in blocked_payloads
+
+
+def test_input_folder_browser_reparse_containment_policy_without_link_privileges(monkeypatch, tmp_path):
+    import asyncio
+
+    load_package()
+    board = sys.modules["comfyui_deno_custom_nodes.deno_multi_image_board"]
+    folder_paths = sys.modules["folder_paths"]
+    input_dir = tmp_path / "input"
+    inside_target = input_dir / "inside-target"
+    outside_target = tmp_path / "outside-target"
+    input_dir.mkdir()
+    inside_target.mkdir()
+    outside_target.mkdir()
+    Image.new("RGB", (3, 2), color=(12, 34, 56)).save(inside_target / "inside.png")
+    Image.new("RGB", (3, 2), color=(65, 43, 21)).save(outside_target / "outside.png")
+
+    internal_link = input_dir / "internal-link"
+    external_link = input_dir / "external-link"
+    real_realpath = os.path.realpath
+    real_listdir = os.listdir
+    real_stat = os.stat
+    real_isdir = os.path.isdir
+    real_isfile = os.path.isfile
+    input_real = real_realpath(input_dir)
+    link_targets = {
+        os.path.normcase(str(internal_link)): real_realpath(inside_target),
+        os.path.normcase(str(external_link)): real_realpath(outside_target),
+    }
+
+    def fake_realpath(path):
+        text = str(path)
+        normalized = os.path.normcase(os.path.abspath(text))
+        for link_path, target_path in link_targets.items():
+            if normalized == link_path or normalized.startswith(link_path + os.sep):
+                suffix = normalized[len(link_path):].lstrip("\\/")
+                return real_realpath(os.path.join(target_path, suffix))
+        return real_realpath(text)
+
+    def fake_listdir(path):
+        entries = list(real_listdir(fake_realpath(path)))
+        if os.path.normcase(fake_realpath(path)) == os.path.normcase(input_real):
+            entries.extend(["internal-link", "external-link"])
+        return entries
+
+    monkeypatch.setattr(folder_paths, "get_input_directory", lambda: str(input_dir))
+    monkeypatch.setattr(board.os.path, "realpath", fake_realpath)
+    monkeypatch.setattr(board.os, "listdir", fake_listdir)
+    monkeypatch.setattr(board.os, "stat", lambda path, *args, **kwargs: real_stat(fake_realpath(path), *args, **kwargs))
+    monkeypatch.setattr(board.os.path, "isdir", lambda path: real_isdir(fake_realpath(path)))
+    monkeypatch.setattr(board.os.path, "isfile", lambda path: real_isfile(fake_realpath(path)))
+
+    root_listing = board._list_input_folder_entries("")
+    root_folders = {entry["path"] for entry in root_listing["folders"]}
+    assert "internal-link" in root_folders
+    assert "external-link" not in root_folders
+    assert root_listing["blocked_count"] == 1
+    assert "1 linked item skipped" in root_listing["notice"]
+    assert "external-link" not in json.dumps(root_listing)
+    assert str(outside_target) not in json.dumps(root_listing)
+
+    internal_response = asyncio.run(
+        board.deno_input_folder_images(types.SimpleNamespace(query={"path": "internal-link"}))
+    )
+    blocked_folder_response = asyncio.run(
+        board.deno_input_folder_images(types.SimpleNamespace(query={"path": "external-link"}))
+    )
+    blocked_image_response = asyncio.run(
+        board.deno_input_image_path(
+            types.SimpleNamespace(query={"path": "external-link/outside.png"})
+        )
+    )
+    assert internal_response["status"] == 200
+    assert [entry["name"] for entry in internal_response["payload"]["files"]] == [
+        "internal-link/inside.png"
+    ]
+    assert blocked_folder_response["status"] == 403
+    assert blocked_image_response["status"] == 403
+    blocked_payloads = json.dumps([blocked_folder_response, blocked_image_response])
+    assert "outside the ComfyUI input folder" in blocked_payloads
+    assert "external-link" not in blocked_payloads
+    assert str(outside_target) not in blocked_payloads
+
+
 def test_advanced_image_source_loader_lists_and_expands_external_folders():
     load_package()
     advanced = sys.modules["comfyui_deno_custom_nodes.deno_advanced_image_source_loader"]
@@ -2560,11 +2731,23 @@ def test_ltx_sequencer_declares_sync_controls():
     node_cls = package.NODE_CLASS_MAPPINGS["DenoLTXSequencer"]
     input_types = node_cls.INPUT_TYPES()
 
+    assert input_types["required"]["multi_input"][0] == "IMAGE"
+    assert input_types["required"]["multi_input"][1]["lazy"] is True
     assert input_types["required"]["strength_sync"][0] == "BOOLEAN"
     assert input_types["required"]["bypass"][0] == "BOOLEAN"
     assert list(input_types["required"]).index("bypass") == list(input_types["required"]).index("strength_sync") + 1
     assert node_cls.RETURN_TYPES == ("CONDITIONING", "CONDITIONING", "LATENT")
     assert node_cls.CATEGORY == "Deno/LTX"
+
+
+def test_ltx_sequencer_only_requests_images_for_active_i2v_guides():
+    package = load_package()
+    node_cls = package.NODE_CLASS_MAPPINGS["DenoLTXSequencer"]
+
+    assert node_cls.check_lazy_status(True, 1, None) == []
+    assert node_cls.check_lazy_status(False, 0, None) == []
+    assert node_cls.check_lazy_status(False, 1, None) == ["multi_input"]
+    assert node_cls.check_lazy_status(False, 1, object()) == []
 
 
 def test_ltx_sequencer_bypass_returns_inputs_without_touching_vae():
@@ -2838,6 +3021,7 @@ def test_ltx_model_setup_helper_declares_output_node_and_safe_root_widget():
     assert "presets_json" in input_types["required"]
     assert input_types["required"]["presets_json"][0] == "STRING"
     assert "ltx_23_8gb_vram" in input_types["required"]["presets_json"][1]["default"]
+    assert "ltx_25_distilled_int8" in input_types["required"]["presets_json"][1]["default"]
     assert node_cls().run(input_types["required"]["model_root"][1]["default"]) == ()
 
 
@@ -2905,8 +3089,43 @@ def test_ltx_model_setup_helper_preserves_builtin_preset_for_old_workflows():
     )
 
     assert parsed["presets"][0]["id"] == "ltx_23_8gb_vram"
-    assert parsed["presets"][1]["id"] == "custom_pack"
+    assert parsed["presets"][1]["id"] == "ltx_25_distilled_int8"
+    assert parsed["presets"][2]["id"] == "custom_pack"
     assert parsed["active_preset_id"] == "custom_pack"
+
+
+def test_ltx_model_setup_helper_ltx25_preset_matches_workflow_models():
+    package = load_package()
+    module = sys.modules["comfyui_deno_custom_nodes.deno_ltx_model_downloader"]
+    preset = module._ltx25_package()
+
+    assert preset["id"] == "ltx_25_distilled_int8"
+    assert {(item["target_subdir"], item["filename"], item["size"]) for item in preset["files"]} == {
+        ("diffusion_models", "ltx-2.5-22b-distilled-transformer-comfy-int8-convrot.safetensors", 21_504_034_224),
+        ("text_encoders", "gemma4-12b-with-proj-ltx-2.5-comfy-int8-convrot.safetensors", 15_372_971_786),
+        ("vae", "ltx-2.5-video-vae-bf16.safetensors", 1_472_223_346),
+        ("vae", "ltx-2.5-audio-vae-bf16.safetensors", 364_866_540),
+        ("latent_upscale_models", "ltx-2.5-latent-spatial-upscaler-x2-bf16-1.0.safetensors", 995_778_752),
+    }
+    assert all(item["url"].startswith("https://huggingface.co/Lightricks/LTX-2.5/resolve/main/") for item in preset["files"])
+
+
+def test_ltx_model_setup_helper_replaces_stale_builtin_package_payloads():
+    load_package()
+    module = sys.modules["comfyui_deno_custom_nodes.deno_ltx_model_downloader"]
+
+    canonical = module._canonicalize_builtin_package(
+        {
+            "id": "ltx_25_distilled_int8",
+            "title": "Stale Saved Copy",
+            "files": [],
+        }
+    )
+
+    assert canonical == module._ltx25_package()
+    assert canonical["files"][-1]["filename"] == "ltx-2.5-latent-spatial-upscaler-x2-bf16-1.0.safetensors"
+    assert "Agree and Access" in canonical["description"]
+    assert "LTX-2 Community License" in canonical["description"]
 
 
 def test_ltx_model_setup_helper_checks_registered_model_folder_names():
@@ -3155,7 +3374,7 @@ def test_ltx_model_setup_helper_has_no_backend_download_code():
 def test_ltx_model_setup_helper_frontend_keeps_auto_root_selection_available():
     script = (REPO_ROOT / "web" / "js" / "deno_ltx_model_downloader.js").read_text(encoding="utf-8")
 
-    assert "r2026.06.23-root-intent-c" in script
+    assert "r2026.08.12-ltx25-presets-a" in script
     assert "rootMode" in script
     assert "explicitRootId" in script
     assert "effectiveRootId" in script

--- a/tests/test_ltx25_completion.py
+++ b/tests/test_ltx25_completion.py
@@ -1,0 +1,183 @@
+import importlib.util
+import shutil
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class FakeTensor:
+    def __init__(self, shape):
+        self.shape = tuple(shape)
+
+    def __len__(self):
+        return self.shape[0]
+
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            start, stop, step = key.indices(self.shape[0])
+            count = len(range(start, stop, step))
+            return FakeTensor((count, *self.shape[1:]))
+        raise TypeError(key)
+
+
+def _load_sequencer(monkeypatch, add_guide, attention_helper=None):
+    comfy_extras = types.ModuleType("comfy_extras")
+    nodes_lt = types.ModuleType("comfy_extras.nodes_lt")
+    nodes_lt.LTXVAddGuide = add_guide
+    nodes_lt.get_noise_mask = lambda latent: latent.get("noise_mask")
+    if attention_helper is not None:
+        nodes_lt._append_guide_attention_entry = attention_helper
+    comfy_extras.nodes_lt = nodes_lt
+    monkeypatch.setitem(sys.modules, "comfy_extras", comfy_extras)
+    monkeypatch.setitem(sys.modules, "comfy_extras.nodes_lt", nodes_lt)
+
+    module_name = "deno_ltx_sequencer_plus_completion_test"
+    spec = importlib.util.spec_from_file_location(module_name, REPO_ROOT / "deno_ltx_sequencer_plus.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ltx_sequencer_multi_guide_uses_current_latent_shape_and_attention_metadata(monkeypatch):
+    calls = {"index": [], "attention": [], "encode": 0}
+
+    class AddGuide:
+        @classmethod
+        def encode(cls, _vae, _width, _height, image, _scale_factors):
+            calls["encode"] += 1
+            return image, FakeTensor((1, 128, 1, 2, 3))
+
+        @classmethod
+        def get_latent_index(
+            cls, _conditioning, latent_length, _guide_length, frame_idx, _scale_factors, latent_shape=None
+        ):
+            calls["index"].append((latent_length, frame_idx, tuple(latent_shape)))
+            return frame_idx, 0
+
+        @classmethod
+        def append_keyframe(
+            cls, positive, negative, _frame_idx, latent_image, noise_mask, encoded_latent, _strength, _scale_factors
+        ):
+            next_length = latent_image.shape[2] + encoded_latent.shape[2]
+            return (
+                positive,
+                negative,
+                FakeTensor((*latent_image.shape[:2], next_length, *latent_image.shape[3:])),
+                FakeTensor((*noise_mask.shape[:2], next_length, *noise_mask.shape[3:])),
+            )
+
+    def append_attention(positive, negative, count, latent_shape, strength=1.0, attention_mask=None):
+        calls["attention"].append((count, tuple(latent_shape), strength, attention_mask))
+        return positive, negative
+
+    module = _load_sequencer(monkeypatch, AddGuide, append_attention)
+    latent = {
+        "samples": FakeTensor((1, 128, 10, 2, 3)),
+        "noise_mask": FakeTensor((1, 1, 10, 1, 1)),
+    }
+    result = module.DenoLTXSequencer.execute(
+        [["positive", {}]],
+        [["negative", {}]],
+        types.SimpleNamespace(downscale_index_formula=(8, 32, 32)),
+        latent,
+        FakeTensor((2, 64, 64, 3)),
+        2,
+        "frames",
+        25,
+        False,
+        False,
+        insert_frame_1=17,
+        insert_frame_2=-1,
+        strength_1=0.65,
+        strength_2=0.4,
+    )
+
+    assert calls["encode"] == 2
+    assert calls["index"] == [
+        (10, 17, (1, 128, 10, 2, 3)),
+        (11, -1, (1, 128, 11, 2, 3)),
+    ]
+    assert calls["attention"] == [
+        (6, (1, 2, 3), 0.65, None),
+        (6, (1, 2, 3), 0.4, None),
+    ]
+    assert result[2]["samples"].shape == (1, 128, 12, 2, 3)
+    assert result[2]["noise_mask"].shape == (1, 1, 12, 1, 1)
+
+
+def test_ltx_sequencer_keeps_legacy_get_latent_index_signature(monkeypatch):
+    calls = []
+
+    class LegacyAddGuide:
+        @classmethod
+        def get_latent_index(cls, conditioning, latent_length, guide_length, frame_idx, scale_factors):
+            calls.append((conditioning, latent_length, guide_length, frame_idx, scale_factors))
+            return frame_idx, 0
+
+    module = _load_sequencer(monkeypatch, LegacyAddGuide)
+    result = module._get_latent_index("cond", 9, 1, 8, (8, 32, 32), (1, 128, 9, 2, 3))
+
+    assert result == (8, 0)
+    assert calls == [("cond", 9, 1, 8, (8, 32, 32))]
+
+
+def test_ltx_sequencer_lazy_graph_skips_inactive_image_branch_and_rejects_missing_active_input(monkeypatch):
+    class AddGuide:
+        pass
+
+    module = _load_sequencer(monkeypatch, AddGuide)
+    node = module.DenoLTXSequencer
+    latent = {"samples": FakeTensor((1, 128, 10, 2, 3))}
+
+    assert node.INPUT_TYPES()["required"]["multi_input"] == ("IMAGE", {"lazy": True})
+    assert node.check_lazy_status(True, 2, None) == []
+    assert node.check_lazy_status(False, 0, None) == []
+    assert node.check_lazy_status(False, 1, None) == ["multi_input"]
+    assert node.execute("p", "n", object(), latent, None, 0, "frames", 25, True, False) == ("p", "n", latent)
+    assert node.execute("p", "n", object(), latent, None, 1, "frames", 25, True, True) == ("p", "n", latent)
+    with pytest.raises(ValueError, match="multi_input is required"):
+        node.execute("p", "n", object(), latent, None, 1, "frames", 25, True, False)
+
+
+def test_ltx_model_downloader_js_migrates_builtins_custom_presets_and_storage():
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("Node.js is required for the LTX downloader migration harness.")
+
+    result = subprocess.run(
+        [
+            node,
+            str(REPO_ROOT / "tests" / "js" / "ltx_model_downloader_presets_harness.mjs"),
+            str(REPO_ROOT / "web" / "js" / "deno_ltx_model_downloader.js"),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_ltx25_native_help_documents_manual_gated_access_and_license():
+    downloader_en = (REPO_ROOT / "web/js/docs/DenoLTXModelDownloader.md").read_text(encoding="utf-8")
+    downloader_ko = (REPO_ROOT / "web/js/docs/DenoLTXModelDownloader/ko.md").read_text(encoding="utf-8")
+    sequencer_en = (REPO_ROOT / "web/js/docs/DenoLTXSequencer.md").read_text(encoding="utf-8")
+    sequencer_ko = (REPO_ROOT / "web/js/docs/DenoLTXSequencer/ko.md").read_text(encoding="utf-8")
+
+    for text in (downloader_en, downloader_ko):
+        assert "Agree and Access" in text
+        assert "LTX-2 Community License" in text
+        assert "https://huggingface.co/Lightricks/LTX-2.5" in text
+        assert "https://github.com/Lightricks/LTX-2/blob/main/LICENSE.md" in text
+    for text in (sequencer_en, sequencer_ko):
+        assert "lazy" in text
+        assert "LTXVCropGuides" in text

--- a/tests/test_registry_metadata.py
+++ b/tests/test_registry_metadata.py
@@ -89,6 +89,7 @@ def test_pyproject_declares_registry_metadata_for_comfy_manager_discovery():
     assert "RTX upscale helpers" in description
     assert "NVIDIA VFX/nvvfx" in description
     assert "LTX 2.3" in description
+    assert "LTX 2.5" in description
     assert "Bernini Prompt Guide" in description
     assert "Local LLM Loader and Reviewer" in description
     assert "GPT/Gemini-ready Error Help reports" in description
@@ -114,6 +115,7 @@ def test_pyproject_declares_registry_metadata_for_comfy_manager_discovery():
         "rtx-video-super-resolution",
         "nvidia-vfx",
         "ltx-2.3",
+        "ltx-2.5",
         "bernini",
         "bernini-prompt-guide",
         "bernini-conditioning",

--- a/web/js/deno_advanced_image_source_loader.js
+++ b/web/js/deno_advanced_image_source_loader.js
@@ -4,8 +4,8 @@ import { api } from "../../scripts/api.js";
 const ADVANCED_NODE = "DenoAdvancedImageSourceLoader";
 const MIN_SIZE = [520, 620];
 const PANEL_MIN_HEIGHT = 360;
-const PANEL_RESERVED_NODE_HEIGHT = 248;
-const PANEL_MAX_HEIGHT = 780;
+const PANEL_WIDGET_EXTRA_HEIGHT = 12;
+const PANEL_WRAPPER_COMPENSATION = 4;
 const MASONRY_ROW_HEIGHT = 8;
 const MASONRY_GAP = 10;
 const CARD_MIN_HEIGHT = 116;
@@ -68,9 +68,11 @@ function setupAdvancedImageSourceLoader(node) {
 
     const container = document.createElement("div");
     container.tabIndex = 0;
+    container.dataset.denoAdvancedLayout = "fluid-v1";
     container.style.cssText = `
         width: 100%;
-        height: ${PANEL_MIN_HEIGHT}px;
+        height: calc(100% + ${PANEL_WRAPPER_COMPENSATION}px);
+        min-height: ${PANEL_MIN_HEIGHT}px;
         display: flex;
         flex-direction: column;
         gap: ${MASONRY_GAP}px;
@@ -108,7 +110,8 @@ function setupAdvancedImageSourceLoader(node) {
 
     const grid = document.createElement("div");
     grid.style.cssText = `
-        flex: 1;
+        flex: 1 1 0px;
+        height: 0;
         min-height: 0;
         overflow-y: auto;
         display: grid;
@@ -135,38 +138,35 @@ function setupAdvancedImageSourceLoader(node) {
     folderUploadInput.style.display = "none";
 
     container.append(topBar, hint, statusLabel, grid, uploadInput, folderUploadInput);
+    node.addDOMWidget("advanced_source_panel", "deno_advanced_image_source_loader", container, {
+        serialize: false,
+        getMinHeight: () => PANEL_MIN_HEIGHT + PANEL_WIDGET_EXTRA_HEIGHT,
+    });
 
-    function panelHeight() {
-        const nodeHeight = Number(node.size?.[1]) || MIN_SIZE[1];
-        return Math.max(
-            PANEL_MIN_HEIGHT,
-            Math.min(PANEL_MAX_HEIGHT, nodeHeight - PANEL_RESERVED_NODE_HEIGHT)
-        );
+    const nextNodeSize = resolveAdvancedNodeSize(node.size);
+    if (shouldApplyAdvancedNodeSize(node.size, nextNodeSize)) {
+        if (typeof node.setSize === "function") {
+            node.setSize(nextNodeSize);
+        } else {
+            node.size = nextNodeSize;
+        }
     }
 
-    function refreshPanelHeight() {
-        container.style.height = `${panelHeight()}px`;
-        requestAnimationFrame(refreshMasonrySpans);
-    }
-
-    const widget = node.addDOMWidget("advanced_source_panel", "deno_advanced_image_source_loader", container, { serialize: false });
-    widget.computeSize = () => {
-        const height = panelHeight();
-        container.style.height = `${height}px`;
-        return [Math.max(node.size?.[0] ?? 0, MIN_SIZE[0]), height + 12];
+    let masonryRefreshFrame = 0;
+    const scheduleMasonryRefresh = () => {
+        if (masonryRefreshFrame) {
+            return;
+        }
+        masonryRefreshFrame = requestAnimationFrame(() => {
+            masonryRefreshFrame = 0;
+            refreshMasonrySpans();
+        });
     };
-
-    node.size = [
-        Math.max(node.size?.[0] ?? 0, MIN_SIZE[0]),
-        Math.max(node.size?.[1] ?? 0, MIN_SIZE[1]),
-    ];
-
-    const originalOnResize = node.onResize;
-    node.onResize = function () {
-        const result = originalOnResize?.apply(this, arguments);
-        refreshPanelHeight();
-        return result;
-    };
+    const panelResizeObserver = typeof ResizeObserver === "function"
+        ? new ResizeObserver(scheduleMasonryRefresh)
+        : null;
+    panelResizeObserver?.observe(container);
+    panelResizeObserver?.observe(grid);
 
     let draggedCard = null;
     let placeholder = null;
@@ -201,6 +201,46 @@ function setupAdvancedImageSourceLoader(node) {
             .filter(Boolean);
     }
 
+    function updateEnabledCount(paths, disabled) {
+        const enabledCount = paths.filter((path) => !disabled.has(path)).length;
+        countLabel.textContent = `${enabledCount}/${paths.length} enabled`;
+    }
+
+    function applyCardDisabledState(card, isDisabled) {
+        if (!card) {
+            return;
+        }
+        card.dataset.denoDisabled = isDisabled ? "true" : "false";
+        card.style.background = isDisabled ? "rgba(7, 12, 9, 0.92)" : "rgba(13, 31, 20, 0.9)";
+        card.setAttribute("aria-pressed", String(!isDisabled));
+        const image = card.querySelector("[data-deno-card-image]");
+        if (image) {
+            image.style.opacity = isDisabled ? "0.78" : "1";
+        }
+        const name = card.querySelector("[data-deno-card-name]");
+        if (name) {
+            name.style.color = isDisabled ? "#b6c9b9" : "#d9ffe5";
+        }
+        const disabledPill = card.querySelector("[data-deno-disabled-pill]");
+        if (disabledPill) {
+            disabledPill.style.display = isDisabled ? "block" : "none";
+        }
+    }
+
+    function syncDisabledCardStates(paths, disabled) {
+        const cards = Array.from(grid.querySelectorAll("[data-source-index]"));
+        if (
+            cards.length !== paths.length
+            || cards.some((card, index) => card.dataset.path !== paths[index])
+        ) {
+            return false;
+        }
+        cards.forEach((card) => applyCardDisabledState(card, disabled.has(card.dataset.path)));
+        updateEnabledCount(paths, disabled);
+        scheduleMasonryRefresh();
+        return true;
+    }
+
     function setDisabledPaths(paths) {
         if (!disabledWidget) {
             return;
@@ -210,7 +250,10 @@ function setupAdvancedImageSourceLoader(node) {
             .filter((entry) => activePaths.has(entry));
         disabledWidget.value = cleaned.join("\n");
         disabledWidget.callback?.(disabledWidget.value);
-        render();
+        const currentPaths = getPaths();
+        if (!syncDisabledCardStates(currentPaths, new Set(cleaned))) {
+            render();
+        }
         node.setDirtyCanvas?.(true, true);
         app.graph?.setDirtyCanvas?.(true, true);
     }
@@ -234,10 +277,9 @@ function setupAdvancedImageSourceLoader(node) {
     function render() {
         const paths = getPaths();
         const disabled = new Set(getDisabledPaths());
-        const enabledCount = paths.filter((path) => !disabled.has(path)).length;
-        countLabel.textContent = `${enabledCount}/${paths.length} enabled`;
+        updateEnabledCount(paths, disabled);
         grid.replaceChildren(...paths.map((path, index) => buildCard(path, index, disabled.has(path))));
-        requestAnimationFrame(refreshMasonrySpans);
+        scheduleMasonryRefresh();
     }
 
     function buildCard(path, index, isDisabled) {
@@ -256,7 +298,7 @@ function setupAdvancedImageSourceLoader(node) {
             box-sizing: border-box;
             border: 1px solid rgba(72,255,132,0.32);
             border-radius: 8px;
-            background: ${isDisabled ? "rgba(5, 8, 7, 0.86)" : "rgba(13, 31, 20, 0.9)"};
+            background: rgba(13, 31, 20, 0.9);
             color: #d9ffe5;
             cursor: grab;
             overflow: hidden;
@@ -282,11 +324,12 @@ function setupAdvancedImageSourceLoader(node) {
         const previewUrl = getPreviewUrl(path);
         if (previewUrl) {
             const image = document.createElement("img");
+            image.dataset.denoCardImage = "true";
             image.loading = "lazy";
             image.decoding = "async";
             image.src = previewUrl;
             image.alt = "";
-            image.style.cssText = `width:100%; height:100%; object-fit:contain; opacity:${isDisabled ? "0.38" : "1"}; pointer-events:none;`;
+            image.style.cssText = "width:100%; height:100%; object-fit:contain; opacity:1; pointer-events:none;";
             image.onload = () => applyMasonrySpanForImage(card, image);
             image.onerror = () => {
                 preview.textContent = getSourceKind(path);
@@ -298,6 +341,7 @@ function setupAdvancedImageSourceLoader(node) {
         }
 
         const name = document.createElement("div");
+        name.dataset.denoCardName = "true";
         name.textContent = path;
         name.title = path;
         name.style.cssText = `
@@ -305,7 +349,7 @@ function setupAdvancedImageSourceLoader(node) {
             overflow: hidden;
             text-overflow: ellipsis;
             font: 700 10px sans-serif;
-            color: ${isDisabled ? "#7d917f" : "#d9ffe5"};
+            color: #d9ffe5;
         `;
 
         const badge = document.createElement("div");
@@ -327,18 +371,23 @@ function setupAdvancedImageSourceLoader(node) {
         `;
 
         const disabledOverlay = document.createElement("div");
+        disabledOverlay.dataset.denoDisabledPill = "true";
         disabledOverlay.textContent = "Disabled";
         disabledOverlay.style.cssText = `
             position: absolute;
-            inset: 0;
-            display: ${isDisabled ? "flex" : "none"};
-            align-items: center;
-            justify-content: center;
-            background: rgba(0,0,0,0.58);
+            left: 50%;
+            top: 50%;
+            transform: translate(-50%, -50%);
+            display: none;
+            padding: 4px 9px;
+            border: 1px solid rgba(255,255,255,0.34);
+            border-radius: 999px;
+            background: rgba(0,0,0,0.46);
             color: #dfffea;
-            font: 900 12px sans-serif;
+            font: 800 11px sans-serif;
             letter-spacing: 0;
             pointer-events: none;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.35);
         `;
 
         const remove = document.createElement("button");
@@ -562,6 +611,7 @@ function setupAdvancedImageSourceLoader(node) {
         });
 
         card.append(preview, name, remove, badge, disabledOverlay);
+        applyCardDisabledState(card, isDisabled);
         return card;
     }
 
@@ -794,26 +844,57 @@ function setupAdvancedImageSourceLoader(node) {
     });
 
     node.__denoAdvancedPanCleanup?.();
-    node.__denoAdvancedPanCleanup = installMiddleMouseCanvasPan(container);
+    node.__denoAdvancedPanCleanup = installMiddleMouseCanvasPan(container, grid);
     const originalOnRemoved = node.onRemoved;
     node.onRemoved = function () {
         this.__denoCloseAdvancedFolderBrowser?.();
         this.__denoCloseAdvancedFolderBrowser = null;
         this.__denoAdvancedPanCleanup?.();
         this.__denoAdvancedPanCleanup = null;
+        panelResizeObserver?.disconnect();
+        if (masonryRefreshFrame) {
+            cancelAnimationFrame(masonryRefreshFrame);
+            masonryRefreshFrame = 0;
+        }
         return originalOnRemoved?.apply(this, arguments);
     };
 
     setTimeout(() => {
         node._denoUpdateAdvancedSourceVisibility?.();
-        refreshPanelHeight();
         render();
     }, 0);
 }
 
-function installMiddleMouseCanvasPan(root) {
+function resolveAdvancedNodeSize(currentSize, minSize = MIN_SIZE) {
+    const width = Number(currentSize?.[0]);
+    const height = Number(currentSize?.[1]);
+    const minWidth = Math.max(1, Number(minSize?.[0]) || MIN_SIZE[0]);
+    const minHeight = Math.max(1, Number(minSize?.[1]) || MIN_SIZE[1]);
+    return [
+        Math.max(Number.isFinite(width) ? width : 0, minWidth),
+        Math.max(Number.isFinite(height) ? height : 0, minHeight),
+    ];
+}
+
+function shouldApplyAdvancedNodeSize(currentSize, nextSize, tolerance = 1) {
+    if (!Array.isArray(currentSize)) {
+        return true;
+    }
+    const allowedDelta = Math.max(0, Number(tolerance) || 0);
+    return nextSize.some((value, index) => {
+        const currentValue = Number(currentSize[index]);
+        return !Number.isFinite(currentValue) || Math.abs(currentValue - value) > allowedDelta;
+    });
+}
+
+function installMiddleMouseCanvasPan(root, localScrollSurface = null) {
     let forwardingPan = false;
     let cleanedUp = false;
+
+    const eventTargetsRoot = (event) => {
+        const path = typeof event.composedPath === "function" ? event.composedPath() : [];
+        return path.length ? path.includes(root) : root.contains?.(event.target);
+    };
 
     const forward = (event) => {
         const canvas = app.canvas?.canvas;
@@ -847,20 +928,63 @@ function installMiddleMouseCanvasPan(root) {
         event.stopPropagation();
     };
 
+    const onWheel = (event) => {
+        if (!eventTargetsRoot(event)) {
+            return;
+        }
+        const target = event.target;
+        const usesLocalScroll = Boolean(
+            localScrollSurface
+            && (target === localScrollSurface || localScrollSurface.contains?.(target))
+        );
+        const canScrollUp = Number(localScrollSurface?.scrollTop || 0) > 0;
+        const canScrollDown = (
+            Number(localScrollSurface?.scrollTop || 0)
+            + Number(localScrollSurface?.clientHeight || 0)
+        ) < Number(localScrollSurface?.scrollHeight || 0) - 1;
+        const canConsumeLocally = usesLocalScroll && (
+            (event.deltaY < 0 && canScrollUp)
+            || (event.deltaY > 0 && canScrollDown)
+        );
+        if (canConsumeLocally) {
+            const deltaScale = event.deltaMode === 1
+                ? 16
+                : event.deltaMode === 2
+                    ? Math.max(1, Number(localScrollSurface.clientHeight || 1))
+                    : 1;
+            localScrollSurface.scrollTop += event.deltaY * deltaScale;
+            consume(event);
+            return;
+        }
+        const canvas = app.canvas?.canvas;
+        if (!canvas) {
+            return;
+        }
+        canvas.dispatchEvent(new WheelEvent("wheel", {
+            bubbles: true,
+            cancelable: true,
+            view: window,
+            deltaX: event.deltaX,
+            deltaY: event.deltaY,
+            deltaZ: event.deltaZ,
+            deltaMode: event.deltaMode,
+            screenX: event.screenX,
+            screenY: event.screenY,
+            clientX: event.clientX,
+            clientY: event.clientY,
+            ctrlKey: event.ctrlKey,
+            altKey: event.altKey,
+            shiftKey: event.shiftKey,
+            metaKey: event.metaKey,
+        }));
+        consume(event);
+    };
+
     const onMouseDown = (event) => {
-        if (!shouldForward(event)) {
+        if (!eventTargetsRoot(event) || !shouldForward(event)) {
             return;
         }
         forwardingPan = true;
-        if (forward(event)) {
-            consume(event);
-        }
-    };
-
-    const onRootMouseMove = (event) => {
-        if (!shouldForward(event)) {
-            return;
-        }
         if (forward(event)) {
             consume(event);
         }
@@ -893,8 +1017,8 @@ function installMiddleMouseCanvasPan(root) {
         }
     };
 
-    root.addEventListener("mousedown", onMouseDown, true);
-    root.addEventListener("mousemove", onRootMouseMove, true);
+    window.addEventListener("wheel", onWheel, { capture: true, passive: false });
+    window.addEventListener("mousedown", onMouseDown, true);
     window.addEventListener("mousemove", onWindowMouseMove, true);
     window.addEventListener("mouseup", onWindowMouseUp, true);
     root.addEventListener("auxclick", onAuxClick, true);
@@ -905,8 +1029,8 @@ function installMiddleMouseCanvasPan(root) {
         }
         cleanedUp = true;
         forwardingPan = false;
-        root.removeEventListener("mousedown", onMouseDown, true);
-        root.removeEventListener("mousemove", onRootMouseMove, true);
+        window.removeEventListener("wheel", onWheel, { capture: true, passive: false });
+        window.removeEventListener("mousedown", onMouseDown, true);
         window.removeEventListener("mousemove", onWindowMouseMove, true);
         window.removeEventListener("mouseup", onWindowMouseUp, true);
         root.removeEventListener("auxclick", onAuxClick, true);
@@ -1115,6 +1239,7 @@ function showBrowserModal(options) {
     let parentFolder = "";
     let folders = [];
     let files = [];
+    let listingNotice = "";
     const selected = new Set();
 
     const refreshSelected = () => {
@@ -1215,7 +1340,8 @@ function showBrowserModal(options) {
             return card;
         }));
 
-        status.textContent = `${folders.length} folder${folders.length === 1 ? "" : "s"}, ${files.length} image${files.length === 1 ? "" : "s"} found`;
+        const countStatus = `${folders.length} folder${folders.length === 1 ? "" : "s"}, ${files.length} image${files.length === 1 ? "" : "s"} found`;
+        status.textContent = listingNotice ? `${countStatus}. ${listingNotice}` : countStatus;
         refreshSelected();
     };
 
@@ -1231,6 +1357,7 @@ function showBrowserModal(options) {
             parentFolder = normalizeSlashPath(payload.parent || "");
             folders = payload.folders || [];
             files = payload.files || [];
+            listingNotice = String(payload.notice || "");
             render();
         } catch (error) {
             if (!request.isCurrent() || closed || error?.name === "AbortError") {
@@ -1239,6 +1366,7 @@ function showBrowserModal(options) {
             status.textContent = error.message || String(error);
             folders = [];
             files = [];
+            listingNotice = "";
             list.replaceChildren();
         }
     };
@@ -1278,6 +1406,8 @@ async function fetchInputFolderImages(folderPath = "", signal = undefined) {
             name: normalizeSlashPath(entry.name || ""),
             display_name: entry.display_name || String(entry.name || "").split("/").pop() || entry.name,
         })).filter((entry) => entry.name && IMAGE_RE.test(entry.name)),
+        blocked_count: Math.max(0, Number(payload.blocked_count) || 0),
+        notice: String(payload.notice || ""),
     };
 }
 
@@ -1498,8 +1628,13 @@ function inputStyle() {
 }
 
 function hideWidget(widget) {
+    if (!widget) {
+        return;
+    }
+    widget.options = widget.options && typeof widget.options === "object" ? widget.options : {};
+    widget.options.hidden = true;
     widget.hidden = true;
-    widget.computeSize = () => [0, -4];
+    widget.type = "hidden";
     if (widget.element) {
         widget.element.style.display = "none";
     }
@@ -1509,8 +1644,17 @@ function toggleWidgetVisibility(widget, visible) {
     if (!widget) {
         return;
     }
+    if (!Object.prototype.hasOwnProperty.call(widget, "__denoVisibilityOriginalComputeSize")) {
+        widget.__denoVisibilityOriginalComputeSize = widget.computeSize;
+    }
+    if (!Object.prototype.hasOwnProperty.call(widget, "__denoVisibilityOriginalType")) {
+        widget.__denoVisibilityOriginalType = widget.type;
+    }
+    widget.options = widget.options && typeof widget.options === "object" ? widget.options : {};
+    widget.options.hidden = !visible;
     widget.hidden = !visible;
-    widget.computeSize = visible ? undefined : () => [0, -4];
+    widget.type = visible ? widget.__denoVisibilityOriginalType : "hidden";
+    widget.computeSize = visible ? widget.__denoVisibilityOriginalComputeSize : () => [0, -4];
     if (widget.element) {
         widget.element.style.display = visible ? "" : "none";
     }
@@ -1545,5 +1689,9 @@ if (typeof window !== "undefined" && typeof window.__DENO_ADVANCED_IMAGE_SOURCE_
         getSourceKind,
         installMiddleMouseCanvasPan,
         createLatestRequestGate,
+        hideWidget,
+        toggleWidgetVisibility,
+        resolveAdvancedNodeSize,
+        shouldApplyAdvancedNodeSize,
     });
 }

--- a/web/js/deno_extra_nodes.js
+++ b/web/js/deno_extra_nodes.js
@@ -868,7 +868,7 @@ function setupMultiImageLoader(node, options = {}) {
     }
 
     node.__denoLoaderReady = true;
-    hideWidget(pathsWidget);
+    hideSerializedWidget(pathsWidget);
     const outputSizeHintEnabled = options.outputSizeHint !== false;
     const sequencerNotificationsEnabled = options.notifySequencers !== false;
     const maxImages = Number.isFinite(Number(options.maxImages))
@@ -1316,6 +1316,8 @@ function setupMultiImageLoader(node, options = {}) {
                 parent: normalizeInputFolderPath(payload?.parent ?? ""),
                 folders: (payload?.folders ?? []).map(normalizeInputFolderFolder).filter(Boolean),
                 files: (payload?.files ?? []).map(normalizeInputFolderFile).filter(Boolean),
+                blocked_count: Math.max(0, Number(payload?.blocked_count) || 0),
+                notice: String(payload?.notice || ""),
             };
         }
 
@@ -1334,7 +1336,7 @@ function setupMultiImageLoader(node, options = {}) {
             .map((entry) => String(entry || "").trim())
             .filter((entry) => /\.(?:png|jpe?g|webp|bmp|gif|tiff?)$/i.test(entry))
             .sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" }));
-        return { path: "", parent: "", folders: [], files };
+        return { path: "", parent: "", folders: [], files, blocked_count: 0, notice: "" };
     }
 
     function showInputFolderBrowser() {
@@ -1467,6 +1469,7 @@ function setupMultiImageLoader(node, options = {}) {
         let currentParent = "";
         let allFolders = [];
         let allFiles = [];
+        let listingNotice = "";
         let filteredEntries = [];
         let virtualRenderFrame = 0;
         const virtualGrid = {
@@ -1701,9 +1704,10 @@ function setupMultiImageLoader(node, options = {}) {
                 return `${entry.name || ""} ${entry.path || ""}`.toLowerCase().includes(needle);
             });
             const totalEntries = allFolders.length + allFiles.length;
-            status.textContent = needle
+            const countStatus = needle
                 ? `${filteredEntries.length} of ${totalEntries} input item${totalEntries === 1 ? "" : "s"} shown`
                 : `${allFolders.length} folder${allFolders.length === 1 ? "" : "s"}, ${allFiles.length} image${allFiles.length === 1 ? "" : "s"} found`;
+            status.textContent = listingNotice ? `${countStatus}. ${listingNotice}` : countStatus;
             list.scrollTop = 0;
             renderVirtualGrid();
         };
@@ -1725,6 +1729,7 @@ function setupMultiImageLoader(node, options = {}) {
                     currentParent = normalizeInputFolderPath(payload.parent ?? "");
                     allFolders = payload.folders ?? [];
                     allFiles = payload.files ?? [];
+                    listingNotice = String(payload.notice || "");
                     updatePathLabel();
                     applyInputFolderFilter();
                     refreshSelected();
@@ -1737,6 +1742,7 @@ function setupMultiImageLoader(node, options = {}) {
                     status.textContent = `Failed to read input folder list: ${error.message || error}`;
                     allFolders = [];
                     allFiles = [];
+                    listingNotice = "";
                     filteredEntries = [];
                     updatePathLabel();
                     list.replaceChildren();
@@ -4557,6 +4563,8 @@ function toggleWidgetVisibility(widget, visible) {
         return;
     }
     if (visible) {
+        widget.options = widget.options && typeof widget.options === "object" ? widget.options : {};
+        widget.options.hidden = false;
         widget.hidden = false;
         if (widget.__denoOrigType !== undefined) {
             widget.type = widget.__denoOrigType;
@@ -4570,6 +4578,8 @@ function toggleWidgetVisibility(widget, visible) {
         return;
     }
 
+    widget.options = widget.options && typeof widget.options === "object" ? widget.options : {};
+    widget.options.hidden = true;
     widget.hidden = true;
     if (widget.element) {
         widget.element.style.display = "none";
@@ -4599,11 +4609,28 @@ function createActionButton(label, danger = false) {
 }
 
 function hideWidget(widget) {
+    if (!widget) {
+        return;
+    }
+    widget.options = widget.options && typeof widget.options === "object" ? widget.options : {};
+    widget.options.hidden = true;
     widget.hidden = true;
-    widget.computeSize = () => [0, -4];
+    widget.type = "hidden";
     if (widget.element) {
         widget.element.style.display = "none";
     }
+}
+
+function hideSerializedWidget(widget) {
+    if (!widget) {
+        return;
+    }
+    const preservedValue = widget.value;
+    const preservedCallback = widget.callback;
+    hideWidget(widget);
+    widget.value = preservedValue;
+    widget.callback = preservedCallback;
+    widget.__denoSerializedHidden = true;
 }
 
 function getWidget(node, name) {
@@ -4626,6 +4653,8 @@ if (typeof window !== "undefined" && typeof window.__DENO_EXTRA_NODES_TEST_HOOK_
         resolveLoaderNodeSize,
         shouldApplyLoaderNodeSize,
         installLoaderCanvasNavigation,
+        hideSerializedWidget,
+        toggleWidgetVisibility,
         ensureSequencerDynamicWidget,
         getSequencerFullSchemaStackHeight,
         isSequencerVueNodesMode,

--- a/web/js/deno_ltx_model_downloader.js
+++ b/web/js/deno_ltx_model_downloader.js
@@ -11,7 +11,7 @@ const LEGACY_PRESET_STORAGE_KEYS = [
     "deno_ltx_model_downloader_presets_v1",
     "deno_ltx_model_downloader_presets_v2",
 ];
-const LTX_MODEL_DOWNLOADER_REV = "r2026.06.23-root-intent-c";
+const LTX_MODEL_DOWNLOADER_REV = "r2026.08.12-ltx25-presets-a";
 
 const DEFAULT_PACKAGE = {
     id: "ltx_23_8gb_vram",
@@ -69,9 +69,60 @@ const DEFAULT_PACKAGE = {
     ],
 };
 
+const LTX25_PACKAGE = {
+    id: "ltx_25_distilled_int8",
+    title: "LTX 2.5 Distilled INT8",
+    description: "Official LTX 2.5 distilled INT8 model set, including the projected Gemma 4 text encoder, video/audio VAEs, and x2 spatial upscaler. Sign in to Hugging Face and complete Agree and Access before opening the download links. Files are provided under the LTX-2 Community License.",
+    files: [
+        {
+            id: "diffusion_model",
+            label: "LTX 2.5 distilled INT8 model",
+            url: "https://huggingface.co/Lightricks/LTX-2.5/resolve/main/diffusion_models/ltx-2.5-22b-distilled-transformer-comfy-int8-convrot.safetensors?download=true",
+            target_subdir: "diffusion_models",
+            filename: "ltx-2.5-22b-distilled-transformer-comfy-int8-convrot.safetensors",
+            size: 21504034224,
+        },
+        {
+            id: "text_encoder",
+            label: "Gemma 4 text encoder with LTX 2.5 projection",
+            url: "https://huggingface.co/Lightricks/LTX-2.5/resolve/main/text_encoders/gemma4-12b-with-proj-ltx-2.5-comfy-int8-convrot.safetensors?download=true",
+            target_subdir: "text_encoders",
+            filename: "gemma4-12b-with-proj-ltx-2.5-comfy-int8-convrot.safetensors",
+            size: 15372971786,
+        },
+        {
+            id: "video_vae",
+            label: "LTX 2.5 video VAE",
+            url: "https://huggingface.co/Lightricks/LTX-2.5/resolve/main/vae/ltx-2.5-video-vae-bf16.safetensors?download=true",
+            target_subdir: "vae",
+            filename: "ltx-2.5-video-vae-bf16.safetensors",
+            size: 1472223346,
+        },
+        {
+            id: "audio_vae",
+            label: "LTX 2.5 audio VAE",
+            url: "https://huggingface.co/Lightricks/LTX-2.5/resolve/main/vae/ltx-2.5-audio-vae-bf16.safetensors?download=true",
+            target_subdir: "vae",
+            filename: "ltx-2.5-audio-vae-bf16.safetensors",
+            size: 364866540,
+        },
+        {
+            id: "spatial_upscaler",
+            label: "LTX 2.5 spatial upscaler x2",
+            url: "https://huggingface.co/Lightricks/LTX-2.5/resolve/main/latent_upscale_models/ltx-2.5-latent-spatial-upscaler-x2-bf16-1.0.safetensors?download=true",
+            target_subdir: "latent_upscale_models",
+            filename: "ltx-2.5-latent-spatial-upscaler-x2-bf16-1.0.safetensors",
+            size: 995778752,
+        },
+    ],
+};
+
+const BUILTIN_PACKAGES = [DEFAULT_PACKAGE, LTX25_PACKAGE];
+const BUILTIN_PACKAGE_IDS = new Set(BUILTIN_PACKAGES.map((item) => item.id));
+
 const DEFAULT_STATE = {
     active_preset_id: DEFAULT_PACKAGE.id,
-    presets: [DEFAULT_PACKAGE],
+    presets: BUILTIN_PACKAGES,
 };
 
 app.registerExtension({
@@ -681,6 +732,16 @@ function buildUi(node, rootWidget, presetsWidget) {
             if (!request.isCurrent() || sequence !== state.refreshSequence) {
                 return;
             }
+            const normalizedBackendState = normalizedPresetsStateFromPayload(payload);
+            if (normalizedBackendState) {
+                if (!presetsStateEqual(state.presetsState, normalizedBackendState)) {
+                    state.presetsState = writePresetsState(presetsWidget, normalizedBackendState);
+                    state.editorPresetId = currentPackage(state.presetsState).id;
+                    markWorkflowDirty();
+                    renderPresetButton();
+                    editor.load(currentPackage(state.presetsState));
+                }
+            }
             renderRoots(payload);
             renderFiles(payload.files || []);
             const total = (payload.files || []).length;
@@ -707,15 +768,15 @@ function buildUi(node, rootWidget, presetsWidget) {
 
     function saveEditorPreset(nextPackage) {
         const normalized = normalizePackage(nextPackage);
-        const editingDefaultPreset = state.editorPresetId === DEFAULT_PACKAGE.id;
+        const editingBuiltinPreset = isBuiltinPresetId(state.editorPresetId);
         const requestedId = normalized.id || slugify(normalized.title);
         const addingPreset = !state.editorPresetId;
-        const packageId = editingDefaultPreset || addingPreset
-            ? uniquePresetId(requestedId === DEFAULT_PACKAGE.id ? `${DEFAULT_PACKAGE.id}_custom` : requestedId, state.presetsState.presets)
+        const packageId = editingBuiltinPreset || addingPreset
+            ? uniquePresetId(isBuiltinPresetId(requestedId) ? `${requestedId}_custom` : requestedId, state.presetsState.presets)
             : state.editorPresetId;
         normalized.id = packageId;
 
-        const presets = ensureDefaultPreset(state.presetsState.presets);
+        const presets = ensureBuiltinPresets(state.presetsState.presets);
         const existingIndex = presets.findIndex((item) => item.id === packageId);
         if (existingIndex >= 0) {
             presets[existingIndex] = normalized;
@@ -1423,11 +1484,17 @@ function prettyBytes(value) {
 }
 
 function readPresetsState(widget) {
+    let parsedWidgetState = null;
     let widgetState = null;
     try {
-        widgetState = normalizePresetsState(JSON.parse(widget?.value || ""));
+        parsedWidgetState = JSON.parse(widget?.value || "");
+        widgetState = normalizePresetsState(parsedWidgetState);
     } catch (_error) {
         widgetState = normalizePresetsState(DEFAULT_STATE);
+    }
+    if (widget && JSON.stringify(parsedWidgetState) !== JSON.stringify(widgetState)) {
+        widget.value = JSON.stringify(widgetState, null, 2);
+        widget.callback?.(widget.value);
     }
     const storedState = readStoredPresetsState();
     if (storedState && hasCustomPresets(storedState)) {
@@ -1458,10 +1525,7 @@ function readStoredPresetsState() {
                 continue;
             }
             const stored = normalizePresetsState(JSON.parse(raw));
-            return {
-                active_preset_id: DEFAULT_PACKAGE.id,
-                presets: stored.presets,
-            };
+            return stored;
         } catch (_error) {
             // Ignore stale browser storage and keep the workflow as authority.
         }
@@ -1473,7 +1537,7 @@ function writeStoredPresetsState(value) {
     try {
         const normalized = normalizePresetsState(value);
         localStorage.setItem(PRESET_STORAGE_KEY, JSON.stringify({
-            active_preset_id: DEFAULT_PACKAGE.id,
+            active_preset_id: normalized.active_preset_id,
             presets: normalized.presets,
         }));
     } catch (_error) {
@@ -1486,7 +1550,7 @@ function mergePresetLibrary(workflowState, storedState) {
     const stored = normalizePresetsState(storedState);
     const byId = new Map(workflow.presets.map((item) => [item.id, item]));
     for (const item of stored.presets) {
-        if (item.id !== DEFAULT_PACKAGE.id && !byId.has(item.id)) {
+        if (!isBuiltinPresetId(item.id) && !byId.has(item.id)) {
             byId.set(item.id, item);
         }
     }
@@ -1501,12 +1565,12 @@ function mergePresetLibrary(workflowState, storedState) {
 }
 
 function hasCustomPresets(state) {
-    return normalizePresetsState(state).presets.some((item) => item.id !== DEFAULT_PACKAGE.id);
+    return normalizePresetsState(state).presets.some((item) => !isBuiltinPresetId(item.id));
 }
 
 function normalizePresetsState(value = {}) {
     const presets = Array.isArray(value.presets) ? value.presets.map(normalizePackage) : [];
-    const safePresets = ensureDefaultPreset(presets);
+    const safePresets = ensureBuiltinPresets(presets);
     let activeId = String(value.active_preset_id || safePresets[0].id);
     if (!safePresets.some((item) => item.id === activeId)) {
         activeId = safePresets[0].id;
@@ -1540,12 +1604,24 @@ function normalizePackage(value = {}) {
     };
 }
 
-function ensureDefaultPreset(presets = []) {
-    const defaultPreset = normalizePackage(DEFAULT_PACKAGE);
+function ensureBuiltinPresets(presets = []) {
+    const builtins = BUILTIN_PACKAGES.map(normalizePackage);
     const customPresets = presets
         .map(normalizePackage)
-        .filter((item) => item.id !== DEFAULT_PACKAGE.id);
-    return [defaultPreset, ...customPresets];
+        .filter((item) => !isBuiltinPresetId(item.id));
+    return [...builtins, ...customPresets];
+}
+
+function isBuiltinPresetId(presetId) {
+    return BUILTIN_PACKAGE_IDS.has(String(presetId || ""));
+}
+
+function presetsStateEqual(left, right) {
+    return JSON.stringify(normalizePresetsState(left)) === JSON.stringify(normalizePresetsState(right));
+}
+
+function normalizedPresetsStateFromPayload(payload = {}) {
+    return payload?.presets_state ? normalizePresetsState(payload.presets_state) : null;
 }
 
 function uniquePresetId(baseId, presets = []) {
@@ -1553,7 +1629,7 @@ function uniquePresetId(baseId, presets = []) {
     const used = new Set(
         presets
             .map((item) => String(item?.id || ""))
-            .filter((id) => id && id !== DEFAULT_PACKAGE.id)
+            .filter((id) => id && !isBuiltinPresetId(id))
     );
     if (!used.has(safeBase)) {
         return safeBase;
@@ -1640,5 +1716,17 @@ async function copyText(text) {
 if (typeof window !== "undefined" && typeof window.__DENO_LTX_MODEL_DOWNLOADER_TEST_HOOK__ === "function") {
     window.__DENO_LTX_MODEL_DOWNLOADER_TEST_HOOK__({
         createLatestRequestGate,
+        normalizePresetsState,
+        mergePresetLibrary,
+        hasCustomPresets,
+        isBuiltinPresetId,
+        presetsStateEqual,
+        normalizedPresetsStateFromPayload,
+        readPresetsState,
+        readStoredPresetsState,
+        writeStoredPresetsState,
+        DEFAULT_PACKAGE,
+        LTX25_PACKAGE,
+        DEFAULT_STATE,
     });
 }

--- a/web/js/docs/DenoLTXModelDownloader.md
+++ b/web/js/docs/DenoLTXModelDownloader.md
@@ -1,0 +1,27 @@
+# (Deno) Easy Model Download Helper
+
+Checks the model files needed by built-in LTX presets and opens their official download pages. It never downloads or writes model files automatically.
+
+The built-in presets cover the existing LTX 2.3 8GB VRAM GGUF workflow and the official LTX 2.5 Distilled INT8 two-stage workflow. Custom presets saved in a workflow or browser are kept alongside the built-ins.
+
+## LTX 2.5 access
+
+Before using the LTX 2.5 links:
+
+1. Sign in to Hugging Face.
+2. Open the [Lightricks/LTX-2.5 model page](https://huggingface.co/Lightricks/LTX-2.5).
+3. Complete **Agree and Access**.
+4. Review the [LTX-2 Community License](https://github.com/Lightricks/LTX-2/blob/main/LICENSE.md).
+
+The LTX 2.5 preset includes the distilled INT8 transformer, projected Gemma 4 text encoder, video VAE, audio VAE, and x2 latent spatial upscaler. The node opens each Hugging Face link in the browser so the account access requirement remains visible.
+
+## Inputs
+
+| Name | Description |
+| --- | --- |
+| model_root | ComfyUI models root to check. The panel can automatically select a registered root that already contains the most required files. |
+| presets_json | Saved preset library. Built-in presets are refreshed while custom and unknown preset IDs are preserved. |
+
+## Usage
+
+Select a preset, open each missing file link, then move the downloaded file into the exact target folder shown by the node. Press **Refresh Check** after the files are in place.

--- a/web/js/docs/DenoLTXModelDownloader/ko.md
+++ b/web/js/docs/DenoLTXModelDownloader/ko.md
@@ -1,0 +1,27 @@
+# (Deno) Easy Model Download Helper
+
+내장 LTX 프리셋에 필요한 모델 파일을 확인하고 공식 다운로드 페이지를 엽니다. 모델 파일을 자동으로 다운로드하거나 작성하지 않습니다.
+
+내장 프리셋은 기존 LTX 2.3 8GB VRAM GGUF 워크플로우와 공식 LTX 2.5 Distilled INT8 2단계 워크플로우를 지원합니다. 워크플로우나 브라우저에 저장한 사용자 프리셋은 내장 프리셋과 함께 그대로 유지됩니다.
+
+## LTX 2.5 접근 권한
+
+LTX 2.5 링크를 사용하기 전에 다음 절차를 진행하세요.
+
+1. Hugging Face에 로그인합니다.
+2. [Lightricks/LTX-2.5 모델 페이지](https://huggingface.co/Lightricks/LTX-2.5)를 엽니다.
+3. **Agree and Access**를 완료합니다.
+4. [LTX-2 Community License](https://github.com/Lightricks/LTX-2/blob/main/LICENSE.md)를 확인합니다.
+
+LTX 2.5 프리셋에는 distilled INT8 transformer, projection이 포함된 Gemma 4 text encoder, video VAE, audio VAE, x2 latent spatial upscaler가 들어 있습니다. 계정 접근 절차가 사용자에게 보이도록 각 Hugging Face 파일 링크를 브라우저로 엽니다.
+
+## 입력값
+
+| 이름 | 설명 |
+| --- | --- |
+| model_root | 확인할 ComfyUI models 루트입니다. 등록된 모델 루트 중 필요한 파일이 가장 많이 있는 위치를 패널이 자동 선택할 수 있습니다. |
+| presets_json | 저장된 프리셋 목록입니다. 내장 프리셋은 최신 상태로 갱신하며 사용자 정의 프리셋과 알 수 없는 프리셋 ID는 보존합니다. |
+
+## 사용법
+
+프리셋을 선택하고 누락 파일의 링크를 연 다음, 다운로드한 파일을 노드에 표시된 정확한 대상 폴더로 옮기세요. 파일 배치 후 **Refresh Check**를 누릅니다.

--- a/web/js/docs/DenoLTXSequencer.md
+++ b/web/js/docs/DenoLTXSequencer.md
@@ -1,0 +1,25 @@
+# (Deno) LTX Sequencer
+
+Adds multiple still-image guides to an LTX video latent in one node while keeping the public LTX Add Guide behavior for frame placement, negative indexes, strength, and guide attention metadata.
+
+The image input is lazy: when `bypass` is enabled or `num_images` is `0`, the upstream image branch is not evaluated.
+
+## Inputs
+
+| Name | Description |
+| --- | --- |
+| positive / negative | LTX conditioning to receive guide keyframe and attention metadata. |
+| vae | LTX video VAE used to encode each guide image. |
+| latent | Video-only LTX latent. Combined audio/video latents are not accepted by the underlying guide operation. |
+| multi_input | Image batch. Images are consumed in batch order, up to `num_images`. |
+| num_images | Number of images from the batch to use. Set to `0` to disable the image branch. |
+| insert_mode | Interprets each guide position as frames or seconds. |
+| frame_rate | Converts second positions to frame indexes. |
+| strength_sync | Frontend convenience switch for editing the visible strength controls together. |
+| bypass | Returns conditioning and latent unchanged without evaluating `multi_input`. |
+| insert_frame_N / insert_second_N | Start position for guide N. Negative frame indexes count from the end according to the current ComfyUI LTX Add Guide behavior. |
+| strength_N | Influence for guide N. `0` skips its encode and guide append; `1` is full guide strength. |
+
+## Output
+
+The positive and negative conditioning include the guide metadata, and the latent contains the appended guide frames and noise mask. Use the official `LTXVCropGuides` at the appropriate point before decoding a guide-bearing video latent.

--- a/web/js/docs/DenoLTXSequencer/ko.md
+++ b/web/js/docs/DenoLTXSequencer/ko.md
@@ -1,0 +1,25 @@
+# (Deno) LTX Sequencer
+
+여러 장의 정지 이미지를 한 노드에서 LTX 비디오 latent의 guide로 추가합니다. 프레임 위치, 음수 인덱스, strength, guide attention metadata는 현재 ComfyUI의 LTX Add Guide 동작을 따릅니다.
+
+이미지 입력은 lazy 방식입니다. `bypass`가 켜져 있거나 `num_images`가 `0`이면 upstream 이미지 경로를 실행하지 않습니다.
+
+## 입력값
+
+| 이름 | 설명 |
+| --- | --- |
+| positive / negative | guide keyframe과 attention metadata를 받을 LTX conditioning입니다. |
+| vae | 각 guide 이미지를 인코딩할 LTX video VAE입니다. |
+| latent | 비디오 전용 LTX latent입니다. 기반 guide 연산은 audio/video 결합 latent를 지원하지 않습니다. |
+| multi_input | 이미지 배치입니다. 배치 순서대로 `num_images`만큼 사용합니다. |
+| num_images | 배치에서 사용할 이미지 수입니다. `0`이면 이미지 경로를 비활성화합니다. |
+| insert_mode | 각 guide 위치를 프레임 또는 초 단위로 해석합니다. |
+| frame_rate | 초 단위 위치를 프레임 인덱스로 변환할 때 사용합니다. |
+| strength_sync | 화면에 보이는 strength 값을 함께 편집하기 위한 프런트엔드 편의 기능입니다. |
+| bypass | `multi_input`을 실행하지 않고 conditioning과 latent를 그대로 반환합니다. |
+| insert_frame_N / insert_second_N | N번째 guide의 시작 위치입니다. 음수 프레임 인덱스는 현재 ComfyUI LTX Add Guide 방식에 따라 영상 끝에서부터 계산합니다. |
+| strength_N | N번째 guide의 영향력입니다. `0`이면 인코딩과 guide 추가를 생략하고 `1`이면 최대 guide 강도입니다. |
+
+## 출력값
+
+positive와 negative conditioning에는 guide metadata가 포함되고, latent에는 guide frame과 noise mask가 추가됩니다. guide가 포함된 비디오 latent를 디코딩하기 전 적절한 위치에서 공식 `LTXVCropGuides`를 사용하세요.


### PR DESCRIPTION
## Summary

- add the complete official LTX 2.5 Distilled INT8 two-stage model preset and gated-download guidance
- update the LTX Sequencer for lazy guide inputs and current ComfyUI guide metadata while preserving its saved schema
- fix input-folder external link handling and Nodes 2.0 image-loader layout, hidden widget, wheel, and disabled-card behavior

## Validation

- 599 Python tests passed in the CI-equivalent suite
- affected JavaScript harnesses and `node --check` passed
- live Nodes 2.0 fresh/save/reopen, 13-image resizing, wheel/middle-pan, disabled persistence, and internal/external junction behavior verified on isolated port 8191
- Registry package manifest: 422 files; forbidden experimental A2V and local/operator artifacts absent

Closes #71.
Closes #72.
