### PR TITLE
Diagnose an already-converted ComfyUI LoRA instead of reporting missing PDD heads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This file intentionally stays short. Detailed engineering notes belong in privat
 
 ## Unreleased
 
+- MiniMax H3 Acc Loader now names an already-converted ComfyUI LoRA as such and points to LoraLoaderModelOnly, instead of reporting it as a checkpoint with missing PDD heads.
+
 ## 0.7.103 - 2026-09-05
 
 - Moved URL image loading to urllib3's HTTP client, using its supported public-IP connection and original-host HTTPS verification options. Per-redirect address validation, direct connections, timeouts, response size limits, and saved workflows are preserved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file intentionally stays short. Detailed engineering notes belong in privat
 
 ## Unreleased
 
-- MiniMax H3 Acc Loader now names an already-converted ComfyUI LoRA as such and points to LoraLoaderModelOnly, instead of reporting it as a checkpoint with missing PDD heads.
+- MiniMax H3 Acc Loader now distinguishes a declared H3 conversion from other unsupported LoRA layouts and explains how to select an original Acc checkpoint. Guidance for compatible converted PDD LoRAs includes the required ComfyUI PDD support and built-in LoRA loader.
 
 ## 0.7.104 - 2026-09-06
 

--- a/deno_minimax_h3_pdd_core.py
+++ b/deno_minimax_h3_pdd_core.py
@@ -43,14 +43,14 @@ def converted_layout_reason(
     state: Mapping[str, torch.Tensor],
     metadata: Mapping[str, str] | None,
 ) -> str | None:
-    """Name the evidence that a file was already rewritten into ComfyUI LoRA layout."""
+    """Describe a declared conversion or tensor layout unsupported by this loader."""
 
     layout = (metadata or {}).get("converted_layout")
     if layout:
         return f"metadata says converted_layout={layout!r}"
     for key in state:
         if key.endswith(CONVERTED_LORA_SUFFIXES):
-            return f"tensors use ComfyUI LoRA names such as {key!r}"
+            return f"tensors use LoRA names such as {key!r}"
     return None
 
 
@@ -192,10 +192,17 @@ def validate_checkpoint(
 ) -> tuple[PDDConfig, dict[str, tuple[torch.Tensor, torch.Tensor]]]:
     converted = converted_layout_reason(state, metadata)
     if converted:
+        original_guidance = "Use an original Alibaba MiniMax H3 Acc checkpoint with this node."
+        if (metadata or {}).get("converted_layout") == "comfyui_minimax_h3":
+            raise ValueError(
+                f"This file declares a converted MiniMax H3 LoRA layout ({converted}). "
+                f"{original_guidance} To use a compatible converted PDD LoRA, update "
+                "ComfyUI to a version with MiniMax H3 PDD support (ComfyUI PR #15908) "
+                "and use the built-in LoraLoaderModelOnly node."
+            )
         raise ValueError(
-            f"This file is an already-converted MiniMax H3 LoRA ({converted}), not an "
-            "original Acc checkpoint: its PDD heads are baked into ordinary LoRA weights. "
-            "Load it with the built-in LoraLoaderModelOnly node instead."
+            f"Unsupported LoRA layout for MiniMax H3 Acc Loader ({converted}). "
+            f"{original_guidance}"
         )
 
     config = parse_config(metadata)

--- a/deno_minimax_h3_pdd_core.py
+++ b/deno_minimax_h3_pdd_core.py
@@ -36,6 +36,24 @@ SUPPORTED_TARGETS = {
     "adaln_proj.linear",
 }
 
+CONVERTED_LORA_SUFFIXES = (".lora_A.weight", ".lora_B.weight")
+
+
+def converted_layout_reason(
+    state: Mapping[str, torch.Tensor],
+    metadata: Mapping[str, str] | None,
+) -> str | None:
+    """Name the evidence that a file was already rewritten into ComfyUI LoRA layout."""
+
+    layout = (metadata or {}).get("converted_layout")
+    if layout:
+        return f"metadata says converted_layout={layout!r}"
+    for key in state:
+        if key.endswith(CONVERTED_LORA_SUFFIXES):
+            return f"tensors use ComfyUI LoRA names such as {key!r}"
+    return None
+
+
 _TRANSFORMER = re.compile(r"^transformer_blocks\.(\d+)\.(.+)$")
 _REFINER = re.compile(r"^token_refiner\.refiner_blocks\.(\d+)\.(.+)$")
 
@@ -172,10 +190,21 @@ def validate_checkpoint(
     state: Mapping[str, torch.Tensor],
     metadata: Mapping[str, str] | None,
 ) -> tuple[PDDConfig, dict[str, tuple[torch.Tensor, torch.Tensor]]]:
+    converted = converted_layout_reason(state, metadata)
+    if converted:
+        raise ValueError(
+            f"This file is an already-converted MiniMax H3 LoRA ({converted}), not an "
+            "original Acc checkpoint: its PDD heads are baked into ordinary LoRA weights. "
+            "Load it with the built-in LoraLoaderModelOnly node instead."
+        )
+
     config = parse_config(metadata)
     missing = sorted(HEAD_KEYS - set(state))
     if missing:
-        raise ValueError(f"MiniMax H3 Acc checkpoint is missing PDD heads: {missing}")
+        raise ValueError(
+            f"MiniMax H3 Acc checkpoint is missing PDD heads: {missing}. "
+            "Every original Acc checkpoint carries all four head banks."
+        )
 
     expected_heads = {
         "proj_out.weight": (config.num_steps, 96, 5376),

--- a/tests/test_minimax_h3_acc_loader.py
+++ b/tests/test_minimax_h3_acc_loader.py
@@ -258,15 +258,48 @@ def test_converted_comfy_lora_is_named_rather_than_reported_as_missing_heads():
     message = str(excinfo.value)
     assert "comfyui_minimax_h3" in message
     assert "LoraLoaderModelOnly" in message
+    assert "original Alibaba MiniMax H3 Acc checkpoint" in message
+    assert "compatible converted PDD LoRA" in message
+    assert "ComfyUI PR #15908" in message
+    assert "baked" not in message
     assert "missing PDD heads" not in message
 
 
-def test_converted_comfy_lora_is_detected_without_the_metadata_marker():
+def test_unmarked_lora_layout_does_not_claim_h3_conversion_or_loader_compatibility():
     with pytest.raises(ValueError) as excinfo:
         validate_checkpoint(_converted_comfy_state(), ACC_METADATA)
     message = str(excinfo.value)
+    assert message.startswith("Unsupported LoRA layout")
     assert "lora_A.weight" in message
-    assert "LoraLoaderModelOnly" in message
+    assert "original Alibaba MiniMax H3 Acc checkpoint" in message
+    assert "LoraLoaderModelOnly" not in message
+
+
+@pytest.mark.parametrize(
+    "state,metadata",
+    [
+        ({"base_model.model.layers.0.self_attn.q_proj.lora_A.weight": object()}, None),
+        (
+            {"diffusion_model.double_blocks.0.img_attn.qkv.lora_B.weight": object()},
+            ACC_METADATA,
+        ),
+        ({}, {"converted_layout": "some_other_architecture"}),
+        (
+            _converted_comfy_state(),
+            dict(ACC_METADATA, converted_layout="comfyui_minimax_h3_unknown"),
+        ),
+    ],
+)
+def test_unrelated_or_unknown_lora_layouts_get_neutral_original_checkpoint_guidance(
+    state, metadata
+):
+    with pytest.raises(ValueError) as excinfo:
+        validate_checkpoint(state, metadata)
+    message = str(excinfo.value)
+    assert message.startswith("Unsupported LoRA layout")
+    assert "original Alibaba MiniMax H3 Acc checkpoint" in message
+    assert "LoraLoaderModelOnly" not in message
+    assert "baked" not in message
 
 
 def test_original_layout_still_reports_its_own_missing_heads():
@@ -276,6 +309,28 @@ def test_original_layout_still_reports_its_own_missing_heads():
     }
     with pytest.raises(ValueError, match="missing PDD heads"):
         validate_checkpoint(state, ACC_METADATA)
+
+
+@requires_real_torch
+def test_complete_original_checkpoint_still_validates_without_changing_tensors():
+    zero = torch.zeros(1)
+    state = {
+        "proj_out.weight": zero.expand(32, 96, 5376),
+        "proj_out.bias": zero.expand(32, 96),
+        "audio_proj_out.weight": zero.expand(32, 32, 5376),
+        "audio_proj_out.bias": zero.expand(32, 32),
+        "transformer_blocks.0.to_q.lora_down": zero.expand(64, 5376),
+        "transformer_blocks.0.to_q.lora_up": zero.expand(5376, 64),
+    }
+    original_state = dict(state)
+    config, pairs = validate_checkpoint(state, ACC_METADATA)
+    assert config == parse_config(ACC_METADATA)
+    assert set(pairs) == {"transformer_blocks.0.to_q"}
+    down, up = pairs["transformer_blocks.0.to_q"]
+    assert down is state["transformer_blocks.0.to_q.lora_down"]
+    assert up is state["transformer_blocks.0.to_q.lora_up"]
+    assert state.keys() == original_state.keys()
+    assert all(state[key] is tensor for key, tensor in original_state.items())
 
 
 def test_pruned_compatibility_skips_only_full_width_adaln_pairs():

--- a/tests/test_minimax_h3_acc_loader.py
+++ b/tests/test_minimax_h3_acc_loader.py
@@ -25,6 +25,7 @@ from deno_minimax_h3_pdd_core import (
     parse_config,
     select_model_compatible_pairs,
     shifted_sigmas,
+    validate_checkpoint,
     validate_model_adaln_layout,
     validate_sigma_schedule,
 )
@@ -229,6 +230,52 @@ def test_audio_factor_is_finite_and_positive():
     value = audio_inner_velocity_factor(1.0, 0.9882352941, VIDEO_SHIFT, AUDIO_SHIFT)
     assert value > 0.0
     assert math.isfinite(value)
+
+
+ACC_METADATA = {
+    "pdd_num_steps": "32",
+    "pdd_block_size": "4",
+    "lora_rank": "64",
+    "lora_alpha": "64.0",
+    "lora_targets": "to_q,to_k,to_v,to_out.0,ff.net.0.proj,ff.net.2,adaln_proj.linear",
+}
+
+
+def _converted_comfy_state():
+    """Key shape of an Acc LoRA already rewritten for the built-in ComfyUI loader."""
+
+    return {
+        "diffusion_model.blocks.0.attn.qkv_proj.lora_A.weight": object(),
+        "diffusion_model.blocks.0.attn.qkv_proj.lora_B.weight": object(),
+        "diffusion_model.blocks.0.adaln_proj.linear.diff_b": object(),
+    }
+
+
+def test_converted_comfy_lora_is_named_rather_than_reported_as_missing_heads():
+    metadata = dict(ACC_METADATA, converted_layout="comfyui_minimax_h3")
+    with pytest.raises(ValueError) as excinfo:
+        validate_checkpoint(_converted_comfy_state(), metadata)
+    message = str(excinfo.value)
+    assert "comfyui_minimax_h3" in message
+    assert "LoraLoaderModelOnly" in message
+    assert "missing PDD heads" not in message
+
+
+def test_converted_comfy_lora_is_detected_without_the_metadata_marker():
+    with pytest.raises(ValueError) as excinfo:
+        validate_checkpoint(_converted_comfy_state(), ACC_METADATA)
+    message = str(excinfo.value)
+    assert "lora_A.weight" in message
+    assert "LoraLoaderModelOnly" in message
+
+
+def test_original_layout_still_reports_its_own_missing_heads():
+    state = {
+        "transformer_blocks.0.to_q.lora_down": object(),
+        "transformer_blocks.0.to_q.lora_up": object(),
+    }
+    with pytest.raises(ValueError, match="missing PDD heads"):
+        validate_checkpoint(state, ACC_METADATA)
 
 
 def test_pruned_compatibility_skips_only_full_width_adaln_pairs():


### PR DESCRIPTION
MiniMax H3 Acc Loader now explains when a selected file uses a converted or unsupported LoRA layout, instead of reporting only missing PDD heads. The exact `converted_layout=comfyui_minimax_h3` marker receives H3-specific guidance. Generic LoRA tensor names, stripped markers, and unknown conversion markers receive neutral guidance to select an original Alibaba MiniMax H3 Acc checkpoint.

For compatible converted PDD LoRAs, the message explains that the built-in `LoraLoaderModelOnly` node requires ComfyUI's [MiniMax H3 PDD support](https://github.com/Comfy-Org/ComfyUI/pull/15908). A marker or tensor suffix alone does not certify that a file contains usable PDD heads. Original checkpoint validation, node inputs and outputs, and saved workflows retain their existing behavior.

Validation: all 100 focused tests passed with real PyTorch on CPU, including unrelated LoRA layouts, unknown markers, the conversion guidance, missing original heads, and an intact original checkpoint with its input tensors preserved. [GitHub CI](https://github.com/Deno2026/comfyui-deno-custom-nodes/actions/runs/34049791175) passed frontend syntax checks, the frontend harness, and the full CI suite (768 passed, 252 skipped). The changelog conflict with main is resolved.
