### PR TITLE
Fix Ollama long-form structured output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file intentionally stays short. Detailed engineering notes belong in privat
 
 ## Unreleased
 
+## 0.7.89 - 2026-08-19
+
+- Fixed `(Deno) Local LLM Loader` so Ollama JSON-schema output preserves clearly requested long-form word or character targets instead of collapsing them to a title or short introduction. The compatibility path keeps the original prompt, images, seed, cancellation, and unload behavior, while ordinary requests, source-length references, reviewer/rewrite workflows, LM Studio, and saved workflows remain unchanged. Addresses #77.
+
 ## 0.7.88 - 2026-08-15
 
 - Added Unsloth Studio as a first-class `(Deno) Local LLM Loader` provider with authenticated model discovery and chat, Thinking control, manual and post-run unload, provider-specific URL restoration, and saved-workflow compatibility without storing the API key in workflows or PNG metadata.

--- a/deno_local_llm_refiner.py
+++ b/deno_local_llm_refiner.py
@@ -186,11 +186,194 @@ STRUCTURED_FINAL_ANSWER_SYSTEM_INSTRUCTION = (
     "labels, and Markdown fences unless those visible answer elements are explicitly "
     "requested. Never write anything outside the JSON object."
 )
+OLLAMA_LONG_FORM_STRUCTURED_FINAL_ANSWER_SYSTEM_INSTRUCTION = (
+    "Internal response contract: Return exactly one JSON object matching the required "
+    "transport schema, with the complete requested answer in deno_final_answer. The JSON "
+    "wrapper changes only transport, never the requested content. Follow the original system "
+    "and user messages exactly, including the requested language, target word or character "
+    "count, length, level of detail, sections, and visible formatting. Do not shorten, "
+    "summarize, omit, or expand the answer unless the original request asks for it. Never "
+    "include private chain-of-thought, hidden reasoning, scratch work, or internal deliberation. "
+    "If the user requests reasoning or an explanation, provide only the answer-facing "
+    "explanation while preserving the original requested scope and detail. Exclude provider "
+    "preambles, process commentary, transport labels, and unrequested Markdown fences. Never "
+    "write anything outside the JSON object."
+)
+PLAIN_FINAL_ANSWER_SYSTEM_INSTRUCTION = (
+    "Internal final-answer contract: Return only the complete downstream answer requested by "
+    "the user. Follow the original system and user messages exactly, including the requested "
+    "language, target word or character count, length, level of detail, sections, and visible "
+    "formatting. Do not shorten, summarize, omit, or expand the answer unless the original "
+    "request asks for it. Never include private chain-of-thought, hidden reasoning, scratch "
+    "work, or internal deliberation. If the user requests reasoning or an explanation, provide "
+    "only the answer-facing explanation while preserving the original requested scope and "
+    "detail. Exclude provider preambles, process commentary, transport labels, and unrequested "
+    "Markdown fences. Do not add a transport JSON wrapper unless the original request explicitly "
+    "requires that visible format."
+)
 STRUCTURED_FINALIZATION_INSTRUCTION = (
     "Finish the original request now. Return one valid response matching the required "
     "transport JSON schema, with only the requested downstream final answer in "
     "deno_final_answer and no text outside the JSON object."
 )
+OLLAMA_LONG_FORM_STRUCTURED_FINALIZATION_INSTRUCTION = (
+    "Finish the original request now and return the complete answer at the originally requested "
+    "scope. Preserve every requested language, target word or character count, length, level of "
+    "detail, section, and visible format. Do not shorten, summarize, omit, or expand the answer "
+    "unless the original request asks for it. Return one valid response matching the required "
+    "transport JSON schema, with only the requested downstream final answer in "
+    "deno_final_answer and no text outside the JSON object."
+)
+LONG_FORM_COMPATIBILITY_MIN_WORDS = 100
+LONG_FORM_COMPATIBILITY_MIN_CHARACTERS = 500
+LONG_FORM_COMPATIBILITY_MIN_RATIO = 0.60
+EXPLICIT_WORD_COUNT_RE = re.compile(
+    r"(?P<count>\d{1,6}(?:[,\s.]\d{3})*)[-\s]*"
+    r"(?P<unit>words?|mots?|palabras?|w[oö]rter|woerter|woorden|parole|palavras|단어)",
+    re.IGNORECASE,
+)
+EXPLICIT_CHARACTER_COUNT_RE = re.compile(
+    r"(?P<count>\d{1,7}(?:[,\s.]\d{3})*)\s*"
+    r"(?P<unit>characters?|chars?|caract[eè]res?|caracteres?|zeichen|caratteri|caracteres|"
+    r"문자|文字|字)",
+    re.IGNORECASE,
+)
+EXPLICIT_COUNT_UPPER_BOUND_MARKERS = (
+    "at most",
+    "up to",
+    "no more than",
+    "not more than",
+    "fewer than",
+    "less than",
+    "under ",
+    "within",
+    "maximum",
+    "max ",
+    "or fewer",
+    "or less",
+    "au plus",
+    "jusqu'à",
+    "jusqu’a",
+    "pas plus de",
+    "moins de",
+    "ou moins",
+    "como máximo",
+    "hasta",
+    "no más de",
+    "no mas de",
+    "menos de",
+    "höchstens",
+    "bis zu",
+    "nicht mehr als",
+    "maximal",
+    "weniger als",
+    "al massimo",
+    "fino a",
+    "non più di",
+    "non piu di",
+    "meno di",
+    "no máximo",
+    "no maximo",
+    "até",
+    "ate",
+    "não mais de",
+    "nao mais de",
+    "이하",
+    "이내",
+    "미만",
+    "최대",
+    "제한",
+    "以内",
+    "以下",
+    "未満",
+    "最多",
+    "収まる",
+    "不超过",
+    "不超過",
+)
+EXPLICIT_LONG_FORM_OUTPUT_MARKER_RE = re.compile(
+    r"\b(?:write|generate|create|compose|draft|produce|provide|give|respond|answer|return|"
+    r"summarize|summarise|condense)\b|"
+    r"\b(?:écris|ecris|écrivez|ecrivez|rédige|redige|rédigez|redigez|génère|genere|"
+    r"générez|generez|crée|cree|créez|creez|composez?|produis|produisez|réponds|reponds|"
+    r"répondez|repondez)\b|"
+    r"\b(?:escribe|escriba|redacta|redacte|genera|genere|crea|cree|compón|compon|"
+    r"componga|produce|produzca|responde|responda)\b|"
+    r"\b(?:schreibe|schreiben|verfasse|verfassen|erstelle|erstellen|erzeuge|erzeugen|"
+    r"antworte|antworten)\b|"
+    r"\b(?:scrivi|scriva|redigi|rediga|genera|generi|crea|crei|componi|componga|"
+    r"produci|produca|rispondi|risponda)\b|"
+    r"\b(?:escreva|escrever|redija|redigir|gere|gerar|crie|criar|componha|compor|"
+    r"produza|produzir|responda|responder)\b|"
+    r"\b(?:schrijf|schrijven|maak|maken|genereer|genereren|antwoord|beantwoord)\b|"
+    r"(?:써\s*줘|써줘|쓰(?:세요|기|라)|작성|생성|만들(?:어|기)|답변|대답|"
+    r"書いて|書く|書け|作成|生成|執筆|答えて|回答|写|寫|撰写|撰寫|创作|創作|作答)",
+    re.IGNORECASE,
+)
+EXPLICIT_LONG_FORM_CREATION_MARKER_RE = re.compile(
+    r"^(?:write|generate|create|compose|draft|produce|"
+    r"écris|ecris|écrivez|ecrivez|rédige|redige|rédigez|redigez|génère|genere|"
+    r"générez|generez|crée|cree|créez|creez|compose|composez|produis|produisez|"
+    r"escribe|escriba|redacta|redacte|genera|genere|crea|cree|compón|compon|"
+    r"componga|produce|produzca|schreibe|schreiben|verfasse|verfassen|erstelle|"
+    r"erstellen|erzeuge|erzeugen|scrivi|scriva|redigi|rediga|genera|generi|crea|"
+    r"crei|componi|componga|produci|produca|escreva|escrever|redija|redigir|gere|"
+    r"gerar|crie|criar|componha|compor|produza|produzir|schrijf|schrijven|maak|"
+    r"maken|genereer|genereren|써\s*줘|써줘|쓰세요|쓰기|쓰라|작성|생성|만들어|"
+    r"만들기|書いて|書く|書け|作成|生成|執筆|写|寫|撰写|撰寫|创作|創作)$",
+    re.IGNORECASE,
+)
+EXPLICIT_LONG_FORM_SOURCE_MARKER_RE = re.compile(
+    r"\b(?:source|input|transcript|attachment)\b|"
+    r"\b(?:the|this|that|following|below|provided|attached|given|existing)\s+"
+    r"(?:source|input|text|article|essay|document|transcript|attachment)\b|"
+    r"\b(?:la|le|ce|cet|cette|suivant|suivante|fourni|fournie|joint|jointe)\s+"
+    r"(?:source|entrée|entree|texte|article|document|transcription|pièce|piece)\b|"
+    r"\b(?:la|el|este|esta|siguiente|proporcionado|proporcionada|adjunto|adjunta)\s+"
+    r"(?:fuente|entrada|texto|artículo|articulo|documento|transcripción|transcripcion)\b|"
+    r"\b(?:die|der|das|diese|dieser|dieses|folgende|folgenden|bereitgestellte|angehängte|"
+    r"angehaengte)\s+(?:quelle|eingabe|text|artikel|dokument|transkript|anlage)\b|"
+    r"(?:다음\s*(?:원문|글|문서|입력|자막|전사|답변)|아래\s*(?:원문|글|문서|입력|자막|전사|답변)|"
+    r"이\s*(?:원문|글|문서|입력|자막|전사|답변)|제공된\s*(?:원문|글|문서|입력|답변)|"
+    r"첨부된\s*(?:원문|글|문서|입력)|원문|입력|자막|전사|"
+    r"次の\s*(?:原文|文章|文書|入力|字幕|文字起こし)|以下の\s*(?:原文|文章|文書|入力)|"
+    r"この\s*(?:原文|文章|文書|入力|回答)|原文|入力|添付|"
+    r"下面的?(?:原文|文章|文档|文檔|输入|輸入)|以下的?(?:原文|文章|文档|文檔|输入|輸入)|"
+    r"这篇|這篇|这个(?:原文|文章|文档|输入)|這個(?:原文|文章|文檔|輸入)|原文|输入|輸入|附件)",
+    re.IGNORECASE,
+)
+EXPLICIT_LONG_FORM_DIRECT_CONNECTOR_RE = re.compile(
+    r"\b(?:in|en|em|mit)\s+(?:(?:exactly|about|around|approximately|roughly|at\s+least)\s+)?$",
+    re.IGNORECASE,
+)
+EXPLICIT_LONG_FORM_POST_CONNECTOR_RE = re.compile(r"^\s*(?:로|으로|で)")
+EXPLICIT_LONG_FORM_POST_IMPERATIVE_RE = re.compile(
+    r"^\s*(?:로|으로)\s*(?:(?:글|답변|에세이|기사|보고서|설명)(?:을|를)?\s*)?"
+    r"(?:(?:작성|생성)(?:해\s*(?:주세요|줘)|해주세요|하세요|하십시오|하라)|"
+    r"써\s*(?:주세요|줘)|써줘|쓰세요|쓰라|만들어\s*(?:주세요|줘)|만들어줘)|"
+    r"^\s*で\s*(?:(?:記事|文章|作文|回答|報告|説明)(?:を)?\s*)?"
+    r"(?:(?:作成|生成|執筆)して(?:ください|下さい)|書いて(?:ください|下さい)?|"
+    r"答えて(?:ください|下さい)?|書け|作成せよ)",
+    re.IGNORECASE,
+)
+EXPLICIT_LONG_FORM_REFERENCE_BRIDGE_RE = re.compile(
+    r"\b(?:why|whether|meaning|phrase|term|mention|reference|definition|"
+    r"written|drafted|composed|presented|provided|attached|published|available|"
+    r"expressed|worded|talking\s+about|discussion\s+of)\b",
+    re.IGNORECASE,
+)
+EXPLICIT_LONG_FORM_TARGET_NOUN_RE = re.compile(
+    r"\b(?:text|essay|article|story|report|response|answer|piece|post|description|"
+    r"summary|review|analysis|explanation|translation|outline|"
+    r"texte|essai|histoire|rapport|réponse|reponse|"
+    r"texto|ensayo|artículo|articulo|historia|informe|respuesta|"
+    r"text|aufsatz|artikel|geschichte|bericht|antwort|"
+    r"testo|saggio|articolo|storia|rapporto|risposta|"
+    r"texto|ensaio|artigo|história|historia|relatório|relatorio|resposta)\b|"
+    r"(?:글|에세이|기사|이야기|보고서|답변|文章|作文|記事|物語|報告|回答)",
+    re.IGNORECASE,
+)
+EXPLICIT_COUNT_CLAUSE_BREAKS = "\r\n.!?;:。！？；"
 REVIEWER_PREVIEW_SUBFOLDER = "deno_llm_reviewer"
 _WARM_LOCAL_LLM_KEYS: Dict[str, Optional[float]] = {}
 _ACTIVE_LOCAL_LLM_KEYS: Dict[str, int] = {}
@@ -1445,6 +1628,365 @@ def _final_answer_schema() -> Dict[str, Any]:
         "required": [STRUCTURED_FINAL_ANSWER_FIELD],
         "additionalProperties": False,
     }
+
+
+def _ollama_long_form_structured_final_answer_system_instruction() -> str:
+    schema_text = json.dumps(
+        _final_answer_schema(),
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return (
+        f"{OLLAMA_LONG_FORM_STRUCTURED_FINAL_ANSWER_SYSTEM_INSTRUCTION} "
+        f"Required transport JSON schema: {schema_text}"
+    )
+
+
+def _explicit_count_is_upper_bound(text: str, start: int, end: int) -> bool:
+    context = re.sub(
+        r"\s+",
+        " ",
+        str(text or "")[max(0, start - 36) : min(len(text), end + 24)].lower(),
+    )
+    for marker in EXPLICIT_COUNT_UPPER_BOUND_MARKERS:
+        normalized_marker = marker.strip().lower()
+        if not normalized_marker:
+            continue
+        if any("\uac00" <= character <= "\ud7a3" or "\u3040" <= character <= "\u9fff" for character in normalized_marker):
+            if normalized_marker in context:
+                return True
+            continue
+        marker_pattern = re.escape(normalized_marker).replace(r"\ ", r"\s+")
+        if re.search(rf"(?<!\w){marker_pattern}(?!\w)", context, re.IGNORECASE):
+            return True
+    return False
+
+
+def _parse_explicit_count(value: str) -> Optional[int]:
+    digits = re.sub(r"[,\s.]", "", str(value or ""))
+    try:
+        parsed = int(digits)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _explicit_count_clause_bounds(text: str, start: int, end: int) -> Tuple[int, int]:
+    left = 0
+    right = len(text)
+    for separator in EXPLICIT_COUNT_CLAUSE_BREAKS:
+        preceding = text.rfind(separator, 0, start)
+        if preceding >= 0:
+            left = max(left, preceding + 1)
+        following = text.find(separator, end)
+        if following >= 0:
+            right = min(right, following)
+    return left, right
+
+
+def _explicit_count_is_quoted(text: str, start: int, end: int) -> bool:
+    line_left = max(text.rfind("\n", 0, start), text.rfind("\r", 0, start)) + 1
+    line_breaks = [position for position in (text.find("\n", end), text.find("\r", end)) if position >= 0]
+    line_right = min(line_breaks) if line_breaks else len(text)
+
+    left_non_space = start - 1
+    while left_non_space >= line_left and text[left_non_space].isspace():
+        left_non_space -= 1
+    right_non_space = end
+    while right_non_space < line_right and text[right_non_space].isspace():
+        right_non_space += 1
+    if left_non_space >= line_left and right_non_space < line_right:
+        if (text[left_non_space], text[right_non_space]) in {
+            ("'", "'"),
+            ('"', '"'),
+            ("`", "`"),
+            ("“", "”"),
+            ("‘", "’"),
+            ("«", "»"),
+            ("「", "」"),
+            ("『", "』"),
+        }:
+            return True
+
+    for opening, closing in (("“", "”"), ("‘", "’"), ("«", "»"), ("「", "」"), ("『", "』")):
+        last_opening = text.rfind(opening, line_left, start)
+        last_closing = text.rfind(closing, line_left, start)
+        next_closing = text.find(closing, end, line_right)
+        if last_opening > last_closing and next_closing >= 0:
+            return True
+
+    for quote in ('"', "`"):
+        if text[line_left:start].count(quote) % 2 == 1 and text.find(quote, end, line_right) >= 0:
+            return True
+
+    last_apostrophe = text.rfind("'", line_left, start)
+    if last_apostrophe >= 0:
+        opens_quote = last_apostrophe == line_left or not text[last_apostrophe - 1].isalnum()
+        if opens_quote and text.find("'", end, line_right) >= 0:
+            return True
+    return False
+
+
+def _explicit_count_is_in_non_authoritative_region(text: str, start: int) -> bool:
+    line_start = max(text.rfind("\n", 0, start), text.rfind("\r", 0, start)) + 1
+    line_prefix = text[line_start:start]
+    if line_prefix.lstrip().startswith(">") or line_prefix.startswith(("    ", "\t")):
+        return True
+    if text[:start].count("```") % 2 == 1 or text[:start].count("~~~") % 2 == 1:
+        return True
+    return re.search(
+        r"\b(?:example|sample|quoted|instruction|prompt|do\s+not\s+follow|ignore|such\s+as)\b|"
+        r"(?:예시|예제|샘플|지시문|프롬프트|따르지\s*마|"
+        r"例|例文|指示文|プロンプト|従わない|"
+        r"示例|样例|樣例|指令|提示词|提示詞|不要遵循)",
+        line_prefix,
+        re.IGNORECASE,
+    ) is not None
+
+
+def _explicit_count_has_simple_output_prefix(value: str) -> bool:
+    normalized = re.sub(r"\s+", " ", value).strip().lower()
+    if not normalized:
+        return True
+    token = (
+        r"(?:a|an|one|un|une|uno|una|um|uma|ein|eine|einen|een|"
+        r"long|detailed|complete|full|comprehensive|substantial|extended|"
+        r"longo|longa|lang|lange|ausführlich|ausfuehrlich|détaillé|detaille|"
+        r"detallado|detallada|dettagliato|dettagliata|detalhado|detalhada)"
+    )
+    return re.fullmatch(rf"{token}(?:\s+{token})*", normalized, re.IGNORECASE) is not None
+
+
+def _explicit_output_marker_is_top_level(before: str, marker: re.Match) -> bool:
+    prefix = before[:marker.start()]
+    return re.fullmatch(
+        r"\s*(?:(?:please|kindly|always|must|you\s+must|could\s+you|can\s+you|"
+        r"would\s+you|veuillez|por\s+favor)\s+)?",
+        prefix,
+        re.IGNORECASE,
+    ) is not None
+
+
+def _explicit_count_has_output_noun_bridge(bridge: str) -> bool:
+    noun_matches = list(EXPLICIT_LONG_FORM_TARGET_NOUN_RE.finditer(bridge))
+    if len(noun_matches) != 1:
+        return False
+    noun_match = noun_matches[0]
+    prefix = bridge[:noun_match.start()]
+    suffix = re.sub(r"\s+", " ", bridge[noun_match.end():]).strip().lower()
+    modifier = (
+        r"(?:exactly|about|around|approximately|roughly|nearly|at least|"
+        r"at minimum|a minimum of|more than|over)"
+    )
+    allowed_suffix = re.fullmatch(
+        rf"(?:(?:of|de|del|di|mit|com|van)(?:\s+{modifier})?|{modifier})?",
+        suffix,
+        re.IGNORECASE,
+    )
+    return _explicit_count_has_simple_output_prefix(prefix) and allowed_suffix is not None
+
+
+def _explicit_count_is_output_target(text: str, start: int, end: int) -> bool:
+    clause_start, clause_end = _explicit_count_clause_bounds(text, start, end)
+    if text[:clause_start].strip():
+        return False
+    before = text[clause_start:start]
+    after = text[end:clause_end]
+    output_before = list(EXPLICIT_LONG_FORM_OUTPUT_MARKER_RE.finditer(before))
+    output_after = list(EXPLICIT_LONG_FORM_OUTPUT_MARKER_RE.finditer(after[:80]))
+    source_before = list(EXPLICIT_LONG_FORM_SOURCE_MARKER_RE.finditer(before))
+    direct_connector = EXPLICIT_LONG_FORM_DIRECT_CONNECTOR_RE.search(before[-48:]) is not None
+    post_connector = EXPLICIT_LONG_FORM_POST_CONNECTOR_RE.match(after) is not None
+    post_imperative_match = EXPLICIT_LONG_FORM_POST_IMPERATIVE_RE.match(after)
+    top_level_output = next(
+        (
+            candidate
+            for candidate in output_before
+            if _explicit_output_marker_is_top_level(before, candidate)
+        ),
+        None,
+    )
+    output_before_is_negated = False
+    if top_level_output is not None:
+        output_prefix = before[max(0, top_level_output.start() - 32):top_level_output.start()]
+        output_before_is_negated = re.search(
+            r"(?:\b(?:do\s+not|don't|never|avoid|without|ne\s+pas|no|nunca|nicht|"
+            r"non|não|nao)\s*|(?:不要|别|別|勿|하지\s*마|말)\s*)$",
+            output_prefix,
+            re.IGNORECASE,
+        ) is not None
+
+    if post_connector:
+        return (
+            bool(output_after)
+            and not source_before
+            and post_imperative_match is not None
+            and re.match(
+                r"^\s*(?:라는|라고|이라는|이라고|という|とは)",
+                after[post_imperative_match.end():],
+            ) is None
+        )
+
+    if direct_connector:
+        if top_level_output is None:
+            return False
+        if output_before_is_negated:
+            return False
+        bridge = before[top_level_output.end():]
+        if EXPLICIT_LONG_FORM_REFERENCE_BRIDGE_RE.search(bridge):
+            return False
+        if re.search(
+            r"\b(?:is|was|contains?|contained|has|had|consists?|consisted|est|était|"
+            r"etait|contient|tenía|tenia|enthält|enthaelt)\b",
+            bridge,
+            re.IGNORECASE,
+        ):
+            return False
+        bridge_without_connector = EXPLICIT_LONG_FORM_DIRECT_CONNECTOR_RE.sub("", bridge)
+        creation_marker = EXPLICIT_LONG_FORM_CREATION_MARKER_RE.fullmatch(top_level_output.group(0))
+        if creation_marker is not None:
+            return (
+                _explicit_count_has_simple_output_prefix(bridge_without_connector)
+                or _explicit_count_has_output_noun_bridge(bridge_without_connector)
+            )
+        if (
+            not re.sub(r"\s+", "", bridge_without_connector)
+            or _explicit_count_has_output_noun_bridge(bridge_without_connector)
+        ):
+            return True
+        if re.fullmatch(
+            r"\s*(?:(?:the|this|that|following|provided|an?|one)\s+)?"
+            r"(?:\d+[,-]?word\s+)?(?:article|text|essay|document|source|report)\s*",
+            bridge_without_connector,
+            re.IGNORECASE,
+        ):
+            return top_level_output.group(0).strip().lower() in {
+                "summarize",
+                "summarise",
+                "condense",
+            }
+        return False
+
+    if top_level_output is None:
+        return False
+    last_output = top_level_output
+    if output_before_is_negated:
+        return False
+    if source_before and source_before[-1].start() > last_output.start():
+        return False
+
+    bridge = before[last_output.end():]
+    if len(bridge) > 120 or EXPLICIT_LONG_FORM_REFERENCE_BRIDGE_RE.search(bridge):
+        return False
+    normalized_bridge = re.sub(r"\s+", " ", bridge).strip().lower()
+    if re.fullmatch(
+        r"(?:the|this|that|following|provided|given|existing|"
+        r"le|la|ce|cet|cette|el|este|esta|der|die|das|dieser|diese|dieses)",
+        normalized_bridge,
+    ):
+        return False
+    if _explicit_count_has_output_noun_bridge(bridge):
+        return True
+
+    if re.fullmatch(
+        r"(?:(?:please|exactly|about|around|approximately|roughly|nearly|at least|"
+        r"at minimum|a minimum of|more than|over)\s+)*",
+        normalized_bridge,
+    ):
+        return True
+
+    target_after_text = re.sub(r"^(?:的|の)\s*", "", after.lstrip())
+    target_after = EXPLICIT_LONG_FORM_TARGET_NOUN_RE.match(target_after_text)
+    creation_marker = EXPLICIT_LONG_FORM_CREATION_MARKER_RE.fullmatch(last_output.group(0))
+    if (
+        creation_marker is not None
+        and target_after is not None
+        and _explicit_count_has_simple_output_prefix(normalized_bridge)
+    ):
+        return True
+
+    if creation_marker is not None and re.fullmatch(
+        r"(?:一篇|一段|一則|一则|篇|段)?",
+        normalized_bridge,
+    ):
+        return EXPLICIT_LONG_FORM_TARGET_NOUN_RE.match(target_after_text) is not None
+    return False
+
+
+def _explicit_long_form_requirements_from_text(
+    text: str,
+) -> Tuple[List[Dict[str, Any]], bool]:
+    requirements: List[Dict[str, Any]] = []
+    saw_output_length_directive = False
+    for unit, pattern, minimum_target in (
+        ("words", EXPLICIT_WORD_COUNT_RE, LONG_FORM_COMPATIBILITY_MIN_WORDS),
+        ("characters", EXPLICIT_CHARACTER_COUNT_RE, LONG_FORM_COMPATIBILITY_MIN_CHARACTERS),
+    ):
+        for match in pattern.finditer(text):
+            if _explicit_count_is_in_non_authoritative_region(text, match.start()):
+                continue
+            if _explicit_count_is_quoted(text, match.start(), match.end()):
+                continue
+            if not _explicit_count_is_output_target(
+                text,
+                match.start(),
+                match.end(),
+            ):
+                continue
+            saw_output_length_directive = True
+            if _explicit_count_is_upper_bound(text, match.start(), match.end()):
+                continue
+            target = _parse_explicit_count(match.group("count"))
+            if target is None or target < minimum_target:
+                continue
+            requirements.append({
+                "unit": unit,
+                "target": target,
+                "minimum_acceptable": max(
+                    1,
+                    int(math.ceil(target * LONG_FORM_COMPATIBILITY_MIN_RATIO)),
+                ),
+                "matched": match.group(0),
+            })
+    return requirements, saw_output_length_directive
+
+
+def _find_explicit_long_form_requirement(
+    system_prompt: str,
+    prompt: str,
+) -> Optional[Dict[str, Any]]:
+    system_text = str(system_prompt or "")
+    system_requirements, system_has_directive = _explicit_long_form_requirements_from_text(system_text)
+    if system_has_directive:
+        if not system_requirements:
+            return None
+        return max(system_requirements, key=lambda requirement: int(requirement["target"]))
+
+    # A configured system prompt can turn the user text into source material for review,
+    # rewrite, translation, classification, or extraction. Unless that authoritative system
+    # prompt declares its own output length, keep the compatibility path off rather than
+    # treating a count inside the source text as an executable generation requirement.
+    if system_text.strip():
+        return None
+
+    prompt_requirements, _prompt_has_directive = _explicit_long_form_requirements_from_text(
+        str(prompt or "")
+    )
+    if not prompt_requirements:
+        return None
+    return max(prompt_requirements, key=lambda requirement: int(requirement["target"]))
+
+
+def _count_answer_for_requirement(answer: str, requirement: Dict[str, Any]) -> int:
+    text = str(answer or "").strip()
+    if requirement.get("unit") == "characters":
+        return len(text)
+    return len(re.findall(r"\S+", text))
+
+
+def _ollama_completion_was_truncated(meta: Dict[str, Any]) -> bool:
+    reason = str(meta.get("done_reason") or "").strip().lower()
+    return reason in {"length", "max_tokens", "max_length", "token_limit"}
 
 
 def _openai_final_answer_response_format() -> Dict[str, Any]:
@@ -3144,6 +3686,7 @@ class DenoLocalLLMRefiner:
                         index=index + 1,
                         total=total,
                         cleanup_state=batch_cleanup_state,
+                        length_request_prompt=prompt,
                     )
                 finally:
                     _clear_local_llm_active(active_key)
@@ -3244,6 +3787,7 @@ class DenoLocalLLMRefiner:
         index: int,
         total: int,
         cleanup_state: Optional[Dict[str, bool]] = None,
+        length_request_prompt: Optional[str] = None,
     ) -> Tuple[str, str, Dict[str, Any]]:
         if provider == PROVIDER_LM_STUDIO:
             return self._run_lm_studio(
@@ -3295,6 +3839,7 @@ class DenoLocalLLMRefiner:
             index,
             total,
             cleanup_state,
+            length_request_prompt,
         )
 
     def _run_ollama(
@@ -3313,12 +3858,26 @@ class DenoLocalLLMRefiner:
         index: int,
         total: int,
         cleanup_state: Optional[Dict[str, bool]] = None,
+        length_request_prompt: Optional[str] = None,
     ) -> Tuple[str, str, Dict[str, Any]]:
         base = _normalize_ollama_url(server_url)
         memory_value = _normalize_model_memory(model_memory)
         keep_minutes_value = max(1, int(keep_minutes))
+        authoritative_length_prompt = (
+            prompt
+            if length_request_prompt is None
+            else str(length_request_prompt or "")
+        )
+        long_form_requirement = _find_explicit_long_form_requirement(
+            system_prompt,
+            authoritative_length_prompt,
+        )
         messages = []
         internal_system_prompt = STRUCTURED_FINAL_ANSWER_SYSTEM_INSTRUCTION
+        finalization_instruction = STRUCTURED_FINALIZATION_INSTRUCTION
+        if long_form_requirement is not None:
+            internal_system_prompt = _ollama_long_form_structured_final_answer_system_instruction()
+            finalization_instruction = OLLAMA_LONG_FORM_STRUCTURED_FINALIZATION_INSTRUCTION
         if system_prompt.strip():
             internal_system_prompt = f"{system_prompt}\n\n{internal_system_prompt}"
         messages.append({"role": "system", "content": internal_system_prompt})
@@ -3458,7 +4017,7 @@ class DenoLocalLLMRefiner:
                 previous_assistant_message["thinking"] = initial_thinking
             continuation_payload["messages"] = list(messages) + [
                 previous_assistant_message,
-                {"role": "user", "content": STRUCTURED_FINALIZATION_INSTRUCTION},
+                {"role": "user", "content": finalization_instruction},
             ]
             continuation_payload["think"] = False
             continuation_payload["keep_alive"] = logical_keep_alive
@@ -3508,8 +4067,94 @@ class DenoLocalLLMRefiner:
                 "initial_meta": initial_meta,
                 "finalization_meta": dict(final_meta),
             }
+        long_form_compatibility: Optional[Dict[str, Any]] = None
+        if long_form_requirement is not None:
+            initial_count = _count_answer_for_requirement(answer, long_form_requirement)
+            minimum_acceptable = int(long_form_requirement["minimum_acceptable"])
+            needs_compatibility_retry = (
+                initial_count < minimum_acceptable
+                or _ollama_completion_was_truncated(final_meta)
+            )
+            if needs_compatibility_retry:
+                if recovery_meta is not None:
+                    raise RuntimeError(
+                        "Ollama returned a valid structured answer after automatic finalization, "
+                        "but it still did not preserve the explicit long-form request "
+                        f"({initial_count} {long_form_requirement['unit']}; expected at least "
+                        f"{minimum_acceptable} for the requested target of "
+                        f"{long_form_requirement['target']}). No further retry was attempted."
+                    )
+                _raise_if_local_llm_stopped(cancel_key)
+                structured_meta = dict(final_meta)
+                plain_system_prompt = PLAIN_FINAL_ANSWER_SYSTEM_INSTRUCTION
+                if system_prompt.strip():
+                    plain_system_prompt = f"{system_prompt}\n\n{plain_system_prompt}"
+                plain_user_message = dict(user_message)
+                compatibility_payload = dict(payload)
+                compatibility_payload["messages"] = [
+                    {"role": "system", "content": plain_system_prompt},
+                    plain_user_message,
+                ]
+                compatibility_payload.pop("format", None)
+                compatibility_payload["think"] = False
+                compatibility_payload["keep_alive"] = logical_keep_alive
+                _send_progress({
+                    "node_id": node_id,
+                    "status": "recovering requested length",
+                    "provider": PROVIDER_OLLAMA,
+                    "model": model,
+                    "index": index,
+                    "total": total,
+                    "answer": "",
+                    "thinking": thought,
+                })
+                fallback_content, _fallback_thinking, final_meta = stream_request(
+                    compatibility_payload,
+                    "recovering requested length",
+                )
+                fallback_answer = str(fallback_content or "").strip()
+                fallback_count = _count_answer_for_requirement(
+                    fallback_answer,
+                    long_form_requirement,
+                )
+                if (
+                    not fallback_answer
+                    or fallback_count < minimum_acceptable
+                    or _ollama_completion_was_truncated(final_meta)
+                ):
+                    truncation_detail = (
+                        f" The retry ended with done_reason={final_meta.get('done_reason')}."
+                        if _ollama_completion_was_truncated(final_meta)
+                        else ""
+                    )
+                    raise RuntimeError(
+                        "Ollama's structured output shortened an explicit long-form request, and "
+                        "the one compatibility retry without the transport schema still did not "
+                        f"reach the minimum expected length ({fallback_count} "
+                        f"{long_form_requirement['unit']}; expected at least "
+                        f"{minimum_acceptable} for the requested target of "
+                        f"{long_form_requirement['target']}).{truncation_detail}"
+                    )
+                answer = fallback_answer
+                long_form_compatibility = {
+                    "attempted": True,
+                    "succeeded": True,
+                    "unit": long_form_requirement["unit"],
+                    "target": long_form_requirement["target"],
+                    "minimum_acceptable": minimum_acceptable,
+                    "initial_count": initial_count,
+                    "final_count": fallback_count,
+                    "matched": long_form_requirement["matched"],
+                    "initial_meta": structured_meta,
+                    "retry_meta": dict(final_meta),
+                }
         post_run_unload: Dict[str, Any] = {"action": "none"}
-        if hold_for_possible_continuation and recovery_meta is None and answer:
+        if (
+            hold_for_possible_continuation
+            and recovery_meta is None
+            and long_form_compatibility is None
+            and answer
+        ):
             if cleanup_state is not None:
                 cleanup_state["provider_cleanup_attempted"] = True
             try:
@@ -3531,6 +4176,8 @@ class DenoLocalLLMRefiner:
             raw["initial_keep_alive"] = initial_keep_alive
         if recovery_meta is not None:
             raw["final_answer_recovery"] = recovery_meta
+        if long_form_compatibility is not None:
+            raw["long_form_compatibility"] = long_form_compatibility
         raw["post_keepalive"] = _ensure_ollama_model_stays_loaded(
             base=base,
             model=model,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "deno-custom-nodes"
 description = "DENO RTX node pack for ComfyUI: MiniMax H3 multi-reference image and Reference to Video helpers, local audio transcription and analysis helpers, Ideogram Director visual JSON/bbox prompt builder, Local LLM Loader and Reviewer helpers, GPT/Gemini-ready Error Help reports, Prompt Only final prompt extraction, RTX Video Super Resolution, RTX Super Resolution, Video SR/VSR, NVIDIA VFX/nvvfx, RTX upscale helpers, LTX 2.3 and LTX 2.5 model/workflow helpers, LTX tiled second-pass refinement helpers, Bernini Prompt Guide, audio/image review gates, Bernini conditioning helpers, Wan 2.2 reference video edit workflows, image and video compare, video preview, Video to GIF/WebP tools, multi-image loading, resize tools, LoRA/model helpers, prompt guides, and visual workflow utilities."
-version = "0.7.88"
+version = "0.7.89"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = ["openai-whisper>=20250625"]

--- a/tests/test_local_llm_regressions.py
+++ b/tests/test_local_llm_regressions.py
@@ -177,6 +177,7 @@ def test_local_llm_refine_preserves_system_and_user_prompts_when_adding_duration
 
     assert len(calls) == 1
     assert calls[0]["system_prompt"] == "Keep this system instruction unchanged."
+    assert calls[0]["length_request_prompt"] == "Direct a natural performance."
     assert calls[0]["prompt"] == (
         "Direct a natural performance.\n\n"
         "This is an 8-second video.\n\n"
@@ -458,6 +459,15 @@ def _ollama_envelope(answer):
     return json.dumps({"deno_final_answer": answer}, ensure_ascii=False)
 
 
+ISSUE_77_FRENCH_LONG_FORM_PROMPT = (
+    "Écris un long texte de 800 mots sur l'intelligence artificielle"
+)
+
+
+def _synthetic_long_answer(word_count, prefix="mot"):
+    return " ".join(f"{prefix}{index}" for index in range(word_count))
+
+
 def _run_lm_studio_kwargs(**overrides):
     kwargs = {
         "server_url": "http://127.0.0.1:1234/v1",
@@ -491,16 +501,21 @@ def _lm_studio_content_chunk(content="", reasoning="", finish_reason=None):
 
 
 @pytest.mark.parametrize("thinking", [False, True])
-def test_local_llm_ollama_uses_structured_final_answer_contract(monkeypatch, thinking):
+def test_local_llm_ollama_long_form_uses_strengthened_structured_contract(
+    monkeypatch,
+    thinking,
+):
     package = load_package()
     module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
     node = package.DenoLocalLLMRefiner()
     payloads = []
     progress = []
 
+    final_answer = _synthetic_long_answer(800, prefix="réponse")
+
     def fake_stream(_url, payload, **_kwargs):
         payloads.append(payload)
-        message = {"content": _ollama_envelope("clean final answer")}
+        message = {"content": _ollama_envelope(final_answer)}
         if thinking:
             message["thinking"] = "private reasoning"
         yield {"message": message, "done": False}
@@ -510,36 +525,89 @@ def test_local_llm_ollama_uses_structured_final_answer_contract(monkeypatch, thi
     monkeypatch.setattr(module, "_send_progress", lambda event: progress.append(dict(event)))
     monkeypatch.setattr(module, "_ensure_ollama_model_stays_loaded", lambda **_kwargs: {"checked": False})
 
-    answer, thought, _raw = node._run_ollama(**_run_ollama_kwargs(thinking=thinking))
+    answer, thought, _raw = node._run_ollama(
+        **_run_ollama_kwargs(
+            model="ministral-3:3b",
+            system_prompt="",
+            prompt=ISSUE_77_FRENCH_LONG_FORM_PROMPT,
+            thinking=thinking,
+        )
+    )
 
-    assert answer == "clean final answer"
+    assert answer == final_answer
     assert thought == ("private reasoning" if thinking else "")
     assert len(payloads) == 1
     assert payloads[0]["think"] is thinking
-    assert payloads[0]["format"] == {
-        "type": "object",
-        "properties": {
-            "deno_final_answer": {
-                "type": "string",
-                "description": (
-                    "Only the complete final answer requested by the original system and user "
-                    "messages. Never include private chain-of-thought, hidden reasoning, scratch "
-                    "work, or internal deliberation. Include an answer-facing explanation or "
-                    "requested visible formatting only when the original request requires it; "
-                    "exclude provider preambles, transport labels, and process commentary."
-                ),
-            }
-        },
-        "required": ["deno_final_answer"],
-        "additionalProperties": False,
-    }
-    assert payloads[0]["messages"][0]["content"].startswith("Keep the user's requested format.")
+    assert payloads[0]["format"] == module._final_answer_schema()
     contract = payloads[0]["messages"][0]["content"]
-    assert "only the completed answer requested by the user" in contract
-    assert "Never include private chain-of-thought" in contract
-    assert "even if requested" in contract
-    assert "answer-facing explanation" in contract
+    serialized_schema = json.dumps(
+        module._final_answer_schema(),
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    assert contract.count(serialized_schema) == 1
+    for fidelity_requirement in (
+        "requested language",
+        "target word or character count",
+        "length",
+        "level of detail",
+        "sections",
+        "visible formatting",
+    ):
+        assert fidelity_requirement in contract
+    assert "concise" not in contract.lower()
+    assert payloads[0]["messages"][1]["content"] == ISSUE_77_FRENCH_LONG_FORM_PROMPT
+    assert payloads[0]["options"] == {"seed": 7}
+    assert "num_predict" not in payloads[0]
+    assert "stop" not in payloads[0]
     assert all(event["answer"] == "" for event in progress)
+
+
+@pytest.mark.parametrize("user_system_prompt", ["", "Keep the user's requested format."])
+def test_local_llm_ollama_ordinary_prompt_keeps_legacy_system_contract_byte_for_byte(
+    monkeypatch,
+    user_system_prompt,
+):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    payloads = []
+
+    def fake_stream(_url, payload, **_kwargs):
+        payloads.append(payload)
+        yield {"message": {"content": _ollama_envelope("ordinary final answer")}, "done": False}
+        yield {"done": True, "done_reason": "stop"}
+
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(module, "_send_progress", lambda _event: None)
+    monkeypatch.setattr(module, "_ensure_ollama_model_stays_loaded", lambda **_kwargs: {"checked": False})
+
+    answer, thought, raw = node._run_ollama(
+        **_run_ollama_kwargs(
+            system_prompt=user_system_prompt,
+            prompt="Explain artificial intelligence briefly.",
+        )
+    )
+
+    expected_contract = module.STRUCTURED_FINAL_ANSWER_SYSTEM_INSTRUCTION
+    if user_system_prompt:
+        expected_contract = f"{user_system_prompt}\n\n{expected_contract}"
+    contract = payloads[0]["messages"][0]["content"]
+    serialized_schema = json.dumps(
+        module._final_answer_schema(),
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+    assert answer == "ordinary final answer"
+    assert thought == ""
+    assert len(payloads) == 1
+    assert contract == expected_contract
+    assert serialized_schema not in contract
+    assert "Required transport JSON schema" not in contract
+    assert "concise" in contract
+    assert module.OLLAMA_LONG_FORM_STRUCTURED_FINAL_ANSWER_SYSTEM_INSTRUCTION not in contract
+    assert "long_form_compatibility" not in raw
 
 
 @pytest.mark.parametrize(
@@ -608,6 +676,509 @@ def test_local_llm_ollama_preserves_multiline_and_reviewer_json_strings(monkeypa
     assert thought == ""
 
 
+def test_local_llm_ollama_800_word_structured_answer_round_trips_uneven_stream(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    final_answer = _synthetic_long_answer(800, prefix="élément")
+    encoded = _ollama_envelope(final_answer)
+    split_points = [1, 9, 37, 142, 503, 1021, len(encoded)]
+
+    def fake_stream(_url, _payload, **_kwargs):
+        start = 0
+        for end in split_points:
+            yield {"message": {"content": encoded[start:end]}, "done": False}
+            start = end
+        yield {
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": 51,
+            "eval_count": 936,
+        }
+
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(module, "_send_progress", lambda _event: None)
+    monkeypatch.setattr(module, "_ensure_ollama_model_stays_loaded", lambda **_kwargs: {"checked": False})
+
+    answer, thought, raw = node._run_ollama(
+        **_run_ollama_kwargs(
+            model="ministral-3:3b",
+            system_prompt="",
+            prompt=ISSUE_77_FRENCH_LONG_FORM_PROMPT,
+        )
+    )
+
+    assert answer.encode("utf-8") == final_answer.encode("utf-8")
+    assert thought == ""
+    assert raw["meta"] == {
+        "done": True,
+        "done_reason": "stop",
+        "prompt_eval_count": 51,
+        "eval_count": 936,
+    }
+    assert "final_answer_recovery" not in raw
+    assert "long_form_compatibility" not in raw
+
+
+def test_local_llm_ollama_short_structured_long_form_uses_one_plain_compatibility_retry(
+    monkeypatch,
+):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    payloads = []
+    progress = []
+    short_answer = "Introduction très courte sur l'intelligence artificielle."
+    long_answer = _synthetic_long_answer(800, prefix="développement")
+    image_attachments = [{
+        "base64": "issue-77-image-data",
+        "width": 1,
+        "height": 1,
+        "sent_width": 1,
+        "sent_height": 1,
+    }]
+    initial_meta = {
+        "done": True,
+        "done_reason": "stop",
+        "prompt_eval_count": 44,
+        "eval_count": 18,
+    }
+    retry_meta = {
+        "done": True,
+        "done_reason": "stop",
+        "prompt_eval_count": 57,
+        "eval_count": 912,
+    }
+
+    def fake_stream(_url, payload, **_kwargs):
+        payloads.append(json.loads(json.dumps(payload, ensure_ascii=False)))
+        if len(payloads) == 1:
+            yield {"message": {"content": _ollama_envelope(short_answer)}, "done": False}
+            yield initial_meta
+            return
+        yield {"message": {"content": long_answer}, "done": False}
+        yield retry_meta
+
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(module, "_send_progress", lambda event: progress.append(dict(event)))
+    monkeypatch.setattr(module, "_ensure_ollama_model_stays_loaded", lambda **_kwargs: {"checked": False})
+
+    answer, thought, raw = node._run_ollama(
+        **_run_ollama_kwargs(
+            model="ministral-3:3b",
+            system_prompt="",
+            prompt=ISSUE_77_FRENCH_LONG_FORM_PROMPT,
+            thinking=True,
+            image_attachments=image_attachments,
+        )
+    )
+
+    assert answer == long_answer
+    assert thought == ""
+    assert len(payloads) == 2
+    assert payloads[0]["format"] == module._final_answer_schema()
+    assert "format" not in payloads[1]
+    assert payloads[1]["think"] is False
+    assert payloads[1]["options"] == payloads[0]["options"] == {"seed": 7}
+    assert payloads[1]["messages"][1] == payloads[0]["messages"][1]
+    assert payloads[1]["messages"][1]["images"] == ["issue-77-image-data"]
+    assert payloads[1]["messages"][0]["content"] == module.PLAIN_FINAL_ANSWER_SYSTEM_INSTRUCTION
+    assert "Do not add a transport JSON wrapper" in payloads[1]["messages"][0]["content"]
+    assert "deno_final_answer" not in payloads[1]["messages"][0]["content"]
+    assert "Required transport JSON schema" not in payloads[1]["messages"][0]["content"]
+    compatibility = raw["long_form_compatibility"]
+    assert compatibility["attempted"] is True
+    assert compatibility["succeeded"] is True
+    assert compatibility["unit"] == "words"
+    assert compatibility["target"] == 800
+    assert compatibility["minimum_acceptable"] == 480
+    assert compatibility["initial_count"] == len(short_answer.split())
+    assert compatibility["final_count"] == 800
+    assert compatibility["initial_meta"] == initial_meta
+    assert compatibility["retry_meta"] == retry_meta
+    assert raw["meta"] == retry_meta
+    assert progress
+    assert all(event["answer"] == "" for event in progress)
+
+
+def test_local_llm_ollama_rejects_truncated_plain_fallback_even_above_minimum(
+    monkeypatch,
+):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    payloads = []
+    fallback_answer = _synthetic_long_answer(600, prefix="truncated")
+
+    def fake_stream(_url, payload, **_kwargs):
+        payloads.append(payload)
+        if len(payloads) == 1:
+            yield {"message": {"content": _ollama_envelope("Too short.")}, "done": False}
+            yield {"done": True, "done_reason": "stop"}
+            return
+        yield {"message": {"content": fallback_answer}, "done": False}
+        yield {"done": True, "done_reason": "length", "eval_count": 600}
+
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(module, "_send_progress", lambda _event: None)
+    monkeypatch.setattr(module, "_ensure_ollama_model_stays_loaded", lambda **_kwargs: {"checked": False})
+
+    with pytest.raises(RuntimeError, match=r"(?i)(truncat|done_reason|length)"):
+        node._run_ollama(
+            **_run_ollama_kwargs(
+                system_prompt="",
+                prompt=ISSUE_77_FRENCH_LONG_FORM_PROMPT,
+            )
+        )
+
+    assert len(payloads) == 2
+    assert "format" not in payloads[1]
+
+
+def test_local_llm_ollama_cancellation_before_plain_fallback_stops_after_one_request(
+    monkeypatch,
+):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    payloads = []
+    cancellation_checks = []
+
+    def fake_stream(_url, payload, **_kwargs):
+        payloads.append(payload)
+        yield {"message": {"content": _ollama_envelope("Too short.")}, "done": False}
+        yield {"done": True, "done_reason": "stop"}
+
+    def stop_before_retry(cancel_key):
+        cancellation_checks.append(cancel_key)
+        raise RuntimeError("Local LLM generation stopped.")
+
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(module, "_send_progress", lambda _event: None)
+    monkeypatch.setattr(module, "_raise_if_local_llm_stopped", stop_before_retry)
+    monkeypatch.setattr(module, "_ensure_ollama_model_stays_loaded", lambda **_kwargs: {"checked": False})
+
+    with pytest.raises(RuntimeError, match="Local LLM generation stopped"):
+        node._run_ollama(
+            **_run_ollama_kwargs(
+                system_prompt="",
+                prompt=ISSUE_77_FRENCH_LONG_FORM_PROMPT,
+            )
+        )
+
+    assert len(payloads) == 1
+    assert len(cancellation_checks) == 1
+
+
+def test_local_llm_ollama_unload_after_run_plain_fallback_owns_terminal_keep_alive(
+    monkeypatch,
+):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    payloads = []
+    explicit_unload_calls = []
+    cleanup_state = {"provider_cleanup_attempted": False}
+    fallback_answer = _synthetic_long_answer(800, prefix="complete")
+
+    def fake_stream(_url, payload, **_kwargs):
+        payloads.append(payload)
+        if len(payloads) == 1:
+            yield {"message": {"content": _ollama_envelope("Too short.")}, "done": False}
+            yield {"done": True, "done_reason": "stop"}
+            return
+        yield {"message": {"content": fallback_answer}, "done": False}
+        yield {"done": True, "done_reason": "stop"}
+
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(module, "_send_progress", lambda _event: None)
+    monkeypatch.setattr(module, "_ensure_ollama_model_stays_loaded", lambda **_kwargs: {"checked": False})
+    monkeypatch.setattr(
+        module,
+        "_ollama_unload_best_effort",
+        lambda *args: explicit_unload_calls.append(args),
+    )
+
+    answer, thought, raw = node._run_ollama(
+        **_run_ollama_kwargs(
+            system_prompt="",
+            prompt=ISSUE_77_FRENCH_LONG_FORM_PROMPT,
+            model_memory="Unload after run",
+            is_last=True,
+            cleanup_state=cleanup_state,
+        )
+    )
+
+    assert answer == fallback_answer
+    assert thought == ""
+    assert [payload["keep_alive"] for payload in payloads] == ["5m", "0m"]
+    assert explicit_unload_calls == []
+    assert cleanup_state["provider_cleanup_attempted"] is True
+    assert raw["post_run_unload"] == {"action": "none"}
+    assert raw["long_form_compatibility"]["succeeded"] is True
+
+
+def test_local_llm_ollama_near_target_structured_long_form_does_not_retry(monkeypatch):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    payloads = []
+    near_target_answer = _synthetic_long_answer(610, prefix="mot")
+
+    def fake_stream(_url, payload, **_kwargs):
+        payloads.append(payload)
+        yield {"message": {"content": _ollama_envelope(near_target_answer)}, "done": False}
+        yield {"done": True, "done_reason": "stop", "eval_count": 700}
+
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(module, "_send_progress", lambda _event: None)
+    monkeypatch.setattr(module, "_ensure_ollama_model_stays_loaded", lambda **_kwargs: {"checked": False})
+
+    answer, _thought, _raw = node._run_ollama(
+        **_run_ollama_kwargs(
+            system_prompt="",
+            prompt=ISSUE_77_FRENCH_LONG_FORM_PROMPT,
+        )
+    )
+
+    assert answer == near_target_answer
+    assert len(payloads) == 1
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "Explain artificial intelligence briefly.",
+        "Explain artificial intelligence in at most 800 words.",
+    ],
+)
+def test_local_llm_ollama_non_minimum_length_requests_do_not_trigger_plain_retry(
+    monkeypatch,
+    prompt,
+):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    payloads = []
+    short_answer = "A brief answer that satisfies the requested upper bound."
+
+    def fake_stream(_url, payload, **_kwargs):
+        payloads.append(payload)
+        yield {"message": {"content": _ollama_envelope(short_answer)}, "done": False}
+        yield {"done": True, "done_reason": "stop", "eval_count": 16}
+
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(module, "_send_progress", lambda _event: None)
+    monkeypatch.setattr(module, "_ensure_ollama_model_stays_loaded", lambda **_kwargs: {"checked": False})
+
+    answer, _thought, _raw = node._run_ollama(
+        **_run_ollama_kwargs(
+            system_prompt="",
+            prompt=prompt,
+        )
+    )
+
+    assert answer == short_answer
+    assert len(payloads) == 1
+
+
+@pytest.mark.parametrize(
+    ("system_prompt", "prompt"),
+    [
+        ("", "Translate the phrase '800 words' into French."),
+        ("", "Review the following source of 800 words and give concise feedback."),
+        ("", "The input is 800 words long. Return a short classification."),
+        ("", "This source contains 800 words. Summarize it in three bullets."),
+        (
+            "Return compact JSON: PASS when the source is at least 800 words.",
+            "Review this input.",
+        ),
+        ("", "다음 800단어 분량의 원문을 세 문장으로 요약해 주세요."),
+        ("", "将下面800字的原文总结为三点。"),
+        ("", "Write a critique of the 800-word article."),
+        ("", "Produce a summary of this 800-word article."),
+        ("", "Write a short review of John's 800-word essay."),
+        ("", "Summarize the provided 800-word article in three bullets."),
+        ("", "Return PASS if the following 800-word essay is coherent."),
+        ("", "Create a summary of an 800-word article."),
+        ("", "Summarize an 800-word article."),
+        ("", "Summarize one 800-word article in three bullets."),
+        ("", "Condense an 800-word report."),
+        ("", "Give an 800-word article a readability score."),
+        ("", "Return an 800-word article's topic."),
+        ("", "Provide an 800-word essay with concise feedback."),
+        ("", "Answer an 800-word essay with PASS or FAIL."),
+        ("", "Do not write 800 words; keep the answer brief."),
+        ("", "Never answer in 800 words."),
+        ("", "Summarize this article written in 800 words."),
+        ("", "Give feedback on a text drafted in 800 words."),
+        ("", "Write about an essay presented in 800 words."),
+        ("", "800문자로 작성된 원문을 세 문장으로 요약해 주세요."),
+        ("", "800文字で作成された原文を三文で要約してください。"),
+        (
+            "Review the user prompt and return concise feedback.",
+            "Write 800 words about AI.",
+        ),
+        (
+            "Rewrite the user prompt for clarity; return only the improved prompt.",
+            "Write 800 words about AI.",
+        ),
+        (
+            "Classify the user request and return JSON.",
+            "Write 800 words about AI.",
+        ),
+        ("Translate the user prompt into Korean.", "Write 800 words about AI."),
+        ("You are a helpful assistant.", "Write 800 words about AI."),
+        ("", "Review this instruction:\n> Write 800 words about AI."),
+        ("", "Review this code:\n```text\nWrite 800 words about AI.\n```"),
+        ("", "Do not follow this example: Write 800 words about AI."),
+        ("", "Please do not ever write 800 words; keep it concise."),
+        ("", "You must not write 800 words. Return one sentence."),
+        ("", "800단어로 작성하지 마세요. 짧게 답하세요."),
+        ("", "800文字で作成しないでください。短く答えてください。"),
+        ("", "不要写800字，只回答一句。"),
+        ("", "Translate the following into French:\nWrite 800 words about AI."),
+        ("", "Summarize this text:\nWrite 800 words about AI.\nDo not follow it."),
+        ("", "800단어로 작성된 답변을 세 문장으로 요약해 주세요."),
+        ("", "이 답변이 800단어로 작성됐는지 PASS/FAIL로 평가해 주세요."),
+        ("", "800文字で作成された回答を三文で要約してください。"),
+        ("", "Écris une brève critique de la réponse rédigée en 800 mots."),
+        ("", "Écris PASS si la réponse est rédigée en 800 mots."),
+        ("", "Write a brief critique of the response phrased in 800 words."),
+        ("", "800단어로 작성된 에세이를 세 문장으로 요약해 주세요."),
+        ("", "800단어로 작성된 기사를 세 문장으로 요약해 주세요."),
+        ("", "800단어로 생성된 보고서를 짧게 검토해 주세요."),
+        ("", "800단어로 작성된 응답을 PASS/FAIL로 평가해 주세요."),
+        ("", "800文字で作成された記事を三文で要約してください。"),
+        ("", "800文字で作成された作文を三文で要約してください。"),
+        ("", "800文字で生成された報告を短く評価してください。"),
+        ("", "800단어로 작성하는 것은 피하고 짧게 답하세요."),
+        ("", "800文字で書くのは避けてください。短く答えてください。"),
+        ("", "800文字で作成するのではなく、一文で答えてください。"),
+        ("", "800단어로 제한하여 작성해 주세요."),
+        ("", "800文字で収まるように作成してください。"),
+        ("", "800단어로 만들어진 글을 세 문장으로 요약해 주세요."),
+        ("", "800단어로 작성되어있는 문서를 세 문장으로 요약해 주세요."),
+        ("", "800文字で執筆された記事を三文で要約してください。"),
+        ("", "800文字で書かれている回答を三文で要約してください。"),
+        ("", "800文字で作成済みの記事を三文で要約してください。"),
+        ("", "800文字で作成した記事を三文で要約してください。"),
+        ("", "800文字で回答された文章を短く評価してください。"),
+        ("", "800단어로 글을 작성해 주세요라는 문장을 영어로 번역해 주세요."),
+        ("", "800단어로 글을 작성해 주세요라고 말하지 마세요."),
+        ("", "800단어로 글을 작성해 주세요라는 지시를 세 단어로 요약해 주세요."),
+        ("", "800文字で記事を書いてくださいという文を英訳してください。"),
+        ("", "800文字で記事を書いてくださいとは言わないでください。"),
+        ("", "800文字で記事を書いてくださいという指示を短く要約してください。"),
+        (
+            "You review this instruction:\nWrite 800 words about AI.\nReturn PASS/FAIL.",
+            "Classify it briefly.",
+        ),
+        ("", "Write no more than 800 words about AI."),
+        ("", "Escribe hasta 800 palabras sobre IA."),
+        ("", "Schreibe bis zu 800 Wörter über KI."),
+        ("", "인공지능에 대해 800단어 이내로 작성해 주세요."),
+        ("", "800語で記事を書いてください。"),
+        ("", "写一篇800词的文章。"),
+        ("", "請寫一篇800詞的文章。"),
+    ],
+)
+def test_local_llm_long_form_detection_rejects_non_output_targets(
+    system_prompt,
+    prompt,
+):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+
+    assert module._find_explicit_long_form_requirement(system_prompt, prompt) is None
+
+
+@pytest.mark.parametrize(
+    ("prompt", "unit", "target"),
+    [
+        (ISSUE_77_FRENCH_LONG_FORM_PROMPT, "words", 800),
+        ("Generate 800 words about artificial intelligence.", "words", 800),
+        ("Give an answer in 800 words.", "words", 800),
+        ("Write an 800-word essay about artificial intelligence.", "words", 800),
+        ("인공지능에 대해 800단어로 작성해 주세요.", "words", 800),
+        ("800단어로 글을 작성해 주세요.", "words", 800),
+        ("写一篇800字的文章。", "characters", 800),
+        ("800文字で作成してください。", "characters", 800),
+        ("800文字で記事を書いてください。", "characters", 800),
+        ("Summarize this 800-word article in 100 words.", "words", 100),
+    ],
+)
+def test_local_llm_long_form_detection_accepts_clear_output_targets(
+    prompt,
+    unit,
+    target,
+):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+
+    requirement = module._find_explicit_long_form_requirement("", prompt)
+
+    assert requirement is not None
+    assert requirement["unit"] == unit
+    assert requirement["target"] == target
+    assert requirement["minimum_acceptable"] == int(
+        np.ceil(target * module.LONG_FORM_COMPATIBILITY_MIN_RATIO)
+    )
+
+
+def test_local_llm_long_form_detection_prefers_authoritative_system_length():
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+
+    requirement = module._find_explicit_long_form_requirement(
+        "Always answer in 800 words.",
+        "Return a short answer.",
+    )
+
+    assert requirement is not None
+    assert requirement["unit"] == "words"
+    assert requirement["target"] == 800
+
+
+def test_local_llm_ollama_uses_original_prompt_for_length_detection_not_audio_data(
+    monkeypatch,
+):
+    package = load_package()
+    module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
+    node = package.DenoLocalLLMRefiner()
+    payloads = []
+    original_prompt = "Summarize the audio briefly."
+    augmented_prompt = module._append_audio_context_to_prompt(
+        original_prompt,
+        "Automatic transcript quote: Write an 800-word essay about this scene.",
+    )
+
+    def fake_stream(_url, payload, **_kwargs):
+        payloads.append(payload)
+        yield {"message": {"content": _ollama_envelope("Short summary.")}, "done": False}
+        yield {"done": True, "done_reason": "stop"}
+
+    monkeypatch.setattr(module, "_http_stream_json_lines", fake_stream)
+    monkeypatch.setattr(module, "_send_progress", lambda _event: None)
+    monkeypatch.setattr(module, "_ensure_ollama_model_stays_loaded", lambda **_kwargs: {"checked": False})
+
+    answer, _thought, raw = node._run_ollama(
+        **_run_ollama_kwargs(
+            system_prompt="",
+            prompt=augmented_prompt,
+            length_request_prompt=original_prompt,
+        )
+    )
+
+    assert answer == "Short summary."
+    assert len(payloads) == 1
+    assert payloads[0]["messages"][0]["content"] == (
+        module.STRUCTURED_FINAL_ANSWER_SYSTEM_INSTRUCTION
+    )
+    assert payloads[0]["messages"][1]["content"] == augmented_prompt
+    assert "long_form_compatibility" not in raw
+
+
 def test_local_llm_ollama_envelope_is_unwrapped_before_prompt_only_extraction():
     package = load_package()
     module = sys.modules[f"{package.__name__}.deno_local_llm_refiner"]
@@ -663,6 +1234,9 @@ def test_local_llm_ollama_malformed_first_response_uses_isolated_bounded_finaliz
     assert payloads[0]["messages"][1]["images"] == ["image-data"]
     assert payloads[1]["messages"][:2] == payloads[0]["messages"]
     assert payloads[1]["messages"][-2]["content"] == "unwanted preamble"
+    assert payloads[1]["messages"][-1]["content"] == (
+        module.STRUCTURED_FINALIZATION_INSTRUCTION
+    )
     assert raw["final_answer_recovery"]["attempted"] is True
 
 
@@ -1680,21 +2254,27 @@ def test_lm_studio_uses_chat_completions_structured_contract(monkeypatch, thinki
     calls = []
     progress = []
 
+    final_answer = _synthetic_long_answer(800, prefix="réponse")
+
     def fake_stream(url, payload, **kwargs):
         calls.append((url, payload, kwargs))
         if thinking:
             yield _lm_studio_content_chunk(reasoning="private reasoning")
-        yield _lm_studio_content_chunk(content=_ollama_envelope("clean final answer"))
+        yield _lm_studio_content_chunk(content=_ollama_envelope(final_answer))
         yield _lm_studio_content_chunk(finish_reason="stop")
 
     monkeypatch.setattr(module, "_http_stream_sse", fake_stream)
     monkeypatch.setattr(module, "_send_progress", lambda event: progress.append(dict(event)))
 
     answer, thought, raw = node._run_lm_studio(
-        **_run_lm_studio_kwargs(thinking=thinking)
+        **_run_lm_studio_kwargs(
+            system_prompt="Keep the user's requested format.",
+            prompt=ISSUE_77_FRENCH_LONG_FORM_PROMPT,
+            thinking=thinking,
+        )
     )
 
-    assert answer == "clean final answer"
+    assert answer == final_answer
     assert thought == ("private reasoning" if thinking else "")
     assert len(calls) == 1
     url, payload, kwargs = calls[0]
@@ -1703,9 +2283,24 @@ def test_lm_studio_uses_chat_completions_structured_contract(monkeypatch, thinki
     assert payload["reasoning_effort"] == effort
     assert payload["seed"] == 7
     assert payload["response_format"] == module._openai_final_answer_response_format()
-    assert payload["messages"][0]["content"].startswith("Keep the user's requested format.")
+    contract = payload["messages"][0]["content"]
+    serialized_schema = json.dumps(
+        module._final_answer_schema(),
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    assert contract == (
+        "Keep the user's requested format.\n\n"
+        f"{module.STRUCTURED_FINAL_ANSWER_SYSTEM_INSTRUCTION}"
+    )
+    assert serialized_schema not in contract
+    assert "Required transport JSON schema" not in contract
+    assert "concise" in contract
+    assert module.OLLAMA_LONG_FORM_STRUCTURED_FINAL_ANSWER_SYSTEM_INSTRUCTION not in contract
+    assert payload["messages"][1]["content"] == ISSUE_77_FRENCH_LONG_FORM_PROMPT
     assert raw["reasoning_effort"] == effort
     assert raw["api"] == "LM Studio /v1/chat/completions"
+    assert "long_form_compatibility" not in raw
     assert all(event["answer"] == "" for event in progress)
 
 


### PR DESCRIPTION
## Summary

- preserve explicit Ollama long-form word and character targets when structured output would otherwise collapse them to a very short answer
- activate the compatibility path only for high-confidence output-length directives, while keeping ordinary Ollama requests and the LM Studio contract unchanged
- make at most one Ollama-only schema-free retry, preserving the original prompt, images, seed, cancellation, progress hiding, and unload behavior
- keep reviewer/refiner, rewrite, classify, translate, summarize, quoted/example, passive-source, negated, upper-bound, and audio-context cases on their prior behavior

## Compatibility

There are no public node ID, input/output, widget order, serialized workflow, frontend, or persistence changes. Ambiguous length wording deliberately falls back to the previous behavior instead of guessing.

## Validation

- Python suite: 716 passed
- Local LLM focused suite: 202 passed
- multilingual/adversarial length-intent matrix: 69/69 expected classifications
- Local LLM JavaScript async harness: passed
- JavaScript syntax and Python compile checks: passed
- `git diff --check`: passed
- expected Registry package manifest remains 422 files

Addresses #77