### PR TITLE
v0.7.92: MiniMax H3 Acc LoRA Loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file intentionally stays short. Detailed engineering notes belong in privat
 
 ## Unreleased
 
+## 0.7.92 - 2026-08-27
+
+- Added `(Deno) MiniMax H3 Acc LoRA Loader` for direct use of Alibaba PAI's official FL2VA and Ref2VA Acc-LoRA/PDD safetensors with full native ComfyUI MiniMax H3 models. The node applies the complete adapter, automatically returns Euler and the trained 8-step sigma schedule, and rejects incompatible pruned models or schedules; LoRA weights and workflows are not bundled.
+
 ## 0.7.91 - 2026-08-24
 
 - Reworked `(Deno) Text Encoder Unload` from the v0.7.90 wildcard `value` pass-through plus dependency-only `wait_for` into the typed prompt paths used by normal workflows: required `Positive Conditioning` and optional `Negative Conditioning`, with the latter accepting either an encoded negative prompt or `Conditioning Zero Out` and both paths available as named outputs.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,19 @@ The dedicated H3 socket is intentional: a normal ComfyUI `IMAGE` batch requires 
 
 These two MiniMax H3 nodes require ComfyUI 0.30.0 or newer. See the portable [MiniMax H3 multi-reference workflow](docs/workflows/minimax-h3-multi-reference.json) for the complete native H3 pipeline with the two stock `Load Image` nodes replaced by the one-cable DENO loader.
 
+### `(Deno) MiniMax H3 Acc LoRA Loader`
+
+Directly loads Alibaba PAI's official [MiniMax-H3-Acc-LoRAs](https://huggingface.co/alibaba-pai/MiniMax-H3-Acc-LoRAs) without converting or duplicating the safetensors file.
+
+1. Download the official FL2VA or Ref2VA `Acc-8Step.safetensors` file and place it in `ComfyUI/models/minimax_h3_acc_loras/`.
+2. Connect a matching full, non-pruned native MiniMax H3 diffusion model to `model`.
+3. Select the matching Acc-LoRA: FL2VA for FL2VA/T2VA, or Ref2VA for Ref2VA.
+4. Connect this node's `model`, `sampler`, and `sigmas` outputs to the normal guider and `SamplerCustomAdvanced` path.
+
+The node applies the static LoRA weights and the checkpoint's time-dependent PDD output heads, then automatically returns Euler plus the exact trained 8-step sigma schedule. There is no sampler or step widget to configure. The current official checkpoints require LoRA strength `1.0`, video/audio sigma shifts `12.0 / 3.0`, and their exact schedule; another schedule is rejected instead of being approximated silently. The node also rejects pruned H3 models because the official adapters require the full-width AdaLN layers.
+
+LoRA weights and workflows are not bundled with Deno Custom Nodes. Download the weights from Alibaba and build or adapt your own native ComfyUI workflow.
+
 ### MiniMax H3 R2V Audio Reference workflow
 
 The [beginner audio-reference workflow](docs/workflows/minimax-h3-r2v-audio-reference.json) keeps ComfyUI's stock MiniMax H3 reference-audio path and adds an automatic prompt-direction lane:

--- a/__init__.py
+++ b/__init__.py
@@ -485,6 +485,11 @@ _OPTIONAL_NODES = (
         "DenoMiniMaxH3ReferenceToVideo",
         "(Deno) MiniMax H3 Reference to Video",
     ),
+    (
+        "deno_minimax_h3_acc_loader",
+        "DenoMiniMaxH3AccLoader",
+        "(Deno) MiniMax H3 Acc LoRA Loader",
+    ),
     ("deno_audio_transcript", "DenoAudioTranscript", "(Deno) Audio Transcript"),
     (
         "deno_audio_analysis_finalize",
@@ -527,12 +532,12 @@ for _module_name, _class_name, _display_name in _OPTIONAL_NODES:
         _module = importlib.import_module(f".{_module_name}", __name__)
         _node_class = getattr(_module, _class_name)
     except Exception as _exc:
-        if _module_name.startswith("deno_minimax_h3") and _module_name not in _OPTIONAL_REQUIREMENT_WARNED:
+        if _module_name.startswith("deno_minimax_h3") and "minimax_h3" not in _OPTIONAL_REQUIREMENT_WARNED:
             logging.warning(
                 "[DENO] MiniMax H3 nodes require ComfyUI >= 0.30.0; "
                 "update ComfyUI before using these nodes."
             )
-            _OPTIONAL_REQUIREMENT_WARNED.add(_module_name)
+            _OPTIONAL_REQUIREMENT_WARNED.add("minimax_h3")
         logging.warning(
             "[DENO] Skipped node %s (%s): %s: %s",
             _class_name,

--- a/deno_minimax_h3_acc_loader.py
+++ b/deno_minimax_h3_acc_loader.py
@@ -1,0 +1,277 @@
+"""Direct loader for Alibaba MiniMax H3 PDD acceleration checkpoints."""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+
+import torch
+import torch.nn.functional as functional
+
+import comfy.patcher_extension
+import comfy.samplers
+import comfy.utils
+import comfy.weight_adapter
+from comfy.ldm.minimax.model import MiniMaxH3Model
+import folder_paths
+
+from .deno_minimax_h3_pdd_core import (
+    AUDIO_SHIFT,
+    VIDEO_SHIFT,
+    FusedPDDHeads,
+    audio_inner_velocity_factor,
+    build_patch_specs,
+    fuse_heads,
+    select_exact_step,
+    validate_checkpoint,
+)
+
+
+LOGGER = logging.getLogger("deno.minimax_h3_acc")
+MODEL_FOLDER = "minimax_h3_acc_loras"
+WRAPPER_KEY = "deno_minimax_h3_acc_pdd"
+
+
+def _register_model_paths() -> None:
+    default_path = os.path.join(folder_paths.models_dir, MODEL_FOLDER)
+    folder_paths.add_model_folder_path(MODEL_FOLDER, default_path, is_default=True)
+    for lora_path in folder_paths.get_folder_paths("loras"):
+        sibling = os.path.join(os.path.dirname(lora_path), MODEL_FOLDER)
+        folder_paths.add_model_folder_path(MODEL_FOLDER, sibling)
+    folder_paths.folder_names_and_paths[MODEL_FOLDER][1].add(".safetensors")
+
+
+_register_model_paths()
+
+
+class _DeviceHeadCache:
+    def __init__(self, heads: FusedPDDHeads):
+        self.heads = heads
+        self.cache: dict[str, tuple[torch.Tensor, ...]] = {}
+
+    def for_device(self, device) -> tuple[torch.Tensor, ...]:
+        key = str(torch.device(device))
+        cached = self.cache.get(key)
+        if cached is None:
+            cached = tuple(
+                tensor.to(device=device, dtype=torch.float32, non_blocking=True)
+                for tensor in (
+                    self.heads.video_weight,
+                    self.heads.video_bias,
+                    self.heads.audio_weight,
+                    self.heads.audio_bias,
+                )
+            )
+            self.cache[key] = cached
+        return cached
+
+    def clear(self) -> None:
+        self.cache.clear()
+
+
+class _PDDRuntime:
+    def __init__(self, heads: FusedPDDHeads):
+        self.heads = heads
+        self.device_heads = _DeviceHeadCache(heads)
+        self.sigma_v: torch.Tensor | None = None
+        self.transformer_options: dict | None = None
+        self.shift_video = VIDEO_SHIFT
+        self.shift_audio = AUDIO_SHIFT
+
+    def __call__(self, executor, *args, **kwargs):
+        timestep = args[1] if len(args) > 1 else kwargs.get("timestep")
+        transformer_options = args[3] if len(args) > 3 else kwargs.get("transformer_options", {})
+        if timestep is None:
+            raise RuntimeError("MiniMax H3 Acc wrapper did not receive a timestep")
+        transformer_options = transformer_options or {}
+        shift_video = float(transformer_options.get("minimax_h3_sigma_shift_video", VIDEO_SHIFT))
+        shift_audio = float(transformer_options.get("minimax_h3_sigma_shift_audio", AUDIO_SHIFT))
+        if not (
+            math.isclose(shift_video, VIDEO_SHIFT, rel_tol=0.0, abs_tol=1.0e-9)
+            and math.isclose(shift_audio, AUDIO_SHIFT, rel_tol=0.0, abs_tol=1.0e-9)
+        ):
+            raise ValueError(
+                "Alibaba MiniMax H3 Acc requires sigma shifts video=12.0 and audio=3.0; "
+                f"got {shift_video}/{shift_audio}"
+            )
+        self.shift_video = shift_video
+        self.shift_audio = shift_audio
+        self.sigma_v = (timestep.flatten()[0] / 1000.0).float()
+        self.transformer_options = transformer_options
+        try:
+            return executor(*args, **kwargs)
+        finally:
+            self.sigma_v = None
+            self.transformer_options = None
+
+    def current_step(self) -> tuple[int, float, float]:
+        if self.sigma_v is None or self.transformer_options is None:
+            raise RuntimeError("MiniMax H3 Acc final head ran outside an active diffusion call")
+        sample_sigmas = self.transformer_options.get("sample_sigmas")
+        if sample_sigmas is None or sample_sigmas.numel() < 2:
+            raise ValueError("MiniMax H3 Acc requires SamplerCustomAdvanced with the node's SIGMAS output")
+        flat = sample_sigmas.flatten()
+        current = float(self.sigma_v.detach().item())
+        distances = (flat[:-1].to(self.sigma_v.device) - self.sigma_v).abs()
+        index = int(distances.argmin().item())
+        next_sigma = float(flat[index + 1].detach().item())
+        block = select_exact_step(current, next_sigma, self.heads.sigmas_video)
+        return block, current, next_sigma
+
+    def to(self, _device):
+        return self
+
+    def cleanup(self, **_kwargs):
+        self.device_heads.clear()
+
+
+def _make_final_forward(runtime: _PDDRuntime):
+    def pdd_final_forward(self, x, t_emb, video_seg, audio_seg):
+        shift, scale = self.adaln_proj(t_emb)
+        va, vb, vrow = video_seg
+        aa, ab, arow = audio_seg
+        hv = (self.norm(x[va:vb]) * (1.0 + scale[vrow]) + shift[vrow]).to(torch.float32)
+        ha = (self.norm(x[aa:ab]) * (1.0 + scale[arow]) + shift[arow]).to(torch.float32)
+
+        block, current, next_sigma = runtime.current_step()
+        video_w, video_b, audio_w, audio_b = runtime.device_heads.for_device(hv.device)
+        displacement_video = functional.linear(hv, video_w[block], video_b[block])
+        displacement_audio = functional.linear(ha, audio_w[block], audio_b[block])
+        dsig_video = current - next_sigma
+        video_velocity = displacement_video / dsig_video
+        audio_velocity = displacement_audio * audio_inner_velocity_factor(
+            current,
+            next_sigma,
+            runtime.shift_video,
+            runtime.shift_audio,
+        )
+        return video_velocity, audio_velocity
+
+    return pdd_final_forward
+
+
+class DenoMiniMaxH3AccLoader:
+    """Apply the complete Alibaba PDD adapter and emit its exact Euler schedule."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        files = folder_paths.get_filename_list(MODEL_FOLDER)
+        return {
+            "required": {
+                "model": ("MODEL",),
+                "acc_lora": (
+                    files,
+                    {
+                        "tooltip": (
+                            "Alibaba MiniMax-H3 Acc-LoRA. Match FL2VA with FL2VA/T2VA models "
+                            "and Ref2VA with Ref2VA models."
+                        )
+                    },
+                ),
+            }
+        }
+
+    RETURN_TYPES = ("MODEL", "SAMPLER", "SIGMAS")
+    RETURN_NAMES = ("model", "sampler", "sigmas")
+    FUNCTION = "apply"
+    CATEGORY = "Deno/MiniMax H3"
+    DESCRIPTION = (
+        "Loads one official Alibaba MiniMax-H3 Acc safetensors directly, applies all LoRA "
+        "weights and PDD heads, and returns the trained 8-step Euler sampler/sigmas."
+    )
+
+    @classmethod
+    def IS_CHANGED(cls, model, acc_lora):
+        del model
+        path = folder_paths.get_full_path(MODEL_FOLDER, acc_lora)
+        if path is None:
+            return float("nan")
+        stat = os.stat(path)
+        return f"{os.path.abspath(path)}:{stat.st_size}:{stat.st_mtime_ns}"
+
+    def apply(self, model, acc_lora):
+        path = folder_paths.get_full_path_or_raise(MODEL_FOLDER, acc_lora)
+        state, metadata = comfy.utils.load_torch_file(
+            path,
+            safe_load=True,
+            device=torch.device("cpu"),
+            return_metadata=True,
+        )
+        config, pairs = validate_checkpoint(state, metadata)
+
+        model_clone = model.clone()
+        diffusion_model = model_clone.get_model_object("diffusion_model")
+        if not isinstance(diffusion_model, MiniMaxH3Model):
+            raise TypeError("DENO MiniMax H3 Acc Loader can only patch a native ComfyUI MiniMax H3 model")
+        if diffusion_model.use_adaln_curves:
+            raise ValueError(
+                "This Alibaba Acc-LoRA contains full-width AdaLN adapters. "
+                "Select a non-pruned FL2VA/Ref2VA diffusion model."
+            )
+
+        model_state = model_clone.model.state_dict()
+        specs = build_patch_specs(pairs, model_state)
+        patches = {}
+        for spec in specs:
+            adapter = comfy.weight_adapter.LoRAAdapter(
+                set(spec.source_keys),
+                (spec.up, spec.down, config.alpha, None, None, None),
+            )
+            patches[spec.patch_key] = adapter
+        accepted = set(model_clone.add_patches(patches, strength_patch=1.0, strength_model=1.0))
+        missing = set(patches) - accepted
+        if missing:
+            preview = ", ".join(str(item) for item in list(missing)[:5])
+            raise RuntimeError(f"ComfyUI refused {len(missing)} MiniMax H3 Acc patches, e.g. {preview}")
+
+        heads = fuse_heads(state, config)
+        runtime = _PDDRuntime(heads)
+        final_layer = diffusion_model.final_layer
+        bound_forward = _make_final_forward(runtime).__get__(final_layer, final_layer.__class__)
+        if hasattr(model_clone, "remove_wrappers_with_key"):
+            model_clone.remove_wrappers_with_key(
+                comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL,
+                WRAPPER_KEY,
+            )
+        model_clone.add_wrapper_with_key(
+            comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL,
+            WRAPPER_KEY,
+            runtime,
+        )
+        model_clone.add_object_patch("diffusion_model.final_layer.forward", bound_forward)
+        model_clone.set_attachments(
+            "deno_minimax_h3_acc",
+            {
+                "path": path,
+                "metadata": dict(metadata or {}),
+                "lora_pairs": len(pairs),
+                "patches": len(specs),
+                "nfe": config.nfe,
+            },
+        )
+
+        sigmas = torch.tensor(heads.sigmas_video, dtype=torch.float32, device="cpu")
+        sigmas[-1] = 0.0
+        sampler = comfy.samplers.sampler_object("euler")
+        variant = "Ref2VA" if "ref2va" in acc_lora.lower() else "FL2VA/T2VA"
+        LOGGER.info(
+            "Loaded %s | %s | LoRA pairs=%d | grid=%d | block=%d | NFE=%d | "
+            "sampler=Euler | shifts=12/3 | strength=1.0",
+            os.path.basename(path),
+            variant,
+            len(pairs),
+            config.num_steps,
+            config.block_size,
+            config.nfe,
+        )
+        return model_clone, sampler, sigmas
+
+
+NODE_CLASS_MAPPINGS = {
+    "DenoMiniMaxH3AccLoader": DenoMiniMaxH3AccLoader,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "DenoMiniMaxH3AccLoader": "(Deno) MiniMax H3 Acc LoRA Loader",
+}

--- a/deno_minimax_h3_pdd_core.py
+++ b/deno_minimax_h3_pdd_core.py
@@ -1,0 +1,321 @@
+"""Validation, mapping, and schedule math for Alibaba MiniMax H3 PDD.
+
+The released checkpoint contains ordinary low-rank updates plus one complete
+video/audio output projection per interval. ComfyUI stores Q/K/V in a fused
+matrix and uses the opposite SwiGLU half order from the Diffusers checkpoint,
+so both layouts must be mapped explicitly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import re
+from typing import Mapping
+
+import torch
+
+
+VIDEO_SHIFT = 12.0
+AUDIO_SHIFT = 3.0
+
+HEAD_KEYS = {
+    "proj_out.weight",
+    "proj_out.bias",
+    "audio_proj_out.weight",
+    "audio_proj_out.bias",
+}
+
+SUPPORTED_TARGETS = {
+    "to_q",
+    "to_k",
+    "to_v",
+    "to_out.0",
+    "ff.net.0.proj",
+    "ff.net.2",
+    "adaln_proj.linear",
+}
+
+_TRANSFORMER = re.compile(r"^transformer_blocks\.(\d+)\.(.+)$")
+_REFINER = re.compile(r"^token_refiner\.refiner_blocks\.(\d+)\.(.+)$")
+
+
+@dataclass(frozen=True)
+class PDDConfig:
+    num_steps: int
+    block_size: int
+    rank: int
+    alpha: float
+    targets: tuple[str, ...]
+
+    @property
+    def nfe(self) -> int:
+        return self.num_steps // self.block_size
+
+
+@dataclass(frozen=True)
+class PatchSpec:
+    patch_key: object
+    up: torch.Tensor
+    down: torch.Tensor
+    source_keys: tuple[str, str]
+
+
+@dataclass(frozen=True)
+class FusedPDDHeads:
+    video_weight: torch.Tensor
+    video_bias: torch.Tensor
+    audio_weight: torch.Tensor
+    audio_bias: torch.Tensor
+    sigmas_video: tuple[float, ...]
+    sigmas_audio: tuple[float, ...]
+    dsum_video: tuple[float, ...]
+    dsum_audio: tuple[float, ...]
+    config: PDDConfig
+
+
+def _required_int(metadata: Mapping[str, str], key: str) -> int:
+    try:
+        value = int(metadata[key])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(f"MiniMax H3 Acc metadata '{key}' must be an integer") from exc
+    if value < 1:
+        raise ValueError(f"MiniMax H3 Acc metadata '{key}' must be positive")
+    return value
+
+
+def parse_config(metadata: Mapping[str, str] | None) -> PDDConfig:
+    if not metadata:
+        raise ValueError("MiniMax H3 Acc checkpoint has no safetensors metadata")
+    num_steps = _required_int(metadata, "pdd_num_steps")
+    block_size = _required_int(metadata, "pdd_block_size")
+    rank = _required_int(metadata, "lora_rank")
+    try:
+        alpha = float(metadata["lora_alpha"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("MiniMax H3 Acc metadata 'lora_alpha' must be numeric") from exc
+    if not math.isfinite(alpha) or alpha <= 0.0:
+        raise ValueError("MiniMax H3 Acc metadata 'lora_alpha' must be finite and positive")
+    if num_steps % block_size:
+        raise ValueError(
+            f"pdd_num_steps={num_steps} must be divisible by pdd_block_size={block_size}"
+        )
+    raw_targets = metadata.get("lora_targets", "")
+    targets = tuple(part.strip() for part in raw_targets.split(",") if part.strip())
+    if set(targets) != SUPPORTED_TARGETS:
+        raise ValueError(
+            "Unsupported MiniMax H3 Acc target contract: "
+            f"expected {sorted(SUPPORTED_TARGETS)}, got {sorted(set(targets))}"
+        )
+    return PDDConfig(num_steps, block_size, rank, alpha, targets)
+
+
+def lora_pairs(
+    state: Mapping[str, torch.Tensor],
+    config: PDDConfig,
+) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
+    grouped: dict[str, dict[str, torch.Tensor]] = {}
+    unknown = []
+    for key, tensor in state.items():
+        if key in HEAD_KEYS:
+            continue
+        if key.endswith(".lora_down"):
+            grouped.setdefault(key[: -len(".lora_down")], {})["down"] = tensor
+        elif key.endswith(".lora_up"):
+            grouped.setdefault(key[: -len(".lora_up")], {})["up"] = tensor
+        else:
+            unknown.append(key)
+    if unknown:
+        raise ValueError(f"Unsupported tensors in MiniMax H3 Acc checkpoint: {unknown[:5]}")
+    if not grouped:
+        raise ValueError("MiniMax H3 Acc checkpoint contains no LoRA pairs")
+
+    result = {}
+    for base, parts in grouped.items():
+        if set(parts) != {"down", "up"}:
+            raise ValueError(f"Incomplete LoRA pair for {base}")
+        down, up = parts["down"], parts["up"]
+        if down.ndim != 2 or up.ndim != 2:
+            raise ValueError(f"LoRA tensors for {base} must be matrices")
+        if down.shape[0] != config.rank or up.shape[1] != config.rank:
+            raise ValueError(
+                f"LoRA rank mismatch for {base}: metadata={config.rank}, "
+                f"down={tuple(down.shape)}, up={tuple(up.shape)}"
+            )
+        result[base] = (down, up)
+    return result
+
+
+def validate_checkpoint(
+    state: Mapping[str, torch.Tensor],
+    metadata: Mapping[str, str] | None,
+) -> tuple[PDDConfig, dict[str, tuple[torch.Tensor, torch.Tensor]]]:
+    config = parse_config(metadata)
+    missing = sorted(HEAD_KEYS - set(state))
+    if missing:
+        raise ValueError(f"MiniMax H3 Acc checkpoint is missing PDD heads: {missing}")
+
+    expected_heads = {
+        "proj_out.weight": (config.num_steps, 96, 5376),
+        "proj_out.bias": (config.num_steps, 96),
+        "audio_proj_out.weight": (config.num_steps, 32, 5376),
+        "audio_proj_out.bias": (config.num_steps, 32),
+    }
+    for key, shape in expected_heads.items():
+        if tuple(state[key].shape) != shape:
+            raise ValueError(f"Unexpected {key} shape: expected {shape}, got {tuple(state[key].shape)}")
+        if not state[key].is_floating_point():
+            raise ValueError(f"PDD head {key} must be floating point")
+
+    pairs = lora_pairs(state, config)
+    return config, pairs
+
+
+def shifted_sigmas(shift: float, num_steps: int) -> torch.Tensor:
+    base = torch.linspace(1.0, 0.0, num_steps + 1, dtype=torch.float64)
+    return shift * base / (1.0 + (shift - 1.0) * base)
+
+
+def _fuse_bank(bank: torch.Tensor, deltas: torch.Tensor, block_size: int) -> torch.Tensor:
+    if bank.shape[0] != deltas.numel():
+        raise ValueError("PDD head-bank length does not match its sigma grid")
+    fused = []
+    for start in range(0, bank.shape[0], block_size):
+        acc = torch.zeros_like(bank[0], dtype=torch.float64, device="cpu")
+        for index in range(start, start + block_size):
+            acc.add_(bank[index].to(device="cpu", dtype=torch.float64), alpha=float(deltas[index]))
+        fused.append(acc.to(torch.float32))
+    return torch.stack(fused).contiguous()
+
+
+def fuse_heads(state: Mapping[str, torch.Tensor], config: PDDConfig) -> FusedPDDHeads:
+    sigmas_video_full = shifted_sigmas(VIDEO_SHIFT, config.num_steps)
+    sigmas_audio_full = shifted_sigmas(AUDIO_SHIFT, config.num_steps)
+    deltas_video = sigmas_video_full[:-1] - sigmas_video_full[1:]
+    deltas_audio = sigmas_audio_full[:-1] - sigmas_audio_full[1:]
+
+    video_weight = _fuse_bank(state["proj_out.weight"], deltas_video, config.block_size)
+    video_bias = _fuse_bank(state["proj_out.bias"], deltas_video, config.block_size)
+    audio_weight = _fuse_bank(state["audio_proj_out.weight"], deltas_audio, config.block_size)
+    audio_bias = _fuse_bank(state["audio_proj_out.bias"], deltas_audio, config.block_size)
+
+    knots = tuple(range(0, config.num_steps + 1, config.block_size))
+    bounds_v = tuple(float(sigmas_video_full[i]) for i in knots)
+    bounds_a = tuple(float(sigmas_audio_full[i]) for i in knots)
+    dsum_v = tuple(left - right for left, right in zip(bounds_v, bounds_v[1:]))
+    dsum_a = tuple(left - right for left, right in zip(bounds_a, bounds_a[1:]))
+    return FusedPDDHeads(
+        video_weight,
+        video_bias,
+        audio_weight,
+        audio_bias,
+        bounds_v,
+        bounds_a,
+        dsum_v,
+        dsum_a,
+        config,
+    )
+
+
+def _native_target(base: str) -> tuple[str, str]:
+    match = _TRANSFORMER.match(base)
+    if match:
+        return f"diffusion_model.blocks.{match.group(1)}", match.group(2)
+    match = _REFINER.match(base)
+    if match:
+        return f"diffusion_model.token_refiner.blocks.{match.group(1)}", match.group(2)
+    raise ValueError(f"Unsupported MiniMax H3 LoRA module: {base}")
+
+
+def build_patch_specs(
+    pairs: Mapping[str, tuple[torch.Tensor, torch.Tensor]],
+    model_state: Mapping[str, torch.Tensor],
+) -> list[PatchSpec]:
+    specs: list[PatchSpec] = []
+    qkv_index = {"attn.to_q": 0, "attn.to_k": 1, "attn.to_v": 2}
+
+    def require_shape(target: str) -> tuple[int, ...]:
+        if target not in model_state:
+            raise ValueError(
+                f"The connected model does not expose required full MiniMax H3 weight: {target}. "
+                "Use a non-pruned FL2VA/Ref2VA diffusion model."
+            )
+        return tuple(model_state[target].shape)
+
+    for base in sorted(pairs):
+        down, up = pairs[base]
+        prefix, leaf = _native_target(base)
+        source_keys = (base + ".lora_up", base + ".lora_down")
+
+        if leaf in qkv_index:
+            target = prefix + ".attn.qkv_proj.weight"
+            shape = require_shape(target)
+            rows = up.shape[0]
+            if shape != (rows * 3, down.shape[1]):
+                raise ValueError(
+                    f"Shape mismatch for {base} -> {target}: "
+                    f"{tuple(up.shape)}, {tuple(down.shape)}, model={shape}"
+                )
+            offset = (0, qkv_index[leaf] * rows, rows)
+            specs.append(PatchSpec((target, offset), up, down, source_keys))
+        elif leaf == "attn.to_out.0":
+            target = prefix + ".attn.out_proj.weight"
+            shape = require_shape(target)
+            if shape != (up.shape[0], down.shape[1]):
+                raise ValueError(f"Shape mismatch for {base} -> {target}")
+            specs.append(PatchSpec(target, up, down, source_keys))
+        elif leaf == "ff.net.0.proj":
+            target = prefix + ".mlp.fc1.weight"
+            shape = require_shape(target)
+            if shape != (up.shape[0], down.shape[1]) or up.shape[0] % 2:
+                raise ValueError(f"Shape mismatch for {base} -> {target}")
+            half = up.shape[0] // 2
+            # Diffusers stores [value, gate]; ComfyUI's SwiGLU consumes [gate, value].
+            specs.append(PatchSpec((target, (0, 0, half)), up[half:], down, source_keys))
+            specs.append(PatchSpec((target, (0, half, half)), up[:half], down, source_keys))
+        elif leaf == "ff.net.2":
+            target = prefix + ".mlp.fc2.weight"
+            shape = require_shape(target)
+            if shape != (up.shape[0], down.shape[1]):
+                raise ValueError(f"Shape mismatch for {base} -> {target}")
+            specs.append(PatchSpec(target, up, down, source_keys))
+        elif leaf == "adaln_proj.linear":
+            target = prefix + ".adaln_proj.linear.weight"
+            shape = require_shape(target)
+            if shape != (up.shape[0], down.shape[1]):
+                raise ValueError(f"Shape mismatch for {base} -> {target}")
+            specs.append(PatchSpec(target, up, down, source_keys))
+        else:
+            raise ValueError(f"Unsupported MiniMax H3 LoRA target: {base}")
+    return specs
+
+
+def select_exact_step(
+    current: float,
+    next_sigma: float,
+    bounds: tuple[float, ...],
+    tolerance: float = 2.0e-5,
+) -> int:
+    for index, (left, right) in enumerate(zip(bounds, bounds[1:])):
+        if abs(current - left) <= tolerance and abs(next_sigma - right) <= tolerance:
+            return index
+    formatted = ", ".join(f"{value:.9g}" for value in bounds)
+    raise ValueError(
+        "MiniMax H3 Acc requires its exact trained 8-step sigma boundaries. "
+        f"Got {current:.9g} -> {next_sigma:.9g}; expected [{formatted}]"
+    )
+
+
+def audio_inner_velocity_factor(
+    current: float,
+    next_sigma: float,
+    shift_video: float,
+    shift_audio: float,
+) -> float:
+    dsig_video = current - next_sigma
+    if dsig_video <= 0.0:
+        raise ValueError("MiniMax H3 Acc requires a strictly descending sigma schedule")
+    ratio = shift_video / shift_audio
+    carry_now = ratio + (1.0 - ratio) * current
+    carry_next = ratio + (1.0 - ratio) * next_sigma
+    return (carry_now * carry_next / ratio) / dsig_video

--- a/deno_node_metadata.py
+++ b/deno_node_metadata.py
@@ -86,6 +86,10 @@ NODE_INPUT_TOOLTIPS = {
         "ref_video_audios": "Stock MiniMax H3 soundtrack slots paired by number with reference videos.",
         "ref_audios": "Stock MiniMax H3 standalone reference-audio slots, in prompt tag order.",
     },
+    "DenoMiniMaxH3AccLoader": {
+        "model": "Full, non-pruned native ComfyUI MiniMax H3 diffusion model to accelerate.",
+        "acc_lora": "Official Alibaba MiniMax-H3 Acc-LoRA. Match FL2VA with FL2VA/T2VA and Ref2VA with Ref2VA.",
+    },
     "DenoAudioTranscript": {
         "audio": "Source mono or stereo audio to transcribe locally. The node downmixes it to mono and resamples it to 16 kHz for Whisper.",
         "model": "Local Whisper model size. large-v3 prioritizes lyric and difficult-speech accuracy; large-v3-turbo is the faster default. The official checkpoint downloads on first use to ComfyUI/models/stt/whisper.",
@@ -330,6 +334,11 @@ NODE_OUTPUT_TOOLTIPS = {
     "DenoMiniMaxH3ReferenceToVideo": (
         "Positive MiniMax H3 conditioning containing the ordered image, video, and audio references.",
         "Empty MiniMax H3 audio/video latent for sampling.",
+    ),
+    "DenoMiniMaxH3AccLoader": (
+        "MiniMax H3 model patched with the selected Alibaba Acc-LoRA and PDD output heads.",
+        "Euler sampler required by the official acceleration checkpoint.",
+        "Exact trained 8-step sigma schedule required by the official acceleration checkpoint.",
     ),
     "DenoAudioTranscript": (
         "Structured transcript data with requested/detected language, timestamped segments, and a heuristic confidence band for an LLM prompt builder.",

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -95,6 +95,19 @@ ComfyUI 순정 MiniMax H3 Reference to Video용 한 줄 연결 다중 참조 이
 
 이 두 MiniMax H3 노드는 ComfyUI 0.30.0 이상이 필요합니다. 순정 H3 전체 구성에서 여러 `Load Image` 노드만 DENO 한 줄 로더로 교체한 [MiniMax H3 다중 참조 예제 워크플로](workflows/minimax-h3-multi-reference.json)를 함께 제공합니다.
 
+### `(Deno) MiniMax H3 Acc LoRA Loader`
+
+Alibaba PAI가 공개한 공식 [MiniMax-H3-Acc-LoRAs](https://huggingface.co/alibaba-pai/MiniMax-H3-Acc-LoRAs)를 변환하거나 복사본을 만들지 않고 직접 불러옵니다.
+
+1. 공식 FL2VA 또는 Ref2VA `Acc-8Step.safetensors`를 내려받아 `ComfyUI/models/minimax_h3_acc_loras/`에 넣습니다.
+2. 계열이 맞는 순정 MiniMax H3 완전판 diffusion model을 `model`에 연결합니다. `*_pruned_*` 모델은 사용할 수 없습니다.
+3. FL2VA/T2VA 모델에는 FL2VA Acc-LoRA, Ref2VA 모델에는 Ref2VA Acc-LoRA를 선택합니다.
+4. 노드의 `model`, `sampler`, `sigmas`를 기존 guider와 `SamplerCustomAdvanced` 경로에 연결합니다.
+
+노드가 일반 LoRA 가중치와 시간 구간별 PDD 출력 헤드를 함께 적용하고, 공식 설정인 Euler와 정확한 8-step sigma 스케줄을 자동 출력합니다. 샘플러나 step을 따로 고르는 위젯은 없습니다. 현재 공식 체크포인트는 LoRA strength `1.0`, 영상/오디오 sigma shift `12.0 / 3.0`, 정확한 전용 스케줄을 요구하며, 다른 스케줄을 연결하면 임의로 근사하지 않고 실행을 중단합니다.
+
+Deno Custom Nodes에는 LoRA 가중치와 워크플로우를 포함하지 않습니다. 가중치는 Alibaba 저장소에서 각자 내려받고, ComfyUI 순정 워크플로우를 직접 구성하거나 기존 그래프에 연결해 사용합니다.
+
 ### MiniMax H3 R2V 오디오 레퍼런스 워크플로
 
 [초보자용 오디오 레퍼런스 워크플로](workflows/minimax-h3-r2v-audio-reference.json)는 ComfyUI 순정 MiniMax H3 오디오 레퍼런스 경로를 유지하면서 자동 프롬프트 연출 단계를 더합니다.

--- a/node_list.json
+++ b/node_list.json
@@ -3,6 +3,7 @@
   "DenoMultiImageLoader": "(Deno) Multi Image Loader",
   "DenoMiniMaxH3ReferenceImageLoader": "(Deno) MiniMax H3 Multi Reference Image Loader",
   "DenoMiniMaxH3ReferenceToVideo": "(Deno) MiniMax H3 Reference to Video",
+  "DenoMiniMaxH3AccLoader": "(Deno) MiniMax H3 Acc LoRA Loader",
   "DenoAudioTranscript": "(Deno) Audio Transcript",
   "DenoAudioAnalysisFinalize": "(Deno) Audio Analysis Finalizer",
   "DenoTextEncoderUnload": "(Deno) Text Encoder Unload",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "deno-custom-nodes"
-description = "DENO RTX node pack for ComfyUI: MiniMax H3 multi-reference image and Reference to Video helpers, local audio transcription and analysis helpers, targeted text-encoder VRAM unload, Ideogram Director visual JSON/bbox prompt builder, Local LLM Loader and Reviewer helpers, GPT/Gemini-ready Error Help reports, Prompt Only final prompt extraction, RTX Video Super Resolution, RTX Super Resolution, Video SR/VSR, NVIDIA VFX/nvvfx, RTX upscale helpers, LTX 2.3 and LTX 2.5 model/workflow helpers, LTX tiled second-pass refinement helpers, Bernini Prompt Guide, audio/image review gates, Bernini conditioning helpers, Wan 2.2 reference video edit workflows, image and video compare, video preview, Video to GIF/WebP tools, multi-image loading, resize tools, LoRA/model helpers, prompt guides, and visual workflow utilities."
-version = "0.7.91"
+description = "DENO RTX node pack for ComfyUI: MiniMax H3 multi-reference image and Reference to Video helpers, direct Alibaba MiniMax H3 Acc-LoRA/PDD loading with the trained 8-step Euler schedule, local audio transcription and analysis helpers, targeted text-encoder VRAM unload, Ideogram Director visual JSON/bbox prompt builder, Local LLM Loader and Reviewer helpers, GPT/Gemini-ready Error Help reports, Prompt Only final prompt extraction, RTX Video Super Resolution, RTX Super Resolution, Video SR/VSR, NVIDIA VFX/nvvfx, RTX upscale helpers, LTX 2.3 and LTX 2.5 model/workflow helpers, LTX tiled second-pass refinement helpers, Bernini Prompt Guide, audio/image review gates, Bernini conditioning helpers, Wan 2.2 reference video edit workflows, image and video compare, video preview, Video to GIF/WebP tools, multi-image loading, resize tools, LoRA/model helpers, prompt guides, and visual workflow utilities."
+version = "0.7.92"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = ["openai-whisper>=20250625"]
@@ -12,6 +12,9 @@ keywords = [
   "minimax-h3",
   "minimax-h3-reference-to-video",
   "minimax-h3-audio-reference",
+  "minimax-h3-acc-lora",
+  "minimax-h3-pdd",
+  "minimax-h3-8-step",
   "multi-reference-image",
   "audio-transcription",
   "audio-analysis",

--- a/tests/test_image_resize_node.py
+++ b/tests/test_image_resize_node.py
@@ -161,6 +161,13 @@ def install_comfyui_dependency_stubs():
     folder_paths = types.ModuleType("folder_paths")
     folder_paths.models_dir = str(REPO_ROOT / "models")
     folder_paths.folder_names_and_paths = {}
+    def add_model_folder_path(folder_name, path, is_default=False):
+        del is_default
+        paths, extensions = folder_paths.folder_names_and_paths.setdefault(folder_name, ([], set()))
+        if path not in paths:
+            paths.append(path)
+        return paths, extensions
+    folder_paths.add_model_folder_path = add_model_folder_path
     folder_paths.get_filename_list = lambda folder_name: []
     folder_paths.get_full_path = lambda folder_name, filename: str(REPO_ROOT / "models" / folder_name / filename)
     folder_paths.get_full_path_or_raise = folder_paths.get_full_path
@@ -214,6 +221,12 @@ def install_comfyui_dependency_stubs():
     comfy.lora_convert = types.ModuleType("comfy.lora_convert")
     comfy.utils = types.ModuleType("comfy.utils")
     comfy.model_management = types.ModuleType("comfy.model_management")
+    comfy.patcher_extension = types.ModuleType("comfy.patcher_extension")
+    comfy.samplers = types.ModuleType("comfy.samplers")
+    comfy.weight_adapter = types.ModuleType("comfy.weight_adapter")
+    comfy.ldm = types.ModuleType("comfy.ldm")
+    comfy.ldm.minimax = types.ModuleType("comfy.ldm.minimax")
+    comfy.ldm.minimax.model = types.ModuleType("comfy.ldm.minimax.model")
     comfy.lora.model_lora_keys_unet = lambda model, key_map: key_map
     comfy.lora.model_lora_keys_clip = lambda clip, key_map: key_map
     comfy.lora.load_lora = lambda lora_sd, key_map: {}
@@ -221,11 +234,21 @@ def install_comfyui_dependency_stubs():
     comfy.utils.load_torch_file = lambda *args, **kwargs: {}
     comfy.model_management.InterruptProcessingException = RuntimeError
     comfy.model_management.throw_exception_if_processing_interrupted = lambda: None
+    comfy.patcher_extension.WrappersMP = types.SimpleNamespace(DIFFUSION_MODEL="diffusion_model")
+    comfy.samplers.sampler_object = lambda name: name
+    comfy.weight_adapter.LoRAAdapter = lambda *args, **kwargs: (args, kwargs)
+    comfy.ldm.minimax.model.MiniMaxH3Model = type("MiniMaxH3Model", (), {})
     sys.modules["comfy"] = comfy
     sys.modules["comfy.lora"] = comfy.lora
     sys.modules["comfy.lora_convert"] = comfy.lora_convert
     sys.modules["comfy.utils"] = comfy.utils
     sys.modules["comfy.model_management"] = comfy.model_management
+    sys.modules["comfy.patcher_extension"] = comfy.patcher_extension
+    sys.modules["comfy.samplers"] = comfy.samplers
+    sys.modules["comfy.weight_adapter"] = comfy.weight_adapter
+    sys.modules["comfy.ldm"] = comfy.ldm
+    sys.modules["comfy.ldm.minimax"] = comfy.ldm.minimax
+    sys.modules["comfy.ldm.minimax.model"] = comfy.ldm.minimax.model
 
     comfy_api = types.ModuleType("comfy_api")
     comfy_api_latest = types.ModuleType("comfy_api.latest")
@@ -418,6 +441,7 @@ def test_node_registration_exports_expected_nodes():
         "DenoMultiImageLoader",
         "DenoMiniMaxH3ReferenceImageLoader",
         "DenoMiniMaxH3ReferenceToVideo",
+        "DenoMiniMaxH3AccLoader",
         "DenoAudioTranscript",
         "DenoAudioAnalysisFinalize",
         "DenoTextEncoderUnload",
@@ -448,6 +472,9 @@ def test_node_registration_exports_expected_nodes():
     )
     assert package.NODE_DISPLAY_NAME_MAPPINGS["DenoMiniMaxH3ReferenceToVideo"] == (
         "(Deno) MiniMax H3 Reference to Video"
+    )
+    assert package.NODE_DISPLAY_NAME_MAPPINGS["DenoMiniMaxH3AccLoader"] == (
+        "(Deno) MiniMax H3 Acc LoRA Loader"
     )
     assert package.NODE_DISPLAY_NAME_MAPPINGS["DenoAudioTranscript"] == "(Deno) Audio Transcript"
     assert package.NODE_DISPLAY_NAME_MAPPINGS["DenoAudioAnalysisFinalize"] == (
@@ -558,6 +585,7 @@ def test_minimax_h3_nodes_are_skipped_together_when_stock_h3_is_unavailable(monk
     assert "DenoMultiImageLoader" in package.NODE_CLASS_MAPPINGS
     assert "DenoMiniMaxH3ReferenceImageLoader" not in package.NODE_CLASS_MAPPINGS
     assert "DenoMiniMaxH3ReferenceToVideo" not in package.NODE_CLASS_MAPPINGS
+    assert "DenoMiniMaxH3AccLoader" not in package.NODE_CLASS_MAPPINGS
     assert caplog.text.count("MiniMax H3 nodes require ComfyUI >= 0.30.0") == 1
 
 

--- a/tests/test_minimax_h3_acc_loader.py
+++ b/tests/test_minimax_h3_acc_loader.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+import torch
+
+from deno_minimax_h3_pdd_core import (
+    AUDIO_SHIFT,
+    VIDEO_SHIFT,
+    PDDConfig,
+    audio_inner_velocity_factor,
+    build_patch_specs,
+    fuse_heads,
+    parse_config,
+    select_exact_step,
+    shifted_sigmas,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_official_config_is_eight_model_evaluations():
+    config = parse_config(
+        {
+            "pdd_num_steps": "32",
+            "pdd_block_size": "4",
+            "lora_rank": "64",
+            "lora_alpha": "64.0",
+            "lora_targets": "to_q,to_k,to_v,to_out.0,ff.net.0.proj,ff.net.2,adaln_proj.linear",
+        }
+    )
+    assert config.nfe == 8
+    assert config.rank == 64
+
+
+def test_video_schedule_matches_official_comfy_boundaries():
+    actual = shifted_sigmas(VIDEO_SHIFT, 32)[::4]
+    expected = torch.tensor(
+        [
+            1.0,
+            0.9882352941,
+            0.9729729730,
+            0.9523809524,
+            0.9230769231,
+            0.8780487805,
+            0.8,
+            0.6315789474,
+            0.0,
+        ],
+        dtype=torch.float64,
+    )
+    assert torch.allclose(actual, expected, atol=1.0e-10, rtol=0.0)
+
+
+def test_head_fusion_is_delta_weighted():
+    config = PDDConfig(
+        4,
+        2,
+        1,
+        1.0,
+        tuple(
+            sorted(
+                {
+                    "to_q",
+                    "to_k",
+                    "to_v",
+                    "to_out.0",
+                    "ff.net.0.proj",
+                    "ff.net.2",
+                    "adaln_proj.linear",
+                }
+            )
+        ),
+    )
+    state = {
+        "proj_out.weight": torch.arange(4, dtype=torch.float32).view(4, 1, 1).expand(4, 96, 5376),
+        "proj_out.bias": torch.arange(4, dtype=torch.float32).view(4, 1).expand(4, 96),
+        "audio_proj_out.weight": torch.arange(4, dtype=torch.float32).view(4, 1, 1).expand(4, 32, 5376),
+        "audio_proj_out.bias": torch.arange(4, dtype=torch.float32).view(4, 1).expand(4, 32),
+    }
+    fused = fuse_heads(state, config)
+    deltas = shifted_sigmas(VIDEO_SHIFT, 4)
+    deltas = deltas[:-1] - deltas[1:]
+    assert float(fused.video_weight[0, 0, 0]) == pytest.approx(float(deltas[1]), abs=1.0e-6)
+    assert tuple(fused.video_weight.shape) == (2, 96, 5376)
+
+
+def test_qkv_offsets_and_swiglu_half_swap():
+    rank = 2
+    down = torch.zeros(rank, 5)
+    pairs = {
+        "transformer_blocks.0.attn.to_q": (down, torch.zeros(7, rank)),
+        "transformer_blocks.0.attn.to_k": (down, torch.zeros(7, rank)),
+        "transformer_blocks.0.attn.to_v": (down, torch.zeros(7, rank)),
+        "transformer_blocks.0.ff.net.0.proj": (
+            down,
+            torch.cat((torch.full((11, rank), 1.0), torch.full((11, rank), 2.0))),
+        ),
+    }
+    model_state = {
+        "diffusion_model.blocks.0.attn.qkv_proj.weight": torch.zeros(21, 5),
+        "diffusion_model.blocks.0.mlp.fc1.weight": torch.zeros(22, 5),
+    }
+    specs = build_patch_specs(pairs, model_state)
+    offsets = [spec.patch_key[1] for spec in specs if isinstance(spec.patch_key, tuple)]
+    assert (0, 0, 7) in offsets
+    assert (0, 7, 7) in offsets
+    assert (0, 14, 7) in offsets
+    ffn = [
+        spec
+        for spec in specs
+        if isinstance(spec.patch_key, tuple) and "fc1" in spec.patch_key[0]
+    ]
+    assert float(ffn[0].up[0, 0]) == 2.0
+    assert float(ffn[1].up[0, 0]) == 1.0
+
+
+def test_other_sigma_schedules_are_rejected():
+    bounds = tuple(float(value) for value in shifted_sigmas(VIDEO_SHIFT, 32)[::4])
+    assert select_exact_step(bounds[0], bounds[1], bounds) == 0
+    with pytest.raises(ValueError, match="exact trained 8-step sigma boundaries"):
+        select_exact_step(1.0, 0.9, bounds)
+
+
+def test_audio_factor_is_finite_and_positive():
+    value = audio_inner_velocity_factor(1.0, 0.9882352941, VIDEO_SHIFT, AUDIO_SHIFT)
+    assert value > 0.0
+    assert torch.isfinite(torch.tensor(value))
+
+
+def test_public_node_surface_is_three_outputs_and_deno_named():
+    source_path = REPO_ROOT / "deno_minimax_h3_acc_loader.py"
+    source = source_path.read_text(encoding="utf-8")
+    module = ast.parse(source)
+    loader = next(
+        item
+        for item in module.body
+        if isinstance(item, ast.ClassDef) and item.name == "DenoMiniMaxH3AccLoader"
+    )
+    assignments = {
+        item.targets[0].id: ast.literal_eval(item.value)
+        for item in loader.body
+        if isinstance(item, ast.Assign)
+        and len(item.targets) == 1
+        and isinstance(item.targets[0], ast.Name)
+        and item.targets[0].id in {"RETURN_TYPES", "RETURN_NAMES", "CATEGORY"}
+    }
+    assert assignments["RETURN_TYPES"] == ("MODEL", "SAMPLER", "SIGMAS")
+    assert assignments["RETURN_NAMES"] == ("model", "sampler", "sigmas")
+    assert assignments["CATEGORY"] == "Deno/MiniMax H3"
+    assert '"DenoMiniMaxH3AccLoader": "(Deno) MiniMax H3 Acc LoRA Loader"' in source
+    assert (REPO_ROOT / "web/js/docs/DenoMiniMaxH3AccLoader.md").is_file()
+    assert (REPO_ROOT / "web/js/docs/DenoMiniMaxH3AccLoader/ko.md").is_file()

--- a/tests/test_registry_metadata.py
+++ b/tests/test_registry_metadata.py
@@ -85,6 +85,7 @@ def test_pyproject_declares_registry_metadata_for_comfy_manager_discovery():
     description = pyproject["project"]["description"]
     assert "DENO RTX node" in description
     assert "MiniMax H3 multi-reference image" in description
+    assert "direct Alibaba MiniMax H3 Acc-LoRA/PDD loading" in description
     assert "audio transcription and analysis helpers" in description
     assert "targeted text-encoder VRAM unload" in description
     assert "RTX Video Super Resolution" in description
@@ -112,6 +113,9 @@ def test_pyproject_declares_registry_metadata_for_comfy_manager_discovery():
         "minimax-h3",
         "minimax-h3-reference-to-video",
         "minimax-h3-audio-reference",
+        "minimax-h3-acc-lora",
+        "minimax-h3-pdd",
+        "minimax-h3-8-step",
         "multi-reference-image",
         "audio-transcription",
         "audio-analysis",

--- a/web/js/docs/DenoMiniMaxH3AccLoader.md
+++ b/web/js/docs/DenoMiniMaxH3AccLoader.md
@@ -1,0 +1,14 @@
+# (Deno) MiniMax H3 Acc LoRA Loader
+
+Loads Alibaba PAI's official MiniMax H3 Acc-LoRA/PDD safetensors directly. No converted copy is required.
+
+1. Download the matching FL2VA or Ref2VA `Acc-8Step.safetensors` from [Alibaba PAI](https://huggingface.co/alibaba-pai/MiniMax-H3-Acc-LoRAs).
+2. Put it in `ComfyUI/models/minimax_h3_acc_loras/` and refresh or restart ComfyUI.
+3. Connect a matching full, non-pruned native MiniMax H3 diffusion model.
+4. Connect the returned `model` to your guider, and connect `sampler` plus `sigmas` to `SamplerCustomAdvanced`.
+
+The node applies both the ordinary LoRA updates and the checkpoint's time-dependent PDD output heads. It automatically supplies Euler and the exact trained 8-step sigma schedule, so there are no sampler or step widgets to set.
+
+Use FL2VA Acc-LoRA with FL2VA/T2VA and Ref2VA Acc-LoRA with Ref2VA. The current official checkpoints require full-width AdaLN layers, strength `1.0`, video/audio sigma shifts `12.0 / 3.0`, and their exact schedule. A pruned model or another schedule stops with a clear error instead of running an unsupported approximation.
+
+Deno Custom Nodes does not bundle the LoRA weights or a workflow.

--- a/web/js/docs/DenoMiniMaxH3AccLoader/ko.md
+++ b/web/js/docs/DenoMiniMaxH3AccLoader/ko.md
@@ -1,0 +1,14 @@
+# (Deno) MiniMax H3 Acc LoRA Loader
+
+Alibaba PAI의 공식 MiniMax H3 Acc-LoRA/PDD safetensors를 변환 복사본 없이 직접 불러옵니다.
+
+1. [Alibaba PAI 저장소](https://huggingface.co/alibaba-pai/MiniMax-H3-Acc-LoRAs)에서 사용할 모델 계열에 맞는 FL2VA 또는 Ref2VA `Acc-8Step.safetensors`를 내려받습니다.
+2. 파일을 `ComfyUI/models/minimax_h3_acc_loras/`에 넣고 모델 목록을 새로고침하거나 ComfyUI를 재시작합니다.
+3. 같은 계열의 순정 MiniMax H3 완전판 diffusion model을 연결합니다.
+4. 출력 `model`은 guider에, `sampler`와 `sigmas`는 `SamplerCustomAdvanced`에 연결합니다.
+
+노드는 일반 LoRA 업데이트와 시간 구간별 PDD 출력 헤드를 함께 적용합니다. Euler와 정확한 공식 8-step sigma 스케줄을 자동 출력하므로 샘플러나 step 위젯을 따로 설정하지 않습니다.
+
+FL2VA/T2VA에는 FL2VA Acc-LoRA를, Ref2VA에는 Ref2VA Acc-LoRA를 사용하세요. 현재 공식 체크포인트는 full-width AdaLN, strength `1.0`, 영상/오디오 sigma shift `12.0 / 3.0`, 정확한 전용 스케줄을 요구합니다. pruned 모델이나 다른 스케줄은 지원되지 않는 근사 실행 대신 명확한 오류로 중단합니다.
+
+Deno Custom Nodes에는 LoRA 가중치와 워크플로우를 포함하지 않습니다.


### PR DESCRIPTION
## Summary

- Add `(Deno) MiniMax H3 Acc LoRA Loader` to the existing DENO stable node pack.
- Load official Alibaba FL2VA/Ref2VA Acc-LoRA/PDD safetensors directly and emit the trained Euler 8-step schedule.
- Add English/Korean usage docs, native help, Registry metadata, and focused schedule/mapping tests.
- Do not bundle LoRA weights or workflows.

## Checklist

- [x] I ran the focused checks and the full test suite appropriate to this change (`739 passed`; CI frontend checks passed locally)
- [x] I preserved public node IDs and saved-workflow compatibility; this adds one new node ID
- [x] No frontend behavior changed; live ComfyUI `/object_info` verified the integrated 2-input/3-output surface
- [x] I updated `CHANGELOG.md` for user-facing changes